### PR TITLE
Fix session overwrite race condition

### DIFF
--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -419,13 +419,14 @@ impl Channel {
         buffer_size: BufferSize,
         app_protocol: &ApplicationProtocol,
     ) {
-        let session = self.session.get_or_insert_with(|| Session {
+        // TODO: disallow session overwrite
+        let session = Session {
             session_id,
             crc_length: 3,
             crc_seed: random::<CrcSeed>(),
             allow_compression: true,
             use_encryption: false,
-        });
+        };
 
         self.buffer_size = buffer_size;
         self.send_queue
@@ -438,6 +439,7 @@ impl Channel {
                 512,
                 3,
             )));
+        self.session = Some(session);
     }
 
     fn process_heartbeat(&mut self) {

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -419,14 +419,13 @@ impl Channel {
         buffer_size: BufferSize,
         app_protocol: &ApplicationProtocol,
     ) {
-        // TODO: disallow session overwrite
-        let session = Session {
+        let session = self.session.get_or_insert_with(|| Session {
             session_id,
             crc_length: 3,
             crc_seed: random::<CrcSeed>(),
             allow_compression: true,
             use_encryption: false,
-        };
+        });
 
         self.buffer_size = buffer_size;
         self.send_queue
@@ -439,7 +438,6 @@ impl Channel {
                 512,
                 3,
             )));
-        self.session = Some(session);
     }
 
     fn process_heartbeat(&mut self) {


### PR DESCRIPTION
There is currently a race condition when the client sends two session requests in quick succession. The client will use the CRC seed generated from its first session request, but the server will use the second CRC seed generated, leading to `MismatchedHash` deserialization errors that prevent the client from connecting. This PR uses the first session generated rather than the new one.

This does not introduce a security vulnerability because if say, someone was spoofing UDP packets to impersonate a player and sent a session request, the session reply still gets sent back to the player and not the attacker. The attacker doesn't receive information about the current session. If anything, this prevents an attacker from logging the player out by spoofing packets to overwrite their session.

Note that "session" does not refer to an authenticated session. This is referring to the protocol session and not the game server session.

There will be a separate PR at some point to implement proper disconnect handling to clear sessions.