### PR TITLE
Handle disconnects: part one

### DIFF
--- a/config/server.json
+++ b/config/server.json
@@ -13,5 +13,6 @@
     "default_millis_until_resend": 30,
     "max_round_trip_entries": 30,
     "desired_resend_pct": 5,
-    "max_millis_until_resend": 300
+    "max_millis_until_resend": 300,
+    "channel_cleanup_period_millis": 1000
 }

--- a/src/channel_manager.rs
+++ b/src/channel_manager.rs
@@ -62,12 +62,12 @@ impl ChannelManager {
         }
     }
 
-    pub fn authenticate(&mut self, addr: &SocketAddr, guid: u32) {
+    pub fn authenticate(&mut self, addr: &SocketAddr, guid: u32) -> Option<Mutex<Channel>> {
         let channel = self
             .unauthenticated
             .remove(addr)
             .expect("Tried to authenticate non-existent or already-authenticated channel");
-        self.authenticated.insert(addr, guid, channel);
+        self.authenticated.insert(addr, guid, channel)
     }
 
     pub fn receive(

--- a/src/channel_manager.rs
+++ b/src/channel_manager.rs
@@ -12,7 +12,7 @@ pub enum ReceiveResult {
     CreateChannelFirst,
 }
 
-pub struct TooManyChannels(pub usize);
+pub struct TooManyChannels(pub usize, pub Channel);
 
 pub struct ChannelManager {
     unauthenticated: BTreeMap<SocketAddr, Mutex<Channel>>,
@@ -48,7 +48,6 @@ impl ChannelManager {
         addr: &SocketAddr,
         channel: Channel,
     ) -> Result<Option<Mutex<Channel>>, TooManyChannels> {
-        // We don't need to send a disconnect because the sender will interpret it as a disconnect for the new sessions
         let previous = self
             .unauthenticated
             .remove(addr)
@@ -58,7 +57,7 @@ impl ChannelManager {
             self.unauthenticated.insert(*addr, Mutex::new(channel));
             Ok(previous)
         } else {
-            Err(TooManyChannels(self.max_sessions))
+            Err(TooManyChannels(self.max_sessions, channel))
         }
     }
 

--- a/src/channel_manager.rs
+++ b/src/channel_manager.rs
@@ -52,7 +52,7 @@ impl ChannelManager {
         let previous = self
             .unauthenticated
             .remove(addr)
-            .or(self.authenticated.remove(addr));
+            .or(self.authenticated.remove(addr).map(|(_, channel)| channel));
 
         if self.len() < self.max_sessions {
             self.unauthenticated.insert(*addr, Mutex::new(channel));
@@ -161,6 +161,37 @@ impl ChannelManager {
     pub fn len(&self) -> usize {
         self.unauthenticated.len() + self.authenticated.len()
     }
+
+    pub fn drain_filter(
+        &mut self,
+        mut predicate: impl FnMut(&MutexGuard<Channel>) -> bool,
+    ) -> Vec<(Option<u32>, Mutex<Channel>)> {
+        let mut addrs_to_remove = Vec::new();
+        for (addr, channel) in self.unauthenticated.iter() {
+            let channel_handle = channel.lock();
+            if predicate(&channel_handle) {
+                addrs_to_remove.push(*addr);
+            }
+        }
+
+        let mut removed = Vec::new();
+        for addr in addrs_to_remove {
+            if let Some(result) = self.unauthenticated.remove(&addr) {
+                removed.push((None, result));
+            }
+        }
+
+        removed.append(
+            &mut self
+                .authenticated
+                .drain_filter(predicate)
+                .into_iter()
+                .map(|(guid, channel)| (Some(guid), channel))
+                .collect(),
+        );
+
+        removed
+    }
 }
 
 #[derive(Default)]
@@ -195,15 +226,45 @@ impl AuthenticatedChannelManager {
         self.channels.insert(guid, channel)
     }
 
-    pub fn remove(&mut self, addr: &SocketAddr) -> Option<Mutex<Channel>> {
+    pub fn remove(&mut self, addr: &SocketAddr) -> Option<(u32, Mutex<Channel>)> {
         self.socket_to_guid.remove(addr).map(|guid| {
-            self.channels
-                .remove(&guid)
-                .expect("Entry in socket to GUID mapping has no corresponding channel")
+            (
+                guid,
+                self.channels
+                    .remove(&guid)
+                    .expect("Entry in socket to GUID mapping has no corresponding channel"),
+            )
         })
     }
 
     pub fn len(&self) -> usize {
         self.channels.len()
+    }
+
+    pub fn drain_filter(
+        &mut self,
+        mut predicate: impl FnMut(&MutexGuard<Channel>) -> bool,
+    ) -> Vec<(u32, Mutex<Channel>)> {
+        let addrs_to_remove: Vec<SocketAddr> = self
+            .channels
+            .iter()
+            .filter_map(|(_, channel)| {
+                let channel_handle = channel.lock();
+                if predicate(&channel_handle) {
+                    Some(channel_handle.addr)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let mut removed = Vec::new();
+        for addr in addrs_to_remove {
+            if let Some(result) = self.remove(&addr) {
+                removed.push(result);
+            }
+        }
+
+        removed
     }
 }

--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -286,10 +286,10 @@ impl Character {
         )
     }
 
-    pub fn remove_packets(&self, guid: u64) -> Result<Vec<Vec<u8>>, ProcessPacketError> {
+    pub fn remove_packets(&self) -> Result<Vec<Vec<u8>>, ProcessPacketError> {
         let mut packets = vec![GamePacket::serialize(&TunneledPacket {
             unknown1: true,
-            inner: RemoveStandard { guid },
+            inner: RemoveStandard { guid: self.guid },
         })?];
 
         if let Some(mount_id) = self.mount_id {

--- a/src/game_server/handlers/housing.rs
+++ b/src/game_server/handlers/housing.rs
@@ -24,7 +24,7 @@ use crate::{
 
 use super::{
     character::{CurrentFixture, PreviousFixture},
-    guid::{GuidTableHandle, IndexedGuid},
+    guid::{GuidTableHandle, GuidTableIndexer, IndexedGuid},
     lock_enforcer::{CharacterLockRequest, ZoneLockRequest},
     unique_guid::{npc_guid, player_guid, zone_template_guid, FIXTURE_DISCRIMINANT},
     zone::{House, Zone},

--- a/src/game_server/handlers/lock_enforcer.rs
+++ b/src/game_server/handlers/lock_enforcer.rs
@@ -4,7 +4,9 @@ use parking_lot::{RwLockReadGuard, RwLockWriteGuard};
 
 use super::{
     character::{Character, CharacterIndex},
-    guid::{GuidTable, GuidTableHandle, GuidTableReadHandle, GuidTableWriteHandle},
+    guid::{
+        GuidTable, GuidTableHandle, GuidTableIndexer, GuidTableReadHandle, GuidTableWriteHandle,
+    },
     zone::Zone,
 };
 
@@ -12,20 +14,18 @@ pub struct TableReadHandleWrapper<'a, K, V, I = ()> {
     handle: GuidTableReadHandle<'a, K, V, I>,
 }
 
-impl<K: Copy + Ord, V, I: Copy + Ord> TableReadHandleWrapper<'_, K, V, I> {
-    pub fn contains(&self, guid: K) -> bool {
-        self.handle.get(guid).is_some()
-    }
-
-    pub fn index(&self, guid: K) -> Option<I> {
+impl<'a, K: Copy + Ord, V, I: Copy + Ord> GuidTableIndexer<'a, K, V, I>
+    for TableReadHandleWrapper<'a, K, V, I>
+{
+    fn index(&self, guid: K) -> Option<I> {
         self.handle.index(guid)
     }
 
-    pub fn keys(&self) -> impl Iterator<Item = K> + '_ {
+    fn keys(&'a self) -> impl Iterator<Item = K> + '_ {
         self.handle.keys()
     }
 
-    pub fn keys_by_index(&self, index: I) -> impl Iterator<Item = K> + '_ {
+    fn keys_by_index(&'a self, index: I) -> impl Iterator<Item = K> + '_ {
         self.handle.keys_by_index(index)
     }
 }

--- a/src/game_server/handlers/lock_enforcer.rs
+++ b/src/game_server/handlers/lock_enforcer.rs
@@ -21,11 +21,11 @@ impl<'a, K: Copy + Ord, V, I: Copy + Ord> GuidTableIndexer<'a, K, V, I>
         self.handle.index(guid)
     }
 
-    fn keys(&'a self) -> impl Iterator<Item = K> + '_ {
+    fn keys(&'a self) -> impl Iterator<Item = K> {
         self.handle.keys()
     }
 
-    fn keys_by_index(&'a self, index: I) -> impl Iterator<Item = K> + '_ {
+    fn keys_by_index(&'a self, index: I) -> impl Iterator<Item = K> {
         self.handle.keys_by_index(index)
     }
 }

--- a/src/game_server/handlers/zone.rs
+++ b/src/game_server/handlers/zone.rs
@@ -371,7 +371,7 @@ impl Zone {
                 if *add {
                     packets.append(&mut character.add_packets(mount_configs)?);
                 } else {
-                    packets.append(&mut character.remove_packets(*guid)?);
+                    packets.append(&mut character.remove_packets()?);
                 }
             }
         }

--- a/src/game_server/handlers/zone.rs
+++ b/src/game_server/handlers/zone.rs
@@ -29,11 +29,11 @@ use super::{
         Character, CharacterCategory, CharacterIndex, CharacterType, Chunk, Door, NpcTemplate,
         PreviousFixture, Transport,
     },
-    guid::{Guid, GuidTable, GuidTableWriteHandle, IndexedGuid},
+    guid::{Guid, GuidTable, GuidTableIndexer, GuidTableWriteHandle, IndexedGuid},
     housing::prepare_init_house_packets,
     lock_enforcer::{
-        CharacterLockRequest, CharacterReadGuard, CharacterTableReadHandle,
-        CharacterTableWriteHandle, CharacterWriteGuard, ZoneLockRequest,
+        CharacterLockRequest, CharacterReadGuard, CharacterTableWriteHandle, CharacterWriteGuard,
+        ZoneLockRequest,
     },
     mount::MountConfig,
     unique_guid::{
@@ -286,16 +286,16 @@ impl Zone {
         ])
     }
 
-    pub fn other_players_nearby(
+    pub fn other_players_nearby<'a>(
         sender: u32,
         chunk: Chunk,
         instance_guid: u64,
-        characters_table_read_handle: &CharacterTableReadHandle,
+        characters_table_handle: &'a impl GuidTableIndexer<'a, u64, Character, CharacterIndex>,
     ) -> Result<Vec<u32>, ProcessPacketError> {
         let mut guids = Vec::new();
 
         for chunk in Zone::nearby_chunks(chunk) {
-            for guid in characters_table_read_handle.keys_by_index((
+            for guid in characters_table_handle.keys_by_index((
                 instance_guid,
                 chunk,
                 CharacterCategory::Player,
@@ -309,23 +309,23 @@ impl Zone {
         Ok(guids)
     }
 
-    pub fn all_players_nearby(
+    pub fn all_players_nearby<'a>(
         sender: u32,
         chunk: Chunk,
         instance_guid: u64,
-        characters_table_read_handle: &CharacterTableReadHandle,
+        characters_table_handle: &'a impl GuidTableIndexer<'a, u64, Character, CharacterIndex>,
     ) -> Result<Vec<u32>, ProcessPacketError> {
         let mut guids =
-            Zone::other_players_nearby(sender, chunk, instance_guid, characters_table_read_handle)?;
+            Zone::other_players_nearby(sender, chunk, instance_guid, characters_table_handle)?;
         guids.push(sender);
         Ok(guids)
     }
 
-    pub fn diff_character_guids(
+    pub fn diff_character_guids<'a>(
         instance_guid: u64,
         old_chunk: Chunk,
         new_chunk: Chunk,
-        characters_table_read_handle: &CharacterTableReadHandle,
+        characters_table_handle: &'a impl GuidTableIndexer<'a, u64, Character, CharacterIndex>,
         requester_guid: u32,
     ) -> BTreeMap<u64, bool> {
         let old_chunks = Zone::nearby_chunks(old_chunk);
@@ -337,7 +337,7 @@ impl Zone {
         for category in CharacterCategory::iter() {
             for chunk in chunks_to_remove.iter() {
                 for guid in
-                    characters_table_read_handle.keys_by_index((instance_guid, **chunk, category))
+                    characters_table_handle.keys_by_index((instance_guid, **chunk, category))
                 {
                     guids.insert(guid, false);
                 }
@@ -347,7 +347,7 @@ impl Zone {
         for category in CharacterCategory::iter() {
             for chunk in chunks_to_add.iter() {
                 for guid in
-                    characters_table_read_handle.keys_by_index((instance_guid, **chunk, category))
+                    characters_table_handle.keys_by_index((instance_guid, **chunk, category))
                 {
                     guids.insert(guid, true);
                 }

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -635,7 +635,9 @@ impl GameServer {
                         }
                     })?;
                 }
-                OpCode::Logout => broadcasts.append(&mut self.logout(sender)?),
+                OpCode::Logout => {
+                    // Allow the cleanup thread to log the player out on disconnect
+                }
                 _ => println!("Unimplemented: {:?}, {:x?}", op_code, data),
             },
             Err(_) => println!("Unknown op code: {}, {:x?}", raw_op_code, data),

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -116,7 +116,7 @@ impl GameServer {
         })
     }
 
-    pub fn login(&self, data: Vec<u8>) -> Result<(u32, Vec<Broadcast>), ProcessPacketError> {
+    pub fn log_in(&self, data: Vec<u8>) -> Result<(u32, Vec<Broadcast>), ProcessPacketError> {
         let mut cursor = Cursor::new(&data[..]);
         let raw_op_code = cursor.read_u16::<LittleEndian>()?;
 
@@ -228,7 +228,7 @@ impl GameServer {
         }
     }
 
-    pub fn logout(&self, sender: u32) -> Result<Vec<Broadcast>, ProcessPacketError> {
+    pub fn log_out(&self, sender: u32) -> Result<Vec<Broadcast>, ProcessPacketError> {
         self.lock_enforcer()
             .write_characters(|characters_table_write_handle, _| {
                 if let Some((character, (instance_guid, chunk, _))) =

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -241,7 +241,7 @@ impl GameServer {
                         characters_table_write_handle,
                     )?;
 
-                    let remove_packets = character.read().remove_packets(player_guid(sender))?;
+                    let remove_packets = character.read().remove_packets()?;
 
                     Ok(vec![Broadcast::Multi(other_players_nearby, remove_packets)])
                 } else {

--- a/src/game_server/packets/login.rs
+++ b/src/game_server/packets/login.rs
@@ -7,6 +7,13 @@ use packet_serialize::{
 
 use super::{GamePacket, OpCode, Pos};
 
+#[derive(DeserializePacket)]
+pub struct LoginRequest {
+    pub ticket: String,
+    pub guid: u64,
+    pub version: String,
+}
+
 #[derive(SerializePacket, DeserializePacket)]
 pub struct LoginReply {
     pub logged_in: bool,

--- a/src/game_server/packets/login.rs
+++ b/src/game_server/packets/login.rs
@@ -87,6 +87,15 @@ impl GamePacket for ZoneDetailsDone {
 }
 
 #[derive(SerializePacket, DeserializePacket)]
+pub struct Logout {}
+
+impl GamePacket for Logout {
+    type Header = OpCode;
+
+    const HEADER: Self::Header = OpCode::Logout;
+}
+
+#[derive(SerializePacket, DeserializePacket)]
 pub struct ClientBeginZoning {
     pub zone_name: String,
     pub zone_type: u32,

--- a/src/game_server/packets/mod.rs
+++ b/src/game_server/packets/mod.rs
@@ -34,6 +34,7 @@ pub enum OpCode {
     ClientIsReady = 0xd,
     ZoneDetailsDone = 0xe,
     Chat = 0xf,
+    Logout = 0x10,
     Command = 0x1a,
     ClientBeginZoning = 0x1f,
     Combat = 0x20,

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
-use std::u8;
 use tokio::spawn;
 
 use crate::channel_manager::{ChannelManager, ReceiveResult};

--- a/src/main.rs
+++ b/src/main.rs
@@ -234,9 +234,7 @@ fn spawn_process_threads(
 
                 let packets_to_send = channel_manager_read_handle
                     .send_next(&mut channel_handle, server_options.send_packets_per_cycle);
-                packets_to_send
-                    .into_iter()
-                    .for_each(|packet| send_packet(&packet, &src, &socket));
+                send_packets(&packets_to_send, &src, &socket);
 
                 let packets_for_game_server = channel_manager_read_handle.process_next(
                     &mut channel_handle,

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,6 +258,7 @@ fn spawn_process_threads(
                                 if let Some(existing_channel) =
                                     channel_manager.write().authenticate(&src, guid)
                                 {
+                                    println!("Client {} logged in as an already logged-in player {}, disconnecting existing client", src, guid);
                                     broadcasts.append(&mut log_out_and_disconnect(
                                         DisconnectReason::NewConnectionAttempt,
                                         guid,

--- a/src/main.rs
+++ b/src/main.rs
@@ -379,7 +379,7 @@ fn disconnect(
             );
         }
     });
-    channel_handle.process_next(u8::MAX, server_options);
+    channel_handle.process_all(server_options);
 
     match channel_handle.disconnect(disconnect_reason) {
         Ok(disconnect_packets) => send_packets(&disconnect_packets, &channel_handle.addr, socket),

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, VecDeque};
 use std::net::SocketAddr;
 use std::time::{SystemTime, UNIX_EPOCH};
+use std::u8;
 
 use rand::random;
 
@@ -356,6 +357,16 @@ impl Channel {
                     println!("Bad bundled packet");
                 }
             }
+        }
+
+        packets
+    }
+
+    pub fn process_all(&mut self, server_options: &ServerOptions) -> Vec<Vec<u8>> {
+        let mut packets = Vec::new();
+
+        while !self.receive_queue.is_empty() {
+            packets.append(&mut self.process_next(u8::MAX, server_options));
         }
 
         packets

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,7 +1,6 @@
 use std::collections::{BTreeMap, VecDeque};
 use std::net::SocketAddr;
 use std::time::{SystemTime, UNIX_EPOCH};
-use std::u8;
 
 use rand::random;
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -429,17 +429,15 @@ impl Channel {
         self.send_queue.clear();
         self.connected = false;
 
-        let session_id = self
-            .session
-            .as_ref()
-            .map(|session| session.session_id)
-            .unwrap_or(0);
-
-        serialize_packets(
-            &[&Packet::Disconnect(session_id, disconnect_reason)],
-            self.buffer_size,
-            &self.session,
-        )
+        if let Some(session) = &self.session {
+            serialize_packets(
+                &[&Packet::Disconnect(session.session_id, disconnect_reason)],
+                self.buffer_size,
+                &self.session,
+            )
+        } else {
+            Ok(Vec::new())
+        }
     }
 
     pub fn disconnect_if_same_session(

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -425,6 +425,10 @@ impl Channel {
         serialize_packets(&packets_to_send, self.buffer_size, &self.session)
     }
 
+    pub fn connected(&self) -> bool {
+        self.connected
+    }
+
     fn next_server_sequence(&mut self) -> SequenceNumber {
         let next_sequence = self.next_server_sequence;
         self.next_server_sequence = self.next_server_sequence.wrapping_add(1);


### PR DESCRIPTION
This PR implements the groundwork for handling disconnects, as well as these scenarios:
* Client sends a disconnect packet
* Client reconnects with a new session, disconnecting the old session
* Two clients log in as the same player, disconnecting the first client
* The server has reached the maximum number of allowable clients

These scenarios should be enough so that you don't have to kill the server every time you want to reconnect without changing any config. This implementation also properly broadcasts packets to everyone nearby to handle multiplayer scenarios. This will need to be expanded when friends/group members/squad members log out later on.

Login handling has been split into an authentication step and the actual login step where the player is added to the world. We need to split them to prevent adding duplicate players to the world. Currently, the authentication handler naively assumes the player is who they say they are for testing purposes.

These scenarios still need to be covered:
* Client stopped responding for some configurable amount of time
* Client's protocol does not match the server's protocol and version
* Client version does not match the server's allowed client versions