### PR TITLE
Add linting and check style to CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,3 +16,7 @@ jobs:
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
       - name: Run tests
         run: cargo test
+      - name: Lint
+        run: cargo clippy -- -Dwarnings -A unused -A clippy::too_many_arguments
+      - name: Check style
+        run: cargo fmt --all --check

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -170,6 +170,7 @@ async fn prepare_asset_cache(
 
             let mut manifest_file = OpenOptions::new()
                 .create(true)
+                .truncate(false)
                 .append(true)
                 .open(manifest_path)
                 .await?;

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -184,6 +184,7 @@ async fn prepare_asset_cache(
         let manifest_asset_name = &manifest.prefix.join(&manifest.name);
         let mut manifest_file = OpenOptions::new()
             .create(true)
+            .truncate(false)
             .read(true)
             .write(true)
             .open(assets_cache_path.join(manifest_asset_name))


### PR DESCRIPTION
Add linting and check style to CI using Clippy and `rustfmt`.