### PR TITLE
Handle disconnects: part two

### DIFF
--- a/config/server.json
+++ b/config/server.json
@@ -15,5 +15,5 @@
     "desired_resend_pct": 5,
     "max_millis_until_resend": 300,
     "channel_cleanup_period_millis": 1000,
-    "channel_inactive_timeout_millis": 30000
+    "channel_inactive_timeout_millis": 60000
 }

--- a/config/server.json
+++ b/config/server.json
@@ -14,5 +14,6 @@
     "max_round_trip_entries": 30,
     "desired_resend_pct": 5,
     "max_millis_until_resend": 300,
-    "channel_cleanup_period_millis": 1000
+    "channel_cleanup_period_millis": 1000,
+    "channel_inactive_timeout_millis": 30000
 }

--- a/src/channel_manager.rs
+++ b/src/channel_manager.rs
@@ -163,12 +163,12 @@ impl ChannelManager {
 
     pub fn drain_filter(
         &mut self,
-        mut predicate: impl FnMut(&MutexGuard<Channel>) -> bool,
+        mut predicate: impl FnMut(&mut MutexGuard<Channel>) -> bool,
     ) -> Vec<(Option<u32>, Mutex<Channel>)> {
         let mut addrs_to_remove = Vec::new();
         for (addr, channel) in self.unauthenticated.iter() {
-            let channel_handle = channel.lock();
-            if predicate(&channel_handle) {
+            let mut channel_handle = channel.lock();
+            if predicate(&mut channel_handle) {
                 addrs_to_remove.push(*addr);
             }
         }
@@ -242,14 +242,14 @@ impl AuthenticatedChannelManager {
 
     pub fn drain_filter(
         &mut self,
-        mut predicate: impl FnMut(&MutexGuard<Channel>) -> bool,
+        mut predicate: impl FnMut(&mut MutexGuard<Channel>) -> bool,
     ) -> Vec<(u32, Mutex<Channel>)> {
         let addrs_to_remove: Vec<SocketAddr> = self
             .channels
             .iter()
             .filter_map(|(_, channel)| {
-                let channel_handle = channel.lock();
-                if predicate(&channel_handle) {
+                let mut channel_handle = channel.lock();
+                if predicate(&mut channel_handle) {
                     Some(channel_handle.addr)
                 } else {
                     None

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -114,7 +114,7 @@ impl GameServer {
         })
     }
 
-    pub fn authenticate(&self, data: Vec<u8>) -> Result<u32, ProcessPacketError> {
+    pub fn authenticate(&self, data: Vec<u8>) -> Result<(u32, String), ProcessPacketError> {
         let mut cursor = Cursor::new(&data[..]);
         let raw_op_code = cursor.read_u16::<LittleEndian>()?;
 
@@ -122,7 +122,7 @@ impl GameServer {
             Ok(op_code) => match op_code {
                 OpCode::LoginRequest => {
                     let login_packet: LoginRequest = DeserializePacket::deserialize(&mut cursor)?;
-                    shorten_player_guid(login_packet.guid)
+                    shorten_player_guid(login_packet.guid).map(|guid| (guid, login_packet.version))
                 }
                 _ => {
                     println!("Client tried to log in without a login request");

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,11 +99,12 @@ pub struct ServerOptions {
     pub process_packets_per_cycle: u8,
     pub send_packets_per_cycle: u8,
     pub packet_recency_limit: u16,
-    pub default_millis_until_resend: u128,
+    pub default_millis_until_resend: u64,
     pub max_round_trip_entries: usize,
     pub desired_resend_pct: u8,
-    pub max_millis_until_resend: u128,
+    pub max_millis_until_resend: u64,
     pub channel_cleanup_period_millis: u64,
+    pub channel_inactive_timeout_millis: u64,
 }
 
 impl ServerOptions {
@@ -157,10 +158,10 @@ fn spawn_receive_threads(
                                 src,
                                 initial_buffer_size,
                                 server_options.packet_recency_limit,
-                                server_options.default_millis_until_resend,
+                                Duration::from_millis(server_options.default_millis_until_resend),
                                 server_options.max_round_trip_entries,
                                 server_options.desired_resend_pct,
-                                server_options.max_millis_until_resend,
+                                Duration::from_millis(server_options.max_millis_until_resend),
                             );
                             let mut write_handle = channel_manager.write();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,6 +318,10 @@ fn process_once(
             match game_server.authenticate(packet) {
                 Ok((guid, client_version)) => {
                     if !server_options.allows_client_version(&client_version) {
+                        println!(
+                            "Disconnecting client {} that attempted to authenticate with disallowed version {}",
+                            channel_handle.addr, client_version
+                        );
                         disconnect(
                             Some(DisconnectReason::Application),
                             &[],

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -537,6 +537,12 @@ impl Channel {
         server_options: &ServerOptions,
     ) {
         if protocol != PROTOCOL || protocol_version != PROTOCOL_VERSION {
+            println!(
+                "Protocol mismatch on client {}: protocol={:x?}, version={}",
+                self.addr,
+                protocol.as_bytes(),
+                protocol_version
+            );
             let _ = self.disconnect(DisconnectReason::ProtocolMismatch);
             return;
         }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -438,6 +438,7 @@ impl Channel {
         self.send_queue.clear();
         self.connected = false;
 
+        println!("Disconnecting client {} with reason {:?}", self.addr, disconnect_reason);
         if let Some(session) = &self.session {
             serialize_packets(
                 &[&Packet::Disconnect(session.session_id, disconnect_reason)],

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -438,7 +438,10 @@ impl Channel {
         self.send_queue.clear();
         self.connected = false;
 
-        println!("Disconnecting client {} with reason {:?}", self.addr, disconnect_reason);
+        println!(
+            "Disconnecting client {} with reason {:?}",
+            self.addr, disconnect_reason
+        );
         if let Some(session) = &self.session {
             serialize_packets(
                 &[&Packet::Disconnect(session.session_id, disconnect_reason)],

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -469,6 +469,10 @@ impl Channel {
         self.connected
     }
 
+    pub fn elapsed_since_last_receive(&self) -> Duration {
+        Instant::now().saturating_duration_since(self.last_receive_time)
+    }
+
     fn next_server_sequence(&mut self) -> SequenceNumber {
         let next_sequence = self.next_server_sequence;
         self.next_server_sequence = self.next_server_sequence.wrapping_add(1);

--- a/src/protocol/serialize.rs
+++ b/src/protocol/serialize.rs
@@ -1,7 +1,7 @@
 use crate::protocol::hash::{compute_crc, CrcSeed, CrcSize};
 use crate::protocol::{
-    ApplicationProtocol, BufferSize, ClientTick, DisconnectReason, Packet, PacketCount,
-    ProtocolOpCode, SequenceNumber, ServerTick, Session, SessionId, SoeProtocolVersion, Timestamp,
+    BufferSize, ClientTick, DisconnectReason, Packet, PacketCount, Protocol, ProtocolOpCode,
+    ProtocolVersion, SequenceNumber, ServerTick, Session, SessionId, Timestamp,
 };
 use byteorder::{BigEndian, WriteBytesExt};
 use miniz_oxide::deflate::compress_to_vec_zlib;
@@ -59,10 +59,10 @@ fn variable_length_int_size(length: usize) -> usize {
 }
 
 fn serialize_session_request(
-    protocol_version: SoeProtocolVersion,
+    protocol_version: ProtocolVersion,
     session_id: SessionId,
     buffer_size: BufferSize,
-    app_protocol: &ApplicationProtocol,
+    app_protocol: &Protocol,
 ) -> Result<Vec<u8>, SerializeError> {
     let mut buffer = Vec::new();
     buffer.write_u32::<BigEndian>(protocol_version)?;
@@ -83,7 +83,7 @@ fn serialize_session_reply(
     allow_compression: bool,
     encrypt: bool,
     buffer_size: BufferSize,
-    protocol_version: SoeProtocolVersion,
+    protocol_version: ProtocolVersion,
 ) -> Result<Vec<u8>, SerializeError> {
     let mut buffer = Vec::new();
     buffer.write_u32::<BigEndian>(session_id)?;


### PR DESCRIPTION
Follow-up to #68.
* Time out idle connections
* Disconnect clients with a mismatched protocol version
* Disconnect clients with a disallowed client version
* Fix an issue where `return` statements would unintentionally exit out of the infinite loops in each threads.

These scenarios still need to be handled:
* Client sends packets too quickly (limit on the size of the receive queue)
* Client does not acknowledge packets quickly enough (limit on the size of the send queue)
* Client is sending a fragmented packet that is too large when complete (limit on packet length after de-fragmenting a packet)