### PR TITLE
Add item class definitions

### DIFF
--- a/config/item_classes.json
+++ b/config/item_classes.json
@@ -1,10 +1,118 @@
 [
     {
-        "comment": "Single Saber",
+        "comment": "Standard Reverse Single Saber",
+        "guid": 7,
+        "name_id": 0,
+        "icon_set_id": 0,
+        "wield_type": "ReverseSingleSaber",
+        "stat_id": 0,
+        "battle_class_name_id": 0
+    },
+    {
+        "comment": "Standard Staff Saber",
+        "guid": 8,
+        "name_id": 0,
+        "icon_set_id": 0,
+        "wield_type": "StaffSaber",
+        "stat_id": 0,
+        "battle_class_name_id": 0
+    },
+    {
+        "comment": "Standard Single Pistol",
+        "guid": 9,
+        "name_id": 0,
+        "icon_set_id": 0,
+        "wield_type": "SinglePistol",
+        "stat_id": 0,
+        "battle_class_name_id": 0
+    },
+    {
+        "comment": "Standard Single Saber",
         "guid": 10,
         "name_id": 0,
         "icon_set_id": 0,
         "wield_type": "SingleSaber",
+        "stat_id": 0,
+        "battle_class_name_id": 0
+    },
+    {
+        "comment": "Standard Rifle",
+        "guid": 10000,
+        "name_id": 0,
+        "icon_set_id": 0,
+        "wield_type": "Rifle",
+        "stat_id": 0,
+        "battle_class_name_id": 0
+    },
+    {
+        "comment": "Standard Sniper Rifle",
+        "guid": 10001,
+        "name_id": 0,
+        "icon_set_id": 0,
+        "wield_type": "SniperRifle",
+        "stat_id": 0,
+        "battle_class_name_id": 0
+    },
+    {
+        "comment": "Standard Rocket Launcher",
+        "guid": 10002,
+        "name_id": 0,
+        "icon_set_id": 0,
+        "wield_type": "RocketLauncher",
+        "stat_id": 0,
+        "battle_class_name_id": 0
+    },
+    {
+        "comment": "Standard Flame Thrower",
+        "guid": 10003,
+        "name_id": 0,
+        "icon_set_id": 0,
+        "wield_type": "FlameThrower",
+        "stat_id": 0,
+        "battle_class_name_id": 0
+    },
+    {
+        "comment": "Standard Staff",
+        "guid": 10004,
+        "name_id": 0,
+        "icon_set_id": 0,
+        "wield_type": "Staff",
+        "stat_id": 0,
+        "battle_class_name_id": 0
+    },
+    {
+        "comment": "Standard Misc",
+        "guid": 10005,
+        "name_id": 0,
+        "icon_set_id": 0,
+        "wield_type": "Misc",
+        "stat_id": 0,
+        "battle_class_name_id": 0
+    },
+    {
+        "comment": "Standard Bow",
+        "guid": 10006,
+        "name_id": 0,
+        "icon_set_id": 0,
+        "wield_type": "Bow",
+        "stat_id": 0,
+        "battle_class_name_id": 0
+    },
+    {
+        "comment": "Standard Sparklers",
+        "guid": 10007,
+        "name_id": 0,
+        "icon_set_id": 0,
+        "wield_type": "Sparklers",
+        "stat_id": 0,
+        "battle_class_name_id": 0
+    },
+    {
+        "comment": "Standard Heavy Cannon",
+        "guid": 10008,
+        "name_id": 0,
+        "icon_set_id": 0,
+        "wield_type": "HeavyCannon",
         "stat_id": 0,
         "battle_class_name_id": 0
     }

--- a/config/items.json
+++ b/config/items.json
@@ -8,7 +8,7 @@
         "tint": 0,
         "unknown7": 0,
         "cost": 0,
-        "item_class": 1,
+        "item_class": 9,
         "required_battle_class": 0,
         "slot": "PrimaryWeapon",
         "disable_trade": false,

--- a/src/game_server/packets/item.rs
+++ b/src/game_server/packets/item.rs
@@ -72,7 +72,7 @@ pub enum WieldType {
     Misc = 12,
     Bow = 13,
     Sparklers = 14,
-    HipBraceLauncherOneShot = 15,
+    HeavyCannon = 15,
 }
 
 impl SerializePacket for WieldType {


### PR DESCRIPTION
Add all standard item class definitions. Rename the heavy cannon wield type for better clarity.

Item classes that do not require special IDs have IDs that are >10,000 to avoid accidental conflicts with special IDs.