### PR TITLE
Use async for file IO in asset server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ parking_lot = "0.12.1"
 rand = "0.8.5"
 serde_json = "1.0.1"
 serde = { version = "1.0.196", features = ["derive"] }
-tokio = { version = "1.38.0", features = ["rt", "rt-multi-thread", "macros"] }
+tokio = { version = "1.38.0", features = ["fs", "io-util", "rt", "rt-multi-thread", "macros"] }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,16 +1,16 @@
+use std::collections::VecDeque;
 use std::ffi::{OsStr, OsString};
-use std::fs::{create_dir_all, File, OpenOptions, read, read_dir, remove_dir_all, write};
-use std::io::{Read, Write};
 use std::path::{Component, PathBuf};
 
+use axum::{Router, serve};
 use axum::extract::{Path, Request, State};
 use axum::http::StatusCode;
-use axum::{Router, serve};
 use axum::routing::get;
-use byteorder::{BigEndian, WriteBytesExt};
 use miniz_oxide::deflate::compress_to_vec_zlib;
 use serde::Deserialize;
+use tokio::fs::{create_dir_all, OpenOptions, read, read_dir, remove_dir_all, write};
 use tokio::io;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 
 const MAGIC: u32 = 0xa1b2c3d4;
@@ -28,9 +28,9 @@ struct Manifest {
     prefix: PathBuf
 }
 
-fn read_manifests_config(config_dir: &std::path::Path) -> io::Result<Vec<Manifest>> {
-    let mut file = File::open(config_dir.join("manifests.json"))?;
-    let manifests: Vec<ManifestConfig> = serde_json::from_reader(&mut file)?;
+async fn read_manifests_config(config_dir: &std::path::Path) -> io::Result<Vec<Manifest>> {
+    let manifests_data = read(config_dir.join("manifests.json")).await?;
+    let manifests: Vec<ManifestConfig> = serde_json::from_slice(&manifests_data)?;
     Ok(
         manifests.into_iter().map(|manifest_config| {
             let mut full_name = manifest_config.name;
@@ -50,19 +50,27 @@ fn append_extension(extension: impl AsRef<OsStr>, path: &std::path::Path) -> Pat
     os_string.into()
 }
 
-fn list_files(dir: &std::path::Path) -> io::Result<Vec<PathBuf>> {
+async fn list_files(root_dir: &std::path::Path) -> io::Result<Vec<PathBuf>> {
     let mut files = Vec::new();
-    if dir.is_dir() {
-        for entry in read_dir(dir)? {
-            let entry = entry?;
-            let path = entry.path();
-            if path.is_dir() {
-                files.append(&mut list_files(&path)?);
-            } else {
-                files.push(entry.path());
+
+    let mut directories = VecDeque::new();
+    directories.push_back(root_dir.to_path_buf());
+
+    while let Some(dir) = directories.pop_front() {
+        if dir.is_dir() {
+            let mut entries = read_dir(dir).await?;
+            while let Some(entry) = entries.next_entry().await? {
+                let entry = entry;
+                let path = entry.path();
+                if path.is_dir() {
+                    directories.push_back(path);
+                } else {
+                    files.push(path);
+                }
             }
         }
     }
+
     Ok(files)
 }
 
@@ -86,32 +94,32 @@ fn compressed_asset_name(asset_path: &std::path::Path, assets_path: &std::path::
     )
 }
 
-fn write_to_cache(uncompressed_contents: &[u8], compressed_asset_name: &std::path::Path,
+async fn write_to_cache(uncompressed_contents: &[u8], compressed_asset_name: &std::path::Path,
                   assets_cache_path: &std::path::Path) -> io::Result<usize> {
     let mut compressed_contents = Vec::new();
-    compressed_contents.write_u32::<BigEndian>(MAGIC)?;
-    compressed_contents.write_u32::<BigEndian>(uncompressed_contents.len() as u32)?;
+    compressed_contents.write_u32(MAGIC).await?;
+    compressed_contents.write_u32(uncompressed_contents.len() as u32).await?;
     compressed_contents.append(&mut compress_to_vec_zlib(&uncompressed_contents, ZLIB_COMPRESSION_LEVEL));
 
     let cached_asset_path = assets_cache_path.join(&compressed_asset_name);
     if let Some(parent) = cached_asset_path.parent() {
-        create_dir_all(parent)?;
+        create_dir_all(parent).await?;
     }
-    write(&cached_asset_path, &compressed_contents)?;
+    write(&cached_asset_path, &compressed_contents).await?;
     Ok(compressed_contents.len())
 }
 
-fn prepare_asset_cache(assets_path: &std::path::Path, assets_cache_path: &std::path::Path,
+async fn prepare_asset_cache(assets_path: &std::path::Path, assets_cache_path: &std::path::Path,
                        manifests: &[Manifest]) -> io::Result<()> {
-    remove_dir_all(assets_cache_path)?;
-    create_dir_all(assets_cache_path)?;
-    let mut asset_paths = list_files(assets_path)?;
+    remove_dir_all(assets_cache_path).await?;
+    create_dir_all(assets_cache_path).await?;
+    let mut asset_paths = list_files(assets_path).await?;
     asset_paths.sort();
 
     for asset_path in asset_paths {
-        let contents = read(&asset_path)?;
+        let contents = read(&asset_path).await?;
         let compressed_asset_name = compressed_asset_name(&asset_path, assets_path);
-        let bytes_written = write_to_cache(&contents, &compressed_asset_name, assets_cache_path)?;
+        let bytes_written = write_to_cache(&contents, &compressed_asset_name, assets_cache_path).await?;
 
         // Determine which manifest this file belongs to, if any
         let manifest = manifests.iter().fold(
@@ -137,41 +145,41 @@ fn prepare_asset_cache(assets_path: &std::path::Path, assets_cache_path: &std::p
             let mut manifest_entry = Vec::new();
             manifest_entry.append(&mut slash_asset_name.into_encoded_bytes());
             manifest_entry.push(b',');
-            manifest_entry.write_all(crc.to_string().as_bytes())?;
+            manifest_entry.write_all(crc.to_string().as_bytes()).await?;
             manifest_entry.push(b',');
-            manifest_entry.write_all(bytes_written.to_string().as_bytes())?;
+            manifest_entry.write_all(bytes_written.to_string().as_bytes()).await?;
             manifest_entry.push(b'\n');
 
             let mut manifest_file = OpenOptions::new()
                 .create(true)
                 .append(true)
-                .open(manifest_path)?;
-            manifest_file.write_all(&manifest_entry)?;
+                .open(manifest_path).await?;
+            manifest_file.write_all(&manifest_entry).await?;
         }
 
     }
 
     // Compress manifest and create CRC file
     for manifest in manifests {
-        create_dir_all(assets_cache_path.join(&manifest.prefix))?;
+        create_dir_all(assets_cache_path.join(&manifest.prefix)).await?;
         let manifest_asset_name = &manifest.prefix.join(&manifest.name);
         let mut manifest_file = OpenOptions::new()
             .create(true)
             .read(true)
             .write(true)
-            .open(assets_cache_path.join(&manifest_asset_name))?;
+            .open(assets_cache_path.join(&manifest_asset_name)).await?;
         let mut manifest_contents = Vec::new();
-        manifest_file.read_to_end(&mut manifest_contents)?;
+        manifest_file.read_to_end(&mut manifest_contents).await?;
 
         let manifest_compressed_asset_name = append_extension(
             COMPRESSED_EXTENSION,
             &manifest_asset_name
         );
-        write_to_cache(&manifest_contents, &manifest_compressed_asset_name, assets_cache_path)?;
+        write_to_cache(&manifest_contents, &manifest_compressed_asset_name, assets_cache_path).await?;
 
         let manifest_crc = crc32fast::hash(&manifest_contents).to_string();
         let manifest_crc_contents = manifest_crc.as_bytes();
-        write_to_cache(manifest_crc_contents, &&manifest.prefix.join("manifest.crc.z"), assets_cache_path)?;
+        write_to_cache(manifest_crc_contents, &&manifest.prefix.join("manifest.crc.z"), assets_cache_path).await?;
     }
 
     Ok(())
@@ -193,7 +201,7 @@ async fn asset_handler(Path(asset_name): Path<PathBuf>, State(assets_cache_path)
         return Err(StatusCode::BAD_REQUEST);
     }
 
-    let file_data = read(assets_cache_path.join(asset_name)).map_err(|_| StatusCode::NOT_FOUND)?;
+    let file_data = read(assets_cache_path.join(asset_name)).await.map_err(|_| StatusCode::NOT_FOUND)?;
     let crc = crc32fast::hash(&file_data);
     let queried_crc: u32 = if let Some(query) = request.uri().query() {
         str::parse(query).map_err(|_| StatusCode::BAD_REQUEST)?
@@ -209,8 +217,8 @@ async fn asset_handler(Path(asset_name): Path<PathBuf>, State(assets_cache_path)
 }
 
 async fn try_start(port: u16, config_dir: &std::path::Path, assets_path: &std::path::Path, assets_cache_path: PathBuf) -> io::Result<()> {
-    let manifests = read_manifests_config(config_dir)?;
-    prepare_asset_cache(assets_path, &assets_cache_path, &manifests)?;
+    let manifests = read_manifests_config(config_dir).await?;
+    prepare_asset_cache(assets_path, &assets_cache_path, &manifests).await?;
 
     let listener = TcpListener::bind(format!("127.0.0.1:{}", port)).await?;
     let app: Router<()> = Router::new()


### PR DESCRIPTION
Change all file IO in the asset server to use `async`/`await` instead of blocking the thread. The `async` runtime does not always separate tasks onto separate threads. This means that performing synchronous file IO when handling a request could block **all** requests on the asset server, even though the request handler is `async`. This PR changes all file IO in the asset server to use Tokio's `async` file system functions. While changing the asset server setup IO is essentially a no-op (because there is only one task running during setup), I added `async` there to be more future-proof and consistent with the request handler.

See this excellent article about `async` in Rust: https://ryhl.io/blog/async-what-is-blocking/