### PR TITLE
Add lock enforcer

### DIFF
--- a/src/game_server/guid.rs
+++ b/src/game_server/guid.rs
@@ -58,7 +58,11 @@ pub trait GuidTableHandle<'a, K, V: 'a, I> {
 
     fn iter(&'a self) -> impl Iterator<Item = (K, &'a Lock<V>)>;
 
+    fn keys(&'a self) -> impl Iterator<Item = K>;
+
     fn values(&'a self) -> impl Iterator<Item = &'a Lock<V>>;
+
+    fn keys_by_index(&'a self, index: I) -> impl Iterator<Item = K>;
 
     fn values_by_index(&'a self, index: I) -> impl Iterator<Item = &'a Lock<V>>;
 }
@@ -70,12 +74,10 @@ pub struct GuidTableReadHandle<'a, K, V, I = ()> {
 impl<'a, K: Copy + Ord, V, I: Copy + Ord> GuidTableHandle<'a, K, V, I>
     for GuidTableReadHandle<'a, K, V, I>
 {
-    //noinspection DuplicatedCode
     fn get(&self, guid: K) -> Option<&Lock<V>> {
         self.guard.data.get(&guid).map(|(item, _)| item)
     }
 
-    //noinspection DuplicatedCode
     fn iter(&'a self) -> impl Iterator<Item = (K, &'a Lock<V>)> {
         self.guard
             .data
@@ -83,12 +85,23 @@ impl<'a, K: Copy + Ord, V, I: Copy + Ord> GuidTableHandle<'a, K, V, I>
             .map(move |(guid, (item, _))| (*guid, item))
     }
 
-    //noinspection DuplicatedCode
+    fn keys(&'a self) -> impl Iterator<Item = K> {
+        self.guard.data.keys().cloned()
+    }
+
     fn values(&'a self) -> impl Iterator<Item = &'a Lock<V>> {
         self.guard.data.values().map(|(item, _)| item)
     }
 
-    //noinspection DuplicatedCode
+    fn keys_by_index(&'a self, index: I) -> impl Iterator<Item = K> {
+        self.guard
+            .index
+            .get(&index)
+            .map(|index_list| index_list.iter())
+            .unwrap_or_default()
+            .cloned()
+    }
+
     fn values_by_index(&'a self, index: I) -> impl Iterator<Item = &'a Lock<V>> {
         self.guard
             .index
@@ -155,12 +168,10 @@ impl<'a, K: Copy + Ord, V: IndexedGuid<K, I>, I: Copy + Ord> GuidTableWriteHandl
 impl<'a, K: Copy + Ord, I: Copy + Ord, V: IndexedGuid<K, I>> GuidTableHandle<'a, K, V, I>
     for GuidTableWriteHandle<'a, K, V, I>
 {
-    //noinspection DuplicatedCode
     fn get(&self, guid: K) -> Option<&Lock<V>> {
         self.guard.data.get(&guid).map(|(item, _)| item)
     }
 
-    //noinspection DuplicatedCode
     fn iter(&'a self) -> impl Iterator<Item = (K, &'a Lock<V>)> {
         self.guard
             .data
@@ -168,12 +179,23 @@ impl<'a, K: Copy + Ord, I: Copy + Ord, V: IndexedGuid<K, I>> GuidTableHandle<'a,
             .map(|(guid, (item, _))| (*guid, item))
     }
 
-    //noinspection DuplicatedCode
+    fn keys(&'a self) -> impl Iterator<Item = K> {
+        self.guard.data.keys().cloned()
+    }
+
     fn values(&'a self) -> impl Iterator<Item = &'a Lock<V>> {
         self.guard.data.values().map(|(item, _)| item)
     }
 
-    //noinspection DuplicatedCode
+    fn keys_by_index(&'a self, index: I) -> impl Iterator<Item = K> {
+        self.guard
+            .index
+            .get(&index)
+            .map(|index_list| index_list.iter())
+            .unwrap_or_default()
+            .cloned()
+    }
+
     fn values_by_index(&'a self, index: I) -> impl Iterator<Item = &'a Lock<V>> {
         self.guard
             .index

--- a/src/game_server/lock_enforcer.rs
+++ b/src/game_server/lock_enforcer.rs
@@ -1,0 +1,200 @@
+use std::collections::BTreeMap;
+
+use parking_lot::{RwLockReadGuard, RwLockWriteGuard};
+
+use crate::game_server::guid::GuidTable;
+use crate::game_server::zone::{Character, CharacterCategory, Zone};
+
+use super::guid::{GuidTableHandle, GuidTableReadHandle, GuidTableWriteHandle};
+
+pub struct TableReadHandleWrapper<'a, K, V, I = ()> {
+    handle: GuidTableReadHandle<'a, K, V, I>,
+}
+
+impl<K: Copy + Ord, V, I: Copy + Ord> TableReadHandleWrapper<'_, K, V, I> {
+    pub fn contains(&self, guid: K) -> bool {
+        self.handle.get(guid).is_some()
+    }
+
+    pub fn keys(&self) -> impl Iterator<Item = K> + '_ {
+        self.handle.keys()
+    }
+
+    pub fn keys_by_index(&self, index: I) -> impl Iterator<Item = K> + '_ {
+        self.handle.keys_by_index(index)
+    }
+}
+
+impl<'a, K, V, I> From<GuidTableReadHandle<'a, K, V, I>> for TableReadHandleWrapper<'a, K, V, I> {
+    fn from(value: GuidTableReadHandle<'a, K, V, I>) -> Self {
+        TableReadHandleWrapper { handle: value }
+    }
+}
+
+pub type CharacterTableReadHandle<'a> =
+    TableReadHandleWrapper<'a, u64, Character, (u64, CharacterCategory)>;
+pub type CharacterTableWriteHandle<'a> =
+    GuidTableWriteHandle<'a, u64, Character, (u64, CharacterCategory)>;
+pub type CharacterReadGuard<'a> = RwLockReadGuard<'a, Character>;
+pub type CharacterWriteGuard<'a> = RwLockWriteGuard<'a, Character>;
+pub type ZoneTableReadHandle<'a> = TableReadHandleWrapper<'a, u64, Zone>;
+pub type ZoneTableWriteHandle<'a> = GuidTableWriteHandle<'a, u64, Zone>;
+pub type ZoneReadGuard<'a> = RwLockReadGuard<'a, Zone>;
+pub type ZoneWriteGuard<'a> = RwLockWriteGuard<'a, Zone>;
+
+pub struct ZoneLockRequest<
+    R,
+    F: FnOnce(
+        &ZoneTableReadHandle<'_>,
+        BTreeMap<u64, ZoneReadGuard<'_>>,
+        BTreeMap<u64, ZoneWriteGuard<'_>>,
+    ) -> R,
+> {
+    read_guids: Vec<u64>,
+    write_guids: Vec<u64>,
+    zone_consumer: F,
+}
+
+pub struct ZoneLockEnforcer<'a> {
+    zones: &'a GuidTable<u64, Zone>,
+}
+
+impl ZoneLockEnforcer<'_> {
+    pub fn read_zones<
+        R,
+        Z: FnOnce(
+            &ZoneTableReadHandle<'_>,
+            BTreeMap<u64, ZoneReadGuard<'_>>,
+            BTreeMap<u64, ZoneWriteGuard<'_>>,
+        ) -> R,
+        T: FnOnce(&ZoneTableReadHandle<'_>) -> ZoneLockRequest<R, Z>,
+    >(
+        &self,
+        table_consumer: T,
+    ) -> R {
+        let zones_table_read_handle = self.zones.read().into();
+        let mut zone_lock_request = table_consumer(&zones_table_read_handle);
+        zone_lock_request.read_guids.sort();
+        zone_lock_request.write_guids.sort();
+
+        let mut zones_read_map = BTreeMap::new();
+        for guid in zone_lock_request.read_guids {
+            if let Some(lock) = zones_table_read_handle.handle.get(guid) {
+                zones_read_map.insert(guid, lock.read());
+            }
+        }
+
+        let mut zones_write_map = BTreeMap::new();
+        for guid in zone_lock_request.write_guids {
+            if let Some(lock) = zones_table_read_handle.handle.get(guid) {
+                zones_write_map.insert(guid, lock.write());
+            }
+        }
+
+        (zone_lock_request.zone_consumer)(&zones_table_read_handle, zones_read_map, zones_write_map)
+    }
+
+    pub fn write_zones<R, T: FnOnce(&ZoneTableWriteHandle) -> R>(&self, table_consumer: T) -> R {
+        let zones_table_write_handle = self.zones.write();
+        table_consumer(&zones_table_write_handle)
+    }
+}
+
+pub struct CharacterLockRequest<
+    R,
+    F: FnOnce(
+        &CharacterTableReadHandle<'_>,
+        BTreeMap<u64, CharacterReadGuard<'_>>,
+        BTreeMap<u64, CharacterWriteGuard<'_>>,
+        &ZoneLockEnforcer,
+    ) -> R,
+> {
+    read_guids: Vec<u64>,
+    write_guids: Vec<u64>,
+    character_consumer: F,
+}
+
+pub struct LockEnforcer<'a> {
+    characters: &'a GuidTable<u64, Character, (u64, CharacterCategory)>,
+    zones: &'a GuidTable<u64, Zone>,
+}
+
+impl LockEnforcer<'_> {
+    pub fn read_characters<
+        R,
+        C: FnOnce(
+            &CharacterTableReadHandle<'_>,
+            BTreeMap<u64, CharacterReadGuard<'_>>,
+            BTreeMap<u64, CharacterWriteGuard<'_>>,
+            &ZoneLockEnforcer,
+        ) -> R,
+        T: FnOnce(&CharacterTableReadHandle<'_>) -> CharacterLockRequest<R, C>,
+    >(
+        &self,
+        table_consumer: T,
+    ) -> R {
+        let characters_table_read_handle = self.characters.read().into();
+        let mut character_lock_request: CharacterLockRequest<R, C> =
+            table_consumer(&characters_table_read_handle);
+        character_lock_request.read_guids.sort();
+        character_lock_request.write_guids.sort();
+
+        let mut characters_read_map = BTreeMap::new();
+        for guid in character_lock_request.read_guids {
+            if let Some(lock) = characters_table_read_handle.handle.get(guid) {
+                characters_read_map.insert(guid, lock.read());
+            }
+        }
+
+        let mut characters_write_map = BTreeMap::new();
+        for guid in character_lock_request.write_guids {
+            if let Some(lock) = characters_table_read_handle.handle.get(guid) {
+                characters_write_map.insert(guid, lock.write());
+            }
+        }
+
+        let zones_enforcer = ZoneLockEnforcer { zones: self.zones };
+        (character_lock_request.character_consumer)(
+            &characters_table_read_handle,
+            characters_read_map,
+            characters_write_map,
+            &zones_enforcer,
+        )
+    }
+
+    pub fn write_characters<R, T: FnOnce(&CharacterTableWriteHandle, &ZoneLockEnforcer) -> R>(
+        &self,
+        table_consumer: T,
+    ) -> R {
+        let characters_table_write_handle = self.characters.write();
+        let zones_enforcer = ZoneLockEnforcer { zones: self.zones };
+        table_consumer(&characters_table_write_handle, &zones_enforcer)
+    }
+}
+
+impl<'a> From<LockEnforcer<'a>> for ZoneLockEnforcer<'a> {
+    fn from(val: LockEnforcer<'a>) -> Self {
+        ZoneLockEnforcer { zones: val.zones }
+    }
+}
+
+pub struct LockEnforcerSource {
+    characters: GuidTable<u64, Character, (u64, CharacterCategory)>,
+    zones: GuidTable<u64, Zone>,
+}
+
+impl LockEnforcerSource {
+    pub fn from(
+        characters: GuidTable<u64, Character, (u64, CharacterCategory)>,
+        zones: GuidTable<u64, Zone>,
+    ) -> LockEnforcerSource {
+        LockEnforcerSource { characters, zones }
+    }
+
+    pub fn lock_enforcer(&self) -> LockEnforcer {
+        LockEnforcer {
+            characters: &self.characters,
+            zones: &self.zones,
+        }
+    }
+}

--- a/src/game_server/lock_enforcer.rs
+++ b/src/game_server/lock_enforcer.rs
@@ -94,6 +94,10 @@ impl ZoneLockEnforcer<'_> {
         (zone_lock_request.zone_consumer)(&zones_table_read_handle, zones_read_map, zones_write_map)
     }
 
+    // This thread can access individual zones if and only if it holds the table read or write lock.
+    // If this thread holds the table write lock, then no other threads may hold a table lock.
+    // Therefore, if this thread holds the table write lock, it is the only thread that can hold any
+    // zone locks, and we can provide full access to the table without fear of deadlock.
     pub fn write_zones<R, T: FnOnce(&ZoneTableWriteHandle) -> R>(&self, table_consumer: T) -> R {
         let zones_table_write_handle = self.zones.write();
         table_consumer(&zones_table_write_handle)
@@ -162,6 +166,10 @@ impl LockEnforcer<'_> {
         )
     }
 
+    // This thread can access individual characters if and only if it holds the table read or write lock.
+    // If this thread holds the table write lock, then no other threads may hold a table lock.
+    // Therefore, if this thread holds the table write lock, it is the only thread that can hold any
+    // character locks, and we can provide full access to the table without fear of deadlock.
     pub fn write_characters<R, T: FnOnce(&CharacterTableWriteHandle, &ZoneLockEnforcer) -> R>(
         &self,
         table_consumer: T,

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -55,6 +55,7 @@ mod game_packet;
 mod guid;
 mod housing;
 mod item;
+mod lock_enforcer;
 mod login;
 mod mount;
 mod player_data;


### PR DESCRIPTION
Implements the `LockEnforcer` as a safer way to handle locking. This PR only adds the `LockEnforcer`; adding it to the game server will be a subsequent PR.

The splitting of the zone and character tables in #21 introduced more potential for deadlock because the ordering of locks is not always consistent. For example, if thread 1 locks the zones table, thread 2 locks the characters table, thread 1 tries to lock the characters table, and then thread 2 tries to lock the zones table, deadlock will occur. Even before that PR, deadlock potential existed because we don't always obtain individual character and zone locks in any particular order.

For example, the characters table is *usually* locked before the zones table. There is [at least one exception](https://github.com/soir20/oxide/blob/b8704d6eaf2970c70b1f98e3ff12a52c1607ae06/src/game_server/mod.rs#L418-L419) where the zones table is locked first. Another [example](https://github.com/soir20/oxide/blob/b8704d6eaf2970c70b1f98e3ff12a52c1607ae06/src/game_server/zone.rs#L973-L975) is when the characters table is initially locked before the zones table, but the characters table is unlocked and locked again by the same thread without ever releasing the zones table lock.

One way to avoid deadlock is to always obtain all locks in the same order, a well-known concurrency principle. This PR's `LockEnforcer` makes correct lock ordering the path of least resistance by encouraging character locks before zone locks, and the locks within each type are also acquired in order. `LockEnforcer`'s guarantees break down when it is called recursively, but this is significantly easier to catch in PR reviews then manually tracking all the locks.

Sample call to `LockEnforcer`:
```rust
fn test() {
    let characters = GuidTable::new();
    let zones = GuidTable::new();
    let les = LockEnforcerSource::from(characters, zones);

    let le = les.lock_enforcer();

    le.read_characters(|chars_table| CharacterLockRequest {
        read_guids: vec![0, 1, 2],
        write_guids: vec![3, 4, 5],
        character_consumer: |chars_table, chars_read, chars_write, zones_le: &ZoneLockEnforcer| {
            zones_le.read_zones(|zones_table| ZoneLockRequest {
                read_guids: vec![0, 1, 2],
                write_guids: vec![3, 4, 5],
                zone_consumer: |zones_table, zones_read, zones_write| 0,
            })
        },
    });
}
```