### PR TITLE
Receive and process packets on multiple threads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 axum = "0.7.5"
 byteorder = "1.5.0"
 crc32fast = "1.4.2"
+crossbeam-channel = "0.5.13"
 evalexpr = "11.3.0"
 packet_serialize = { path = "src/packet_serialize" }
 miniz_oxide = "0.7.2"

--- a/config/server.json
+++ b/config/server.json
@@ -1,0 +1,12 @@
+{
+    "receive_threads": 1,
+    "process_threads": 4,
+    "max_sessions": 100,
+    "process_packets_per_cycle": 40,
+    "send_packets_per_cycle": 20,
+    "packet_recency_limit": 1000,
+    "default_millis_until_resend": 30,
+    "max_round_trip_entries": 30,
+    "desired_resend_pct": 5,
+    "max_millis_until_resend": 300
+}

--- a/src/channel_manager.rs
+++ b/src/channel_manager.rs
@@ -77,11 +77,12 @@ impl ChannelManager {
     ) -> ReceiveResult {
         if let Some(channel) = self.get_by_addr(addr) {
             let mut channel_handle = channel.lock();
+            let client_not_queued = !channel_handle.needs_processing();
 
             match channel_handle.receive(data) {
                 Ok(packets_received) => {
                     // If the last processing thread did not process all packets, the client is already queued
-                    if !channel_handle.needs_processing() && packets_received > 0 {
+                    if client_not_queued && packets_received > 0 {
                         client_enqueue
                             .send(*addr)
                             .expect("Tried to enqueue client after queue channel disconnected");

--- a/src/channel_manager.rs
+++ b/src/channel_manager.rs
@@ -92,11 +92,11 @@ impl ChannelManager {
     pub fn process_next(
         &self,
         client_enqueue: Sender<SocketAddr>,
-        addr: SocketAddr,
+        addr: &SocketAddr,
         count: u8,
-    ) -> (SocketAddr, Vec<Vec<u8>>) {
+    ) -> Vec<Vec<u8>> {
         let mut channel_handle = self
-            .get_by_addr(&addr)
+            .get_by_addr(addr)
             .expect("Tried to process data on non-existent channel")
             .lock();
 
@@ -105,11 +105,11 @@ impl ChannelManager {
         // Re-enqueue this address for another thread to pick up if there is still more processing to be done
         if channel_handle.queued_received_packets() > 0 {
             client_enqueue
-                .send(addr)
+                .send(*addr)
                 .expect("Tried to enqueue client after queue channel disconnected");
         }
 
-        (addr, processed_packets)
+        processed_packets
     }
 
     pub fn broadcast(&self, broadcasts: Vec<Broadcast>) -> Vec<u32> {

--- a/src/channel_manager.rs
+++ b/src/channel_manager.rs
@@ -1,6 +1,6 @@
 use crate::game_server::Broadcast;
 use crate::protocol::Channel;
-use crossbeam_channel::{Receiver, Sender};
+use crossbeam_channel::Sender;
 use parking_lot::Mutex;
 use std::collections::BTreeMap;
 use std::net::SocketAddr;

--- a/src/channel_manager.rs
+++ b/src/channel_manager.rs
@@ -92,12 +92,9 @@ impl ChannelManager {
     pub fn process_next(
         &self,
         client_enqueue: Sender<SocketAddr>,
-        client_dequeue: Receiver<SocketAddr>,
+        addr: SocketAddr,
         count: u8,
     ) -> (SocketAddr, Vec<Vec<u8>>) {
-        let addr = client_dequeue
-            .recv()
-            .expect("Tried to dequeue client after queue channel disconnected");
         let mut channel_handle = self
             .get_by_addr(&addr)
             .expect("Tried to process data on non-existent channel")

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
+use crossbeam_channel::{bounded, Receiver, Sender};
 use parking_lot::RwLock;
 use std::net::{SocketAddr, UdpSocket};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::thread;
-use std::time::Duration;
 use tokio::spawn;
 
 use crate::channel_manager::{ChannelManager, ReceiveResult};
@@ -35,33 +36,111 @@ async fn main() {
     let game_server = GameServer::new(config_dir).unwrap();
     let process_delta = 40u8;
     let send_delta = 20u8;
-    loop {
-        let mut buf = [0; 512];
-        if let Ok((len, src)) = socket.recv_from(&mut buf) {
-            //println!("Bytes received: {}", len);
-            let recv_data = &buf[0..len];
-            //println!("Bytes: {:x?}", recv_data);
+    let server_options = ServerOptions {
+        receive_threads: 1,
+        process_threads: 4,
+        max_sessions: 100,
+    };
 
+    let channel_manager_arc = Arc::new(channel_manager);
+    let socket_arc = Arc::new(socket);
+    let game_server_arc = Arc::new(game_server);
+    let (client_enqueue, client_dequeue) = bounded(server_options.max_sessions);
+    spawn_receive_threads(
+        server_options.receive_threads,
+        &channel_manager_arc,
+        &socket_arc,
+        client_enqueue.clone(),
+        200,
+        1000,
+        5,
+    );
+    spawn_process_threads(
+        server_options.process_threads,
+        &channel_manager_arc,
+        &socket_arc,
+        client_enqueue,
+        client_dequeue,
+        process_delta,
+        send_delta,
+        &game_server_arc,
+    );
+}
+
+struct ServerOptions {
+    pub receive_threads: u16,
+    pub process_threads: u16,
+    pub max_sessions: usize,
+}
+
+fn spawn_receive_threads(
+    threads: u16,
+    channel_manager: &Arc<RwLock<ChannelManager>>,
+    socket: &Arc<UdpSocket>,
+    client_enqueue: Sender<SocketAddr>,
+    initial_buffer_size: u32,
+    recency_limit: u16,
+    millis_until_resend: u128,
+) {
+    for _ in 0..threads {
+        let channel_manager = Arc::clone(channel_manager);
+        let socket = Arc::clone(socket);
+        let client_enqueue = client_enqueue.clone();
+
+        thread::spawn(move || loop {
+            let mut buf = [0; 512];
+            if let Ok((len, src)) = socket.recv_from(&mut buf) {
+                let recv_data = &buf[0..len];
+
+                let mut read_handle = channel_manager.read();
+
+                let receive_result = read_handle.receive(client_enqueue.clone(), &src, recv_data);
+                if receive_result == ReceiveResult::CreateChannelFirst {
+                    println!("Creating channel for {}", src);
+                    drop(read_handle);
+                    let previous_channel = channel_manager.write().insert(
+                        &src,
+                        Channel::new(initial_buffer_size, recency_limit, millis_until_resend),
+                    );
+                    read_handle = channel_manager.read();
+
+                    if previous_channel.is_some() {
+                        println!("Client {} reconnected, dropping old channel", src);
+                    }
+
+                    read_handle.receive(client_enqueue.clone(), &src, recv_data);
+                }
+            }
+        });
+    }
+}
+
+fn spawn_process_threads(
+    threads: u16,
+    channel_manager: &Arc<RwLock<ChannelManager>>,
+    socket: &Arc<UdpSocket>,
+    client_enqueue: Sender<SocketAddr>,
+    client_dequeue: Receiver<SocketAddr>,
+    process_delta: u8,
+    send_delta: u8,
+    game_server: &Arc<GameServer>,
+) {
+    for _ in 0..threads {
+        let channel_manager = Arc::clone(channel_manager);
+        let socket = Arc::clone(socket);
+        let game_server = Arc::clone(game_server);
+        let client_enqueue = client_enqueue.clone();
+        let client_dequeue = client_dequeue.clone();
+
+        thread::spawn(move || loop {
             let mut read_handle = channel_manager.read();
 
-            let receive_result = read_handle.receive(&src, recv_data);
-            if receive_result == ReceiveResult::CreateChannelFirst {
-                println!("Creating channel for {}", src);
-                drop(read_handle);
-                let previous_channel = channel_manager
-                    .write()
-                    .insert(&src, Channel::new(200, 1000, 5));
-                read_handle = channel_manager.read();
+            let (src, packets_for_game_server) = read_handle.process_next(
+                client_enqueue.clone(),
+                client_dequeue.clone(),
+                process_delta,
+            );
 
-                if previous_channel.is_some() {
-                    println!("Client {} reconnected, dropping old channel", src);
-                }
-
-                read_handle.receive(&src, recv_data);
-            }
-
-            //println!("Processing at most {} packets", process_delta);
-            let packets_for_game_server = read_handle.process_next(&src, process_delta);
             let mut broadcasts = Vec::new();
             for packet in packets_for_game_server {
                 if let Some(guid) = read_handle.guid(&src) {
@@ -85,14 +164,11 @@ async fn main() {
             read_handle.broadcast(broadcasts);
 
             let packets_to_send = read_handle.send_next(&src, send_delta);
-            //println!("Sending {} packets", packets_to_send.len());
             for buffer in packets_to_send {
-                //println!("Sending {} bytes: {:x?}", buffer.len(), buffer);
                 socket
                     .send_to(&buffer, src)
                     .expect("Unable to send packet to client");
             }
-        }
-        thread::sleep(Duration::from_millis(5));
+        });
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,13 +143,13 @@ fn spawn_process_threads(
             thread::spawn(move || loop {
                 // Don't lock the channel manager until we have packets to process
                 // to avoid deadlock with channel creation
-                let addr = client_dequeue
+                let src = client_dequeue
                     .recv()
                     .expect("Tried to dequeue client after queue channel disconnected");
 
                 let mut read_handle = channel_manager.read();
-                let (src, packets_for_game_server) =
-                    read_handle.process_next(client_enqueue.clone(), addr, process_delta);
+                let packets_for_game_server =
+                    read_handle.process_next(client_enqueue.clone(), &src, process_delta);
 
                 let mut broadcasts = Vec::new();
                 for packet in packets_for_game_server {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use crossbeam_channel::{bounded, Receiver, Sender};
 use parking_lot::RwLock;
+use protocol::BufferSize;
 use std::net::{SocketAddr, UdpSocket};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -51,7 +52,7 @@ async fn main() {
         &channel_manager_arc,
         &socket_arc,
         client_enqueue.clone(),
-        200,
+        MAX_BUFFER_SIZE,
         1000,
         5,
     );
@@ -71,6 +72,8 @@ async fn main() {
     }
 }
 
+const MAX_BUFFER_SIZE: BufferSize = 512;
+
 struct ServerOptions {
     pub receive_threads: u16,
     pub process_threads: u16,
@@ -82,7 +85,7 @@ fn spawn_receive_threads(
     channel_manager: &Arc<RwLock<ChannelManager>>,
     socket: &Arc<UdpSocket>,
     client_enqueue: Sender<SocketAddr>,
-    initial_buffer_size: u32,
+    initial_buffer_size: BufferSize,
     recency_limit: u16,
     millis_until_resend: u128,
 ) -> Vec<JoinHandle<()>> {
@@ -93,7 +96,7 @@ fn spawn_receive_threads(
             let client_enqueue = client_enqueue.clone();
 
             thread::spawn(move || loop {
-                let mut buf = [0; 512];
+                let mut buf = [0; MAX_BUFFER_SIZE as usize];
                 if let Ok((len, src)) = socket.recv_from(&mut buf) {
                     let recv_data = &buf[0..len];
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ async fn main() {
         process_packets_per_cycle: 40,
         send_packets_per_cycle: 20,
         packet_recency_limit: 1000,
+        default_millis_until_resend: 50,
     };
     spawn(http::start(
         4000,
@@ -54,7 +55,7 @@ async fn main() {
         client_enqueue.clone(),
         MAX_BUFFER_SIZE,
         server_options.packet_recency_limit,
-        50,
+        server_options.default_millis_until_resend,
     );
     threads.append(&mut spawn_process_threads(
         server_options.process_threads,
@@ -81,6 +82,7 @@ struct ServerOptions {
     pub process_packets_per_cycle: u8,
     pub send_packets_per_cycle: u8,
     pub packet_recency_limit: u16,
+    pub default_millis_until_resend: u128,
 }
 
 fn spawn_receive_threads(

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,10 +26,9 @@ async fn main() {
         process_packets_per_cycle: 40,
         send_packets_per_cycle: 20,
         packet_recency_limit: 1000,
-        default_millis_until_resend: 50,
-        max_round_trip_times: 30,
-        selected_round_trip_index: 27,
-        min_millis_until_resend: 20,
+        default_millis_until_resend: 30,
+        max_round_trip_entries: 30,
+        desired_resend_pct: 5,
         max_millis_until_resend: 300,
     };
     spawn(http::start(
@@ -87,9 +86,8 @@ struct ServerOptions {
     pub send_packets_per_cycle: u8,
     pub packet_recency_limit: u16,
     pub default_millis_until_resend: u128,
-    pub max_round_trip_times: usize,
-    pub selected_round_trip_index: usize,
-    pub min_millis_until_resend: u128,
+    pub max_round_trip_entries: usize,
+    pub desired_resend_pct: u8,
     pub max_millis_until_resend: u128,
 }
 
@@ -125,9 +123,8 @@ fn spawn_receive_threads(
                                 initial_buffer_size,
                                 server_options.packet_recency_limit,
                                 server_options.default_millis_until_resend,
-                                server_options.max_round_trip_times,
-                                server_options.selected_round_trip_index,
-                                server_options.min_millis_until_resend,
+                                server_options.max_round_trip_entries,
+                                server_options.desired_resend_pct,
                                 server_options.max_millis_until_resend,
                             ),
                         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ async fn main() {
         client_enqueue.clone(),
         MAX_BUFFER_SIZE,
         server_options.packet_recency_limit,
-        5,
+        50,
     );
     threads.append(&mut spawn_process_threads(
         server_options.process_threads,

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -541,8 +541,8 @@ impl Channel {
         if ready_to_update {
             self.last_round_trip_times.sort();
             self.millis_until_resend = self.last_round_trip_times[self.selected_round_trip_index]
-                .min(self.min_millis_until_resend)
-                .max(self.max_millis_until_resend);
+                .max(self.min_millis_until_resend)
+                .min(self.max_millis_until_resend);
         }
     }
 }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -243,7 +243,7 @@ impl Channel {
             buffer_size: initial_buffer_size,
             recency_limit,
             millis_until_resend,
-            last_round_trip_times: Vec::with_capacity(max_round_trip_times),
+            last_round_trip_times: vec![0; max_round_trip_times],
             next_round_trip_index: 0,
             selected_round_trip_index,
             min_millis_until_resend,

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -242,6 +242,10 @@ impl Channel {
         Ok(packet_count)
     }
 
+    pub fn queued_received_packets(&self) -> usize {
+        self.receive_queue.len()
+    }
+
     pub fn process_next(&mut self, count: u8) -> Vec<Vec<u8>> {
         let mut needs_new_ack = false;
         let mut packets_to_process = Vec::new();

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -246,6 +246,10 @@ impl Channel {
         self.receive_queue.len()
     }
 
+    pub fn queued_to_send_packets(&self) -> usize {
+        self.send_queue.len()
+    }
+
     pub fn process_next(&mut self, count: u8) -> Vec<Vec<u8>> {
         let mut needs_new_ack = false;
         let mut packets_to_process = Vec::new();

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -267,12 +267,8 @@ impl Channel {
         Ok(packet_count)
     }
 
-    pub fn queued_received_packets(&self) -> usize {
-        self.receive_queue.len()
-    }
-
-    pub fn queued_to_send_packets(&self) -> usize {
-        self.send_queue.len()
+    pub fn needs_processing(&self) -> bool {
+        self.receive_queue.len() > 0 || self.send_queue.len() > 0
     }
 
     pub fn process_next(&mut self, count: u8) -> Vec<Vec<u8>> {

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -268,7 +268,7 @@ impl Channel {
     }
 
     pub fn needs_processing(&self) -> bool {
-        self.receive_queue.len() > 0 || self.send_queue.len() > 0
+        !self.receive_queue.is_empty() || !self.send_queue.is_empty()
     }
 
     pub fn process_next(&mut self, count: u8) -> Vec<Vec<u8>> {

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, VecDeque};
+use std::net::SocketAddr;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use rand::random;
@@ -207,6 +208,7 @@ pub struct Session {
 }
 
 pub struct Channel {
+    pub addr: SocketAddr,
     session: Option<Session>,
     buffer_size: BufferSize,
     recency_limit: SequenceNumber,
@@ -226,6 +228,7 @@ pub struct Channel {
 
 impl Channel {
     pub fn new(
+        addr: SocketAddr,
         initial_buffer_size: BufferSize,
         recency_limit: SequenceNumber,
         millis_until_resend: u128,
@@ -238,6 +241,7 @@ impl Channel {
         }
 
         Channel {
+            addr,
             session: None,
             buffer_size: initial_buffer_size,
             recency_limit,

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -526,7 +526,7 @@ impl Channel {
         for packet in self.send_queue.iter() {
             if !packet.needs_send && packet.is_reliable() {
                 self.last_round_trip_times[self.next_round_trip_index] =
-                    PendingPacket::now() - packet.first_prepare_to_send;
+                    PendingPacket::now().saturating_sub(packet.first_prepare_to_send);
                 self.next_round_trip_index += 1;
 
                 if self.next_round_trip_index == self.last_round_trip_times.len() {


### PR DESCRIPTION
Allow multiple threads to receive and process/send packets. This implementation has two goals:
* ensure that packets for a particular client are always processed in order
* spread processing time fairly among all clients who need it

This is done by using a lock-free, multi-consumer, multi-producer channel (`crossbeam_channel`). Receiver threads enqueue client addresses unless the client is already queued. Processing threads dequeue client addresses, perform a prescribed amount of work, and then re-enqueue the client address if there is more processing to be done. A processing thread can also enqueue a different client address if it broadcasts a packet to that client.

Since the client addresses are processed in the order they enter the queue, this implementation tends to distribute processing time among all clients. Since each client is only queued once at a time, packets must be processed in order.

This PR also improves the packet resend mechanism so that you can set a desired approximate percentage of packets that should be resent; the fixed delay between processing cycles and resend timer have been removed. We cannot know for certain whether a packet has been lost or whether network latency has increased, so we always have to resend some percentage of packets. This approach makes the increase in load on the server because of resent packets fairly straightforward.

The resend timer is capped at 300ms. Without a cap, the resend timer tends to increase rapidly to multiple seconds as packets are repeatedly resent, making the situation worse. Based on [data](https://wondernetwork.com/pings/), a 300ms ping would be unusual, so we can reasonably assume that any packets not acked beyond that threshold have been lost.

I was able to still play with default settings and simulated 60% network packet loss locally, but naturally, this may change when more packets are being exchanged or with a worse network connection. It is possible to configure the server to resend packets more aggressively, but this puts more load on the server.