### PR TITLE
Implement asset server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ Cargo.lock
 
 .idea/
 *.iml
+
+.asset_cache/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+axum = "0.7.5"
 byteorder = "1.5.0"
+crc32fast = "1.4.2"
 packet_serialize = { path = "src/packet_serialize" }
 miniz_oxide = "0.7.2"
 num_enum = "0.7.2"
@@ -12,3 +14,4 @@ parking_lot = "0.12.1"
 rand = "0.8.5"
 serde_json = "1.0.1"
 serde = { version = "1.0.196", features = ["derive"] }
+tokio = { version = "1.38.0", features = ["rt", "rt-multi-thread", "macros"] }

--- a/config/manifests.json
+++ b/config/manifests.json
@@ -1,0 +1,10 @@
+[
+  {
+    "path": "",
+    "name": "Assets"
+  },
+  {
+    "path": "assets",
+    "name": "assetpack000"
+  }
+]

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -191,7 +191,6 @@ async fn asset_handler(Path(asset_name): Path<PathBuf>, State(assets_cache_path)
     });
     if is_invalid_path {
         return Err(StatusCode::BAD_REQUEST);
-
     }
 
     let file_data = read(assets_cache_path.join(asset_name)).map_err(|_| StatusCode::NOT_FOUND)?;

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,0 +1,210 @@
+use std::ffi::{OsStr, OsString};
+use std::fs::{create_dir_all, File, OpenOptions, read, read_dir, remove_dir_all, write};
+use std::io::{Read, Write};
+use std::path::PathBuf;
+
+use axum::extract::{Path, Request, State};
+use axum::http::StatusCode;
+use axum::{Router, serve};
+use axum::routing::get;
+use byteorder::{BigEndian, WriteBytesExt};
+use miniz_oxide::deflate::compress_to_vec_zlib;
+use serde::Deserialize;
+use tokio::io;
+use tokio::net::TcpListener;
+
+const MAGIC: u32 = 0xa1b2c3d4;
+const ZLIB_COMPRESSION_LEVEL: u8 = 6;
+const COMPRESSED_EXTENSION: &str = "z";
+
+#[derive(Deserialize)]
+struct ManifestConfig {
+    name: String,
+    path: PathBuf
+}
+
+struct Manifest {
+    name: OsString,
+    prefix: PathBuf
+}
+
+fn read_manifests_config(config_dir: &std::path::Path) -> io::Result<Vec<Manifest>> {
+    let mut file = File::open(config_dir.join("manifests.json"))?;
+    let manifests: Vec<ManifestConfig> = serde_json::from_reader(&mut file)?;
+    Ok(
+        manifests.into_iter().map(|manifest_config| {
+            let mut full_name = manifest_config.name;
+            full_name.push_str("_manifest.txt");
+            Manifest {
+                name: OsString::from(full_name),
+                prefix: manifest_config.path,
+            }
+        }).collect()
+    )
+}
+
+fn append_extension(extension: impl AsRef<OsStr>, path: &std::path::Path) -> PathBuf {
+    let mut os_string: OsString = path.into();
+    os_string.push(".");
+    os_string.push(extension.as_ref());
+    os_string.into()
+}
+
+fn list_files(dir: &std::path::Path) -> io::Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    if dir.is_dir() {
+        for entry in read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                files.append(&mut list_files(&path)?);
+            } else {
+                files.push(entry.path());
+            }
+        }
+    }
+    Ok(files)
+}
+
+fn forward_slash_path(path: &std::path::Path) -> OsString {
+    let mut os_string = OsString::new();
+    for (index, component) in path.iter().enumerate() {
+        if index > 0 {
+            os_string.push("/");
+        }
+
+        os_string.push(component);
+    }
+
+    os_string
+}
+
+fn compressed_asset_name(asset_path: &std::path::Path, assets_path: &std::path::Path) -> PathBuf {
+    append_extension(
+        COMPRESSED_EXTENSION,
+        asset_path.strip_prefix(&assets_path).expect("Asset entry path was not in the assets folder")
+    )
+}
+
+fn write_to_cache(uncompressed_contents: &[u8], compressed_asset_name: &std::path::Path,
+                  assets_cache_path: &std::path::Path) -> io::Result<usize> {
+    let mut compressed_contents = Vec::new();
+    compressed_contents.write_u32::<BigEndian>(MAGIC)?;
+    compressed_contents.write_u32::<BigEndian>(uncompressed_contents.len() as u32)?;
+    compressed_contents.append(&mut compress_to_vec_zlib(&uncompressed_contents, ZLIB_COMPRESSION_LEVEL));
+
+    let cached_asset_path = assets_cache_path.join(&compressed_asset_name);
+    if let Some(parent) = cached_asset_path.parent() {
+        create_dir_all(parent)?;
+    }
+    write(&cached_asset_path, &compressed_contents)?;
+    Ok(compressed_contents.len())
+}
+
+fn prepare_asset_cache(assets_path: &std::path::Path, assets_cache_path: &std::path::Path,
+                       manifests: &[Manifest]) -> io::Result<()> {
+    remove_dir_all(assets_cache_path)?;
+    create_dir_all(assets_cache_path)?;
+    let mut asset_paths = list_files(assets_path)?;
+    asset_paths.sort();
+
+    for asset_path in asset_paths {
+        let contents = read(&asset_path)?;
+        let compressed_asset_name = compressed_asset_name(&asset_path, assets_path);
+        let bytes_written = write_to_cache(&contents, &compressed_asset_name, assets_cache_path)?;
+
+        // Determine which manifest this file belongs to, if any
+        let manifest = manifests.iter().fold(
+            (None, 0),
+            |(current_manifest, current_depth), manifest| {
+                if compressed_asset_name.starts_with(&manifest.prefix) {
+                    let new_depth = &manifest.prefix.ancestors().count() - 1;
+                    if new_depth >= current_depth {
+                        return (Some(manifest), new_depth);
+                    }
+                }
+
+                (current_manifest, current_depth)
+            }
+        );
+
+        // Add this file to a manifest if necessary
+        if let (Some(manifest), _) = manifest {
+            let manifest_path = assets_cache_path.join(&manifest.prefix).join(&manifest.name);
+            let crc = crc32fast::hash(&contents);
+            let slash_asset_name = forward_slash_path(&compressed_asset_name);
+
+            let mut manifest_entry = Vec::new();
+            manifest_entry.append(&mut slash_asset_name.into_encoded_bytes());
+            manifest_entry.push(b',');
+            manifest_entry.write_all(crc.to_string().as_bytes())?;
+            manifest_entry.push(b',');
+            manifest_entry.write_all(bytes_written.to_string().as_bytes())?;
+            manifest_entry.push(b'\n');
+
+            let mut manifest_file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(manifest_path)?;
+            manifest_file.write_all(&manifest_entry)?;
+        }
+
+    }
+
+    // Compress manifest and create CRC file
+    for manifest in manifests {
+        create_dir_all(assets_cache_path.join(&manifest.prefix))?;
+        let manifest_asset_name = &manifest.prefix.join(&manifest.name);
+        let mut manifest_file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .open(assets_cache_path.join(&manifest_asset_name))?;
+        let mut manifest_contents = Vec::new();
+        manifest_file.read_to_end(&mut manifest_contents)?;
+
+        let manifest_compressed_asset_name = append_extension(
+            COMPRESSED_EXTENSION,
+            &manifest_asset_name
+        );
+        write_to_cache(&manifest_contents, &manifest_compressed_asset_name, assets_cache_path)?;
+
+        let manifest_crc = crc32fast::hash(&manifest_contents).to_string();
+        let manifest_crc_contents = manifest_crc.as_bytes();
+        write_to_cache(manifest_crc_contents, &&manifest.prefix.join("manifest.crc.z"), assets_cache_path)?;
+    }
+
+    Ok(())
+}
+
+async fn asset_handler(Path(asset_name): Path<PathBuf>, State(assets_cache_path): State<PathBuf>, request: Request) -> Result<Vec<u8>, StatusCode> {
+    let file_data = read(assets_cache_path.join(asset_name)).map_err(|_| StatusCode::NOT_FOUND)?;
+    let crc = crc32fast::hash(&file_data);
+    let queried_crc: u32 = if let Some(query) = request.uri().query() {
+        str::parse(query).map_err(|_| StatusCode::BAD_REQUEST)?
+    } else {
+        crc
+    };
+
+    if crc == queried_crc {
+        Ok(file_data)
+    } else {
+        Err(StatusCode::NOT_FOUND)
+    }
+}
+
+async fn try_start(port: u16, config_dir: &std::path::Path, assets_path: &std::path::Path, assets_cache_path: PathBuf) -> io::Result<()> {
+    let manifests = read_manifests_config(config_dir)?;
+    prepare_asset_cache(assets_path, &assets_cache_path, &manifests)?;
+
+    let listener = TcpListener::bind(format!("127.0.0.1:{}", port)).await?;
+    let app: Router<()> = Router::new()
+        .route("/assets/*asset", get(asset_handler))
+        .with_state(assets_cache_path);
+
+    serve(listener, app).await
+}
+
+pub async fn start(port: u16, config_dir: &std::path::Path, assets_path: &std::path::Path, assets_cache_path: PathBuf) {
+    try_start(port, config_dir, assets_path, assets_cache_path).await.expect("Unable to start HTTP server");
+}


### PR DESCRIPTION
# What is implemented
* Implemented an asset server over HTTP for server admins to add custom content.
* Assets are placed in `./config/custom_assets`. At startup, the server generates zlib-compressed versions of the files in `./assets_cache`. The manifest and manifest CRC files are also automatically generated in the cache folder.
* Non-existent files return a 404 response. Improper requests (such as a bad CRC query parameter) return a 400 response.
* If a CRC is provided in the query parameter, the CRC is checked against the CRC of the local file and a 404 response is returned when they do not match. If no query parameter is provided, then the file is always returned.
* Multiple manifest files are supported. (See `Assets_manifest.txt` and `assets/assetpack000_manifest.txt` in the CWA client.) Each file can belong to only one manifest; the deepest applicable manifest is always chosen. For example, with the config in this PR, files inside `./assets/` will always belong to `assets/assetpack000_manifest.txt` because `./assets/` is deeper than `./`. Files in `./test/` would belong to `Assets_manifest.txt` because there's no manifest defined for `./test/`.
* The Rust module is called `http`, not something more specific to assets, because we'll also use this HTTP server to forward auth requests to the auth server.

## Testing
Added test assets with various levels of nesting and compared responses to sample responses from 2014.

# What is not yet implemented
* TLS/HTTPS
* Asset server inside the oxide-client proxy that can read local files
* Configurable port for the HTTP server