### PR TITLE
Fix wield type updates when customizing sabers

### DIFF
--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -151,6 +151,7 @@ impl NpcTemplate {
             auto_interact_radius: self.auto_interact_radius,
             instance_guid,
             wield_type: (self.wield_type, self.wield_type.holster()),
+            holstered: false,
         }
     }
 }
@@ -171,6 +172,7 @@ pub struct Character {
     pub auto_interact_radius: f32,
     pub instance_guid: u64,
     wield_type: (WieldType, WieldType),
+    holstered: bool,
 }
 
 impl IndexedGuid<u64, CharacterIndex> for Character {
@@ -222,6 +224,7 @@ impl Character {
             auto_interact_radius,
             instance_guid,
             wield_type: (wield_type, wield_type.holster()),
+            holstered: false,
         }
     }
 
@@ -268,6 +271,7 @@ impl Character {
             auto_interact_radius: 0.0,
             instance_guid,
             wield_type: (wield_type, wield_type.holster()),
+            holstered: false,
         }
     }
 
@@ -379,13 +383,23 @@ impl Character {
         self.wield_type.0
     }
 
+    pub fn brandished_wield_type(&self) -> WieldType {
+        if self.holstered {
+            self.wield_type.1
+        } else {
+            self.wield_type.0
+        }
+    }
+
     pub fn set_brandished_wield_type(&mut self, wield_type: WieldType) {
-        self.wield_type = (wield_type, wield_type.holster())
+        self.wield_type = (wield_type, wield_type.holster());
+        self.holstered = false;
     }
 
     pub fn brandish_or_holster(&mut self) {
         let (old_wield_type, new_wield_type) = self.wield_type;
         self.wield_type = (new_wield_type, old_wield_type);
+        self.holstered = !self.holstered;
     }
 
     fn door_packet(character: &Character, door: &Door) -> AddNpc {

--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -379,7 +379,7 @@ impl Character {
         self.wield_type.0
     }
 
-    pub fn set_wield_type(&mut self, wield_type: WieldType) {
+    pub fn set_brandished_wield_type(&mut self, wield_type: WieldType) {
         self.wield_type = (wield_type, wield_type.holster())
     }
 

--- a/src/game_server/handlers/inventory.rs
+++ b/src/game_server/handlers/inventory.rs
@@ -61,13 +61,13 @@ pub fn process_inventory_packet(
                     character_consumer: |_, _, mut characters_write, _| {
                         if let Some(character_write_handle) = characters_write.get_mut(&player_guid(sender)) {
 
-                            let mut updated_wield_type = None;
-                            let packets = if let CharacterType::Player(ref mut player_data) = character_write_handle.character_type {
+                            let mut brandished_wield_type = None;
+                            let mut result = if let CharacterType::Player(ref mut player_data) = character_write_handle.character_type {
                                 let possible_battle_class = player_data.battle_classes.get_mut(&unequip_slot.battle_class);
 
                                 if let Some(battle_class) = possible_battle_class {
 
-                                    let mut packets = vec![
+                                    let packets = vec![
                                         GamePacket::serialize(&TunneledPacket {
                                             unknown1: true,
                                             inner: UnequipItem {
@@ -80,16 +80,7 @@ pub fn process_inventory_packet(
                                     battle_class.items.remove(&unequip_slot.slot);
 
                                     if unequip_slot.slot.is_weapon() {
-                                        let wield_type = wield_type_from_slot(&battle_class.items, EquipmentSlot::PrimaryWeapon, game_server);
-                                        updated_wield_type = Some(wield_type);
-
-                                        packets.push(GamePacket::serialize(&TunneledPacket {
-                                            unknown1: true,
-                                            inner: UpdateWieldType {
-                                                guid: player_guid(sender),
-                                                wield_type,
-                                            }
-                                        })?);
+                                        brandished_wield_type = Some(wield_type_from_slot(&battle_class.items, EquipmentSlot::PrimaryWeapon, game_server));
                                     }
 
                                     Ok(vec![Broadcast::Single(sender, packets)])
@@ -103,10 +94,22 @@ pub fn process_inventory_packet(
                                 Err(ProcessPacketError::CorruptedPacket)
                             };
 
-                            if let Some(wield_type) = updated_wield_type {
+                            if let Some(wield_type) = brandished_wield_type {
                                 character_write_handle.set_brandished_wield_type(wield_type);
+
+                                if let Ok(broadcasts) = &mut result {
+                                    broadcasts.push(Broadcast::Single(sender, vec![
+                                        GamePacket::serialize(&TunneledPacket {
+                                            unknown1: true,
+                                            inner: UpdateWieldType {
+                                                guid: player_guid(sender),
+                                                wield_type,
+                                            }
+                                        })?,
+                                    ]));
+                                }
                             }
-                            packets
+                            result
 
                         } else {
                             println!("Unknown player {} tried to unequip slot", sender);
@@ -349,8 +352,15 @@ fn equip_item_in_slot(
     tint_override: Option<u32>,
 ) -> Result<(Vec<Broadcast>, u32), ProcessPacketError> {
     if let Some(character_write_handle) = characters_write.get_mut(&player_guid(sender)) {
-        let mut updated_wield_type = None;
-        let broadcasts = if let CharacterType::Player(ref mut player_data) =
+        // Always brandish a saber when any saber component changes. If we're equipping a new saber, the
+        // wield type will be updated appropriately later.
+        let mut brandished_wield_type = if equip_guid.slot.is_saber() {
+            Some(character_write_handle.brandished_wield_type())
+        } else {
+            None
+        };
+
+        let mut result = if let CharacterType::Player(ref mut player_data) =
             character_write_handle.character_type
         {
             if player_data.inventory.contains(&equip_guid.item_guid) {
@@ -439,15 +449,7 @@ fn equip_item_in_slot(
                                     ) => WieldType::DualPistol,
                                     _ => item_class.wield_type,
                                 };
-                                updated_wield_type = Some(wield_type);
-
-                                packets.push(GamePacket::serialize(&TunneledPacket {
-                                    unknown1: true,
-                                    inner: UpdateWieldType {
-                                        guid: player_guid(sender),
-                                        wield_type,
-                                    },
-                                })?);
+                                brandished_wield_type = Some(wield_type);
                             }
                         }
 
@@ -487,10 +489,24 @@ fn equip_item_in_slot(
             Err(ProcessPacketError::CorruptedPacket)
         };
 
-        if let Some(wield_type) = updated_wield_type {
+        if let Some(wield_type) = brandished_wield_type {
             character_write_handle.set_brandished_wield_type(wield_type);
+
+            if let Ok((broadcasts, _)) = &mut result {
+                broadcasts.push(Broadcast::Single(
+                    sender,
+                    vec![GamePacket::serialize(&TunneledPacket {
+                        unknown1: true,
+                        inner: UpdateWieldType {
+                            guid: player_guid(sender),
+                            wield_type,
+                        },
+                    })?],
+                ))
+            }
         }
-        broadcasts
+
+        result
     } else {
         println!("Unknown player {} tried to equip item", sender);
         Err(ProcessPacketError::CorruptedPacket)

--- a/src/game_server/handlers/inventory.rs
+++ b/src/game_server/handlers/inventory.rs
@@ -77,13 +77,10 @@ pub fn process_inventory_packet(
                                         })?
                                     ];
 
+                                    battle_class.items.remove(&unequip_slot.slot);
+
                                     if unequip_slot.slot.is_weapon() {
-                                        let is_primary_equipped = battle_class.items.contains_key(&EquipmentSlot::PrimaryWeapon);
-                                        wield_type =  match (unequip_slot.slot, wield_type_from_slot(&battle_class.items, unequip_slot.slot, game_server), is_primary_equipped) {
-                                            (EquipmentSlot::SecondaryWeapon, WieldType::SingleSaber, true) => WieldType::SingleSaber,
-                                            (EquipmentSlot::SecondaryWeapon, WieldType::SinglePistol, true) => WieldType::SinglePistol,
-                                            _ => WieldType::None,
-                                        };
+                                        wield_type = wield_type_from_slot(&battle_class.items, EquipmentSlot::PrimaryWeapon, game_server);
 
                                         packets.push(GamePacket::serialize(&TunneledPacket {
                                             unknown1: true,
@@ -93,8 +90,6 @@ pub fn process_inventory_packet(
                                             }
                                         })?);
                                     }
-
-                                    battle_class.items.remove(&unequip_slot.slot);
 
                                     Ok(vec![Broadcast::Single(sender, packets)])
                                 } else {


### PR DESCRIPTION
* Ensure only the *brandished* wield type is set. The current implementation can accidentally lead to setting the wield type to `None` if a saber is holstered and you equip a non-weapon, because `wield_type()` returns `None`.
* Fix a bug in the unequip handler that would holster sabers when entering saber customization.
* Brandish the saber when changing *any* saber component, not just the hilt.