### PR TITLE
Fix bow wield type handling

### DIFF
--- a/config/item_classes.json
+++ b/config/item_classes.json
@@ -91,7 +91,7 @@
     },
     {
         "comment": "Standard Bow",
-        "guid": 10006,
+        "guid": 21,
         "name_id": 0,
         "icon_set_id": 0,
         "wield_type": "Bow",

--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -245,16 +245,17 @@ impl Character {
                     EquipmentSlot::PrimaryWeapon,
                     game_server,
                 );
-                match (
-                    primary_wield_type,
-                    battle_class
-                        .items
-                        .contains_key(&EquipmentSlot::SecondaryWeapon),
-                ) {
-                    (WieldType::SingleSaber, false) => WieldType::SingleSaber,
-                    (WieldType::SingleSaber, true) => WieldType::DualSaber,
-                    (WieldType::SinglePistol, false) => WieldType::SinglePistol,
-                    (WieldType::SinglePistol, true) => WieldType::DualPistol,
+                let secondary_wield_type = wield_type_from_slot(
+                    &battle_class.items,
+                    EquipmentSlot::SecondaryWeapon,
+                    game_server,
+                );
+                match (primary_wield_type, secondary_wield_type) {
+                    (WieldType::SingleSaber, WieldType::None) => WieldType::SingleSaber,
+                    (WieldType::SingleSaber, WieldType::SingleSaber) => WieldType::DualSaber,
+                    (WieldType::SinglePistol, WieldType::None) => WieldType::SinglePistol,
+                    (WieldType::SinglePistol, WieldType::SinglePistol) => WieldType::DualPistol,
+                    (WieldType::None, _) => secondary_wield_type,
                     _ => primary_wield_type,
                 }
             })


### PR DESCRIPTION
Fix the handling of wield types for bows, which should be equipped in the secondary weapon slot. Use the ID 21 for the item class, as the game has special handling for it.