### PR TITLE
Fix asset server CRC check

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -249,10 +249,10 @@ async fn asset_handler(
         return Err(StatusCode::BAD_REQUEST);
     }
 
+    let crc = *crc_map.get(&asset_name).ok_or(StatusCode::NOT_FOUND)?;
     let file_data = read(assets_cache_path.join(&asset_name))
         .await
         .map_err(|_| StatusCode::NOT_FOUND)?;
-    let crc = *crc_map.get(&asset_name).ok_or(StatusCode::NOT_FOUND)?;
     let queried_crc: u32 = if let Some(query) = request.uri().query() {
         str::parse(query).map_err(|_| StatusCode::BAD_REQUEST)?
     } else {


### PR DESCRIPTION
The CRC check in the asset server currently uses the CRC of the compressed file plus magic number, but it should use the CRC of the uncompressed file. I've corrected the CRC calculation and made the CRCs cached in memory, rather than having to recompute the CRC with every request.