### PR TITLE
Implement character chunking

### DIFF
--- a/src/game_server/housing.rs
+++ b/src/game_server/housing.rs
@@ -653,7 +653,7 @@ pub fn process_housing_packet(
                     read_guids: Vec::new(),
                     write_guids: Vec::new(),
                     character_consumer: |characters_table_read_handle, _, _, zones_lock_enforcer| {
-                        let packets = if let Some((instance_guid, _)) = characters_table_read_handle.index(player_guid(sender)) {
+                        let packets = if let Some((instance_guid, _, _)) = characters_table_read_handle.index(player_guid(sender)) {
                             zones_lock_enforcer.read_zones(|_| ZoneLockRequest {
                                 read_guids: vec![instance_guid],
                                 write_guids: Vec::new(),

--- a/src/game_server/lock_enforcer.rs
+++ b/src/game_server/lock_enforcer.rs
@@ -36,10 +36,8 @@ impl<'a, K, V, I> From<GuidTableReadHandle<'a, K, V, I>> for TableReadHandleWrap
     }
 }
 
-pub type CharacterTableReadHandle<'a> =
-    TableReadHandleWrapper<'a, u64, Character, CharacterIndex>;
-pub type CharacterTableWriteHandle<'a> =
-    GuidTableWriteHandle<'a, u64, Character, CharacterIndex>;
+pub type CharacterTableReadHandle<'a> = TableReadHandleWrapper<'a, u64, Character, CharacterIndex>;
+pub type CharacterTableWriteHandle<'a> = GuidTableWriteHandle<'a, u64, Character, CharacterIndex>;
 pub type CharacterReadGuard<'a> = RwLockReadGuard<'a, Character>;
 pub type CharacterWriteGuard<'a> = RwLockWriteGuard<'a, Character>;
 pub type ZoneTableReadHandle<'a> = TableReadHandleWrapper<'a, u64, Zone, u8>;

--- a/src/game_server/lock_enforcer.rs
+++ b/src/game_server/lock_enforcer.rs
@@ -3,9 +3,10 @@ use std::collections::{BTreeMap, BTreeSet};
 use parking_lot::{RwLockReadGuard, RwLockWriteGuard};
 
 use crate::game_server::guid::GuidTable;
-use crate::game_server::zone::{Character, CharacterCategory, Zone};
+use crate::game_server::zone::{Character, Zone};
 
 use super::guid::{GuidTableHandle, GuidTableReadHandle, GuidTableWriteHandle};
+use super::zone::CharacterIndex;
 
 pub struct TableReadHandleWrapper<'a, K, V, I = ()> {
     handle: GuidTableReadHandle<'a, K, V, I>,
@@ -36,9 +37,9 @@ impl<'a, K, V, I> From<GuidTableReadHandle<'a, K, V, I>> for TableReadHandleWrap
 }
 
 pub type CharacterTableReadHandle<'a> =
-    TableReadHandleWrapper<'a, u64, Character, (u64, CharacterCategory)>;
+    TableReadHandleWrapper<'a, u64, Character, CharacterIndex>;
 pub type CharacterTableWriteHandle<'a> =
-    GuidTableWriteHandle<'a, u64, Character, (u64, CharacterCategory)>;
+    GuidTableWriteHandle<'a, u64, Character, CharacterIndex>;
 pub type CharacterReadGuard<'a> = RwLockReadGuard<'a, Character>;
 pub type CharacterWriteGuard<'a> = RwLockWriteGuard<'a, Character>;
 pub type ZoneTableReadHandle<'a> = TableReadHandleWrapper<'a, u64, Zone, u8>;
@@ -127,7 +128,7 @@ pub struct CharacterLockRequest<
 }
 
 pub struct LockEnforcer<'a> {
-    characters: &'a GuidTable<u64, Character, (u64, CharacterCategory)>,
+    characters: &'a GuidTable<u64, Character, CharacterIndex>,
     zones: &'a GuidTable<u64, Zone, u8>,
 }
 
@@ -199,13 +200,13 @@ impl<'a> From<LockEnforcer<'a>> for ZoneLockEnforcer<'a> {
 }
 
 pub struct LockEnforcerSource {
-    characters: GuidTable<u64, Character, (u64, CharacterCategory)>,
+    characters: GuidTable<u64, Character, CharacterIndex>,
     zones: GuidTable<u64, Zone, u8>,
 }
 
 impl LockEnforcerSource {
     pub fn from(
-        characters: GuidTable<u64, Character, (u64, CharacterCategory)>,
+        characters: GuidTable<u64, Character, CharacterIndex>,
         zones: GuidTable<u64, Zone, u8>,
     ) -> LockEnforcerSource {
         LockEnforcerSource { characters, zones }

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use std::vec;
 
 use byteorder::{LittleEndian, ReadBytesExt};
+use guid::GuidTableHandle;
 use lock_enforcer::{
     CharacterLockRequest, LockEnforcer, LockEnforcerSource, ZoneLockRequest, ZoneTableReadHandle,
 };
@@ -13,7 +14,7 @@ use packet_serialize::{
     DeserializePacket, DeserializePacketError, NullTerminatedString, SerializePacketError,
 };
 use unique_guid::{shorten_zone_template_guid, zone_instance_guid};
-use zone::CharacterCategory;
+use zone::CharacterIndex;
 
 use crate::game_server::chat::process_chat_packet;
 use crate::game_server::client_update_packet::{
@@ -283,94 +284,89 @@ impl GameServer {
                         unknown1: true,
                         inner: make_test_npc(),
                     };
-                    //packets.push(GamePacket::serialize(&npc)?);
+                    packets.push(GamePacket::serialize(&npc)?);
 
-                    let (stat_packet, character_guids) = self.lock_enforcer().read_characters(|_| CharacterLockRequest {
-                        read_guids: Vec::new(),
-                        write_guids: Vec::new(),
-                        character_consumer: |characters_table_read_handle, _, _, zones_lock_enforcer| {
-                            if let Some((instance_guid, _)) = characters_table_read_handle.index(player_guid(sender)) {
-                                zones_lock_enforcer.read_zones(|_| ZoneLockRequest {
-                                    read_guids: vec![instance_guid],
-                                    write_guids: Vec::new(),
-                                    zone_consumer: |_, zones_read, _| {
-                                        if let Some(zone) = zones_read.get(&instance_guid) {
-                                            let stats = TunneledPacket {
-                                                unknown1: true,
-                                                inner: Stats {
-                                                    stats: vec![
-                                                        Stat {
-                                                            id: StatId::Speed,
-                                                            multiplier: 1,
-                                                            value1: 0.0,
-                                                            value2: zone.speed,
-                                                        },
-                                                        Stat {
-                                                            id: StatId::PowerRegen,
-                                                            multiplier: 1,
-                                                            value1: 0.0,
-                                                            value2: 1.0,
-                                                        },
-                                                        Stat {
-                                                            id: StatId::PowerRegen,
-                                                            multiplier: 1,
-                                                            value1: 0.0,
-                                                            value2: 1.0,
-                                                        },
-                                                        Stat {
-                                                            id: StatId::GravityMultiplier,
-                                                            multiplier: 1,
-                                                            value1: 0.0,
-                                                            value2: zone.gravity_multiplier,
-                                                        },
-                                                        Stat {
-                                                            id: StatId::JumpHeightMultiplier,
-                                                            multiplier: 1,
-                                                            value1: 0.0,
-                                                            value2: zone.jump_height_multiplier,
-                                                        },
-                                                    ],
-                                                },
-                                            };
+                    let mut character_packets = self.lock_enforcer().read_characters(|characters_table_read_handle| {
+                        let possible_index = characters_table_read_handle.index(player_guid(sender));
+                        let character_guids = possible_index.map(|(instance_guid, chunk, _)| Zone::diff_character_guids(
+                            instance_guid,
+                            Character::MIN_CHUNK,
+                            chunk,
+                            characters_table_read_handle
+                        ))
+                            .unwrap_or_default();
+                        CharacterLockRequest {
+                            read_guids: character_guids.keys().copied().collect(),
+                            write_guids: Vec::new(),
+                            character_consumer: move |_, characters_read, _, zones_lock_enforcer| {
+                                if let Some((instance_guid, _, _)) = possible_index {
+                                    zones_lock_enforcer.read_zones(|_| ZoneLockRequest {
+                                        read_guids: vec![instance_guid],
+                                        write_guids: Vec::new(),
+                                        zone_consumer: |_, zones_read, _| {
+                                            if let Some(zone) = zones_read.get(&instance_guid) {
+                                                let stats = TunneledPacket {
+                                                    unknown1: true,
+                                                    inner: Stats {
+                                                        stats: vec![
+                                                            Stat {
+                                                                id: StatId::Speed,
+                                                                multiplier: 1,
+                                                                value1: 0.0,
+                                                                value2: zone.speed,
+                                                            },
+                                                            Stat {
+                                                                id: StatId::PowerRegen,
+                                                                multiplier: 1,
+                                                                value1: 0.0,
+                                                                value2: 1.0,
+                                                            },
+                                                            Stat {
+                                                                id: StatId::PowerRegen,
+                                                                multiplier: 1,
+                                                                value1: 0.0,
+                                                                value2: 1.0,
+                                                            },
+                                                            Stat {
+                                                                id: StatId::GravityMultiplier,
+                                                                multiplier: 1,
+                                                                value1: 0.0,
+                                                                value2: zone.gravity_multiplier,
+                                                            },
+                                                            Stat {
+                                                                id: StatId::JumpHeightMultiplier,
+                                                                multiplier: 1,
+                                                                value1: 0.0,
+                                                                value2: zone.jump_height_multiplier,
+                                                            },
+                                                        ],
+                                                    },
+                                                };
 
-                                            Ok((GamePacket::serialize(&stats)?, Zone::character_guids(instance_guid, characters_table_read_handle)))
-                                        } else {
-                                            println!(
-                                                "Player {} sent a ready packet from unknown zone {}",
-                                                sender, instance_guid
-                                            );
-                                            Err(ProcessPacketError::CorruptedPacket)
-                                        }
-                                    },
-                                })
-                            } else {
-                                println!(
-                                    "Player {} sent a ready packet but is not in any zone",
-                                    sender
-                                );
-                                Err(ProcessPacketError::CorruptedPacket)
-                            }
-                        },
+                                                let mut packets = vec![GamePacket::serialize(&stats)?];
+
+                                                packets.append(&mut Zone::diff_character_packets(&character_guids, &characters_read)?);
+
+                                                Ok(packets)
+                                            } else {
+                                                println!(
+                                                    "Player {} sent a ready packet from unknown zone {}",
+                                                    sender, instance_guid
+                                                );
+                                                Err(ProcessPacketError::CorruptedPacket)
+                                            }
+                                        },
+                                    })
+                                } else {
+                                    println!(
+                                        "Player {} sent a ready packet but is not in any zone",
+                                        sender
+                                    );
+                                    Err(ProcessPacketError::CorruptedPacket)
+                                }
+                            },
+                        }
                     })?;
-                    packets.push(stat_packet);
-
-                    let mut character_packets =
-                        self.lock_enforcer()
-                            .read_characters(|_| CharacterLockRequest {
-                                read_guids: character_guids.clone(),
-                                write_guids: Vec::new(),
-                                character_consumer: |_, characters_read, _, _| {
-                                    let mut packets = Vec::new();
-
-                                    for guid in character_guids {
-                                        if let Some(character) = characters_read.get(&guid) {
-                                            packets.append(&mut character.to_packets()?);
-                                        }
-                                    }
-
-                                    Ok::<Vec<Vec<u8>>, ProcessPacketError>(packets)
-                                },
-                            })?;
                     packets.append(&mut character_packets);
 
                     let health = TunneledPacket {
@@ -438,7 +434,7 @@ impl GameServer {
                     let pos_update: UpdatePlayerPosition =
                         DeserializePacket::deserialize(&mut cursor)?;
                     // TODO: broadcast pos update to all players
-                    broadcasts.append(&mut Zone::move_character(pos_update, self)?);
+                    broadcasts.append(&mut Zone::move_character(sender, pos_update, self)?);
                 }
                 OpCode::ZoneTeleportRequest => {
                     let teleport_request: ZoneTeleportRequest =
@@ -448,7 +444,7 @@ impl GameServer {
                         |characters_table_write_handle: &mut GuidTableWriteHandle<
                             u64,
                             Character,
-                            (u64, CharacterCategory),
+                            CharacterIndex,
                         >,
                          zones_lock_enforcer| {
                             zones_lock_enforcer.read_zones(|zones_table_read_handle| {
@@ -491,30 +487,26 @@ impl GameServer {
                     )?);
                 }
                 OpCode::TeleportToSafety => {
-                    let mut packets = self.lock_enforcer().read_characters(|_| CharacterLockRequest {
-                        read_guids: Vec::new(),
-                        write_guids: Vec::new(),
-                        character_consumer: |characters_table_read_handle, _, _, zones_lock_enforcer| {
-                            if let Some((instance_guid, _)) = characters_table_read_handle.index(player_guid(sender)) {
-                                zones_lock_enforcer.read_zones(|_| ZoneLockRequest {
-                                    read_guids: vec![instance_guid],
-                                    write_guids: Vec::new(),
-                                    zone_consumer: |_, zones_read, _| {
-                                        if let Some(zone) = zones_read.get(&instance_guid) {
-                                            let spawn_pos = zone.default_spawn_pos;
-                                            let spawn_rot = zone.default_spawn_rot;
+                    let mut packets = self.lock_enforcer().write_characters(|characters_table_write_handle, zones_lock_enforcer| {
+                        if let Some((instance_guid, _, _)) = characters_table_write_handle.index(player_guid(sender)) {
+                            zones_lock_enforcer.read_zones(|_| ZoneLockRequest {
+                                read_guids: vec![instance_guid],
+                                write_guids: Vec::new(),
+                                zone_consumer: |_, zones_read, _| {
+                                    if let Some(zone) = zones_read.get(&instance_guid) {
+                                        let spawn_pos = zone.default_spawn_pos;
+                                        let spawn_rot = zone.default_spawn_rot;
 
-                                            teleport_within_zone(sender, spawn_pos, spawn_rot)
-                                        } else {
-                                            println!("Player {} outside zone tried to teleport to safety", sender);
-                                            Err(ProcessPacketError::CorruptedPacket)
-                                        }
-                                    },
-                                })
-                            } else {
-                                println!("Unknown player {} tried to teleport to safety", sender);
-                                Err(ProcessPacketError::CorruptedPacket)
-                            }
+                                        teleport_within_zone(sender, spawn_pos, spawn_rot, characters_table_write_handle)
+                                    } else {
+                                        println!("Player {} outside zone tried to teleport to safety", sender);
+                                        Err(ProcessPacketError::CorruptedPacket)
+                                    }
+                                },
+                            })
+                        } else {
+                            println!("Unknown player {} tried to teleport to safety", sender);
+                            Err(ProcessPacketError::CorruptedPacket)
                         }
                     })?;
                     broadcasts.append(&mut packets);

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -284,7 +284,7 @@ impl GameServer {
                         unknown1: true,
                         inner: make_test_npc(),
                     };
-                    packets.push(GamePacket::serialize(&npc)?);
+                    //packets.push(GamePacket::serialize(&npc)?);
 
                     let mut character_packets = self.lock_enforcer().read_characters(|characters_table_read_handle| {
                         let possible_index = characters_table_read_handle.index(player_guid(sender));

--- a/src/game_server/player_update_packet.rs
+++ b/src/game_server/player_update_packet.rs
@@ -640,7 +640,7 @@ pub fn make_test_npc() -> AddNpc {
         unknown6: 1,
         scale: 1.0,
         pos: Pos {
-            x: 387.3,
+            x: 887.3,
             y: 171.93376,
             z: 1546.956,
             w: 1.0,

--- a/src/game_server/player_update_packet.rs
+++ b/src/game_server/player_update_packet.rs
@@ -640,7 +640,7 @@ pub fn make_test_npc() -> AddNpc {
         unknown6: 1,
         scale: 1.0,
         pos: Pos {
-            x: 887.3,
+            x: 387.3,
             y: 171.93376,
             z: 1546.956,
             w: 1.0,

--- a/src/game_server/update_position.rs
+++ b/src/game_server/update_position.rs
@@ -2,7 +2,7 @@ use packet_serialize::{DeserializePacket, SerializePacket};
 
 use crate::game_server::game_packet::{GamePacket, OpCode};
 
-#[derive(SerializePacket, DeserializePacket)]
+#[derive(Clone, SerializePacket, DeserializePacket)]
 pub struct UpdatePlayerPosition {
     pub guid: u64,
     pub pos_x: f32,

--- a/src/game_server/zone.rs
+++ b/src/game_server/zone.rs
@@ -642,19 +642,17 @@ impl Zone {
 
     fn nearby_chunks(center: Chunk) -> BTreeSet<Chunk> {
         let (center_x, center_z) = center;
-        BTreeSet::from_iter(
-            vec![
-                (center_x.saturating_sub(1), center_z.saturating_sub(1)),
-                (center_x.saturating_sub(1), center_z),
-                (center_x.saturating_sub(1), center_z.saturating_add(1)),
-                (center_x, center_z.saturating_sub(1)),
-                (center_x, center_z),
-                (center_x, center_z.saturating_add(1)),
-                (center_x.saturating_add(1), center_z.saturating_sub(1)),
-                (center_x.saturating_add(1), center_z),
-                (center_x.saturating_add(1), center_z.saturating_add(1)),
-            ],
-        )
+        BTreeSet::from_iter(vec![
+            (center_x.saturating_sub(1), center_z.saturating_sub(1)),
+            (center_x.saturating_sub(1), center_z),
+            (center_x.saturating_sub(1), center_z.saturating_add(1)),
+            (center_x, center_z.saturating_sub(1)),
+            (center_x, center_z),
+            (center_x, center_z.saturating_add(1)),
+            (center_x.saturating_add(1), center_z.saturating_sub(1)),
+            (center_x.saturating_add(1), center_z),
+            (center_x.saturating_add(1), center_z.saturating_add(1)),
+        ])
     }
 
     pub fn diff_character_guids(


### PR DESCRIPTION
Implement character chunking. This implementation uses a chunk size of ~200 units, the range at which NPCs start to become small. NPCs within a 3x3 chunk range, centered on the player's current chunk, are visible so that NPCs no closer than 200 units appear/disappear abruptly.

![image](https://github.com/soir20/oxide/assets/71418127/61c85707-91cb-4a9e-8ca8-c2561804a3e6)

Character chunks are used as part of the index for the character `GuidTable`. This means that any position update to a character needs to account for removing and re-inserting the character to update the index if their chunk changes.