### PR TITLE
Ignore spammy camera update packet

### DIFF
--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -441,6 +441,9 @@ impl GameServer {
                     // TODO: broadcast pos update to all players
                     broadcasts.append(&mut Zone::move_character(sender, pos_update, self)?);
                 }
+                OpCode::UpdatePlayerCamera => {
+                    // Ignore this unused packet to reduce log spam for now
+                }
                 OpCode::ZoneTeleportRequest => {
                     let teleport_request: ZoneTeleportRequest =
                         DeserializePacket::deserialize(&mut cursor)?;

--- a/src/game_server/packets/mod.rs
+++ b/src/game_server/packets/mod.rs
@@ -52,6 +52,7 @@ pub enum OpCode {
     WelcomeScreen = 0x5d,
     TeleportToSafety = 0x7a,
     UpdatePlayerPosition = 0x7d,
+    UpdatePlayerCamera = 0x7e,
     Housing = 0x7f,
     ClientGameSettings = 0x8f,
     Portrait = 0x9b,


### PR DESCRIPTION
Ignore the currently-unused camera update packet to reduce log spam.