### PR TITLE
Add support for equip saber packet

### DIFF
--- a/src/game_server/handlers/inventory.rs
+++ b/src/game_server/handlers/inventory.rs
@@ -62,7 +62,7 @@ pub fn process_inventory_packet(
                     }
                 })
             }
-            InventoryOpCode::EquipGuid => {
+            InventoryOpCode::EquipGuid | InventoryOpCode::EquipSaber => {
                 let equip_guid: EquipGuid = DeserializePacket::deserialize(cursor)?;
                 game_server.lock_enforcer().read_characters(|_| CharacterLockRequest {
                     read_guids: vec![],

--- a/src/game_server/packets/inventory.rs
+++ b/src/game_server/packets/inventory.rs
@@ -9,6 +9,7 @@ use super::{item::EquipmentSlot, OpCode};
 pub enum InventoryOpCode {
     UnequipSlot = 0x2,
     EquipGuid = 0x3,
+    EquipSaber = 0xd,
 }
 
 impl SerializePacket for InventoryOpCode {


### PR DESCRIPTION
Support equip saber packet, which is essentially a duplicate of the regular equip packet.