### PR TITLE
Include client address and GUID in all logs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,10 @@ edition = "2021"
 [dependencies]
 axum = "0.7.5"
 byteorder = "1.5.0"
+chrono = "0.4.38"
 crc32fast = "1.4.2"
 crossbeam-channel = "0.5.13"
+defer-lite = "1.0.0"
 evalexpr = "11.3.0"
 packet_serialize = { path = "src/packet_serialize" }
 miniz_oxide = "0.7.2"

--- a/src/channel_manager.rs
+++ b/src/channel_manager.rs
@@ -1,6 +1,6 @@
 use crate::game_server::Broadcast;
 use crate::protocol::{Channel, DisconnectReason};
-use crate::ServerOptions;
+use crate::{info, ServerOptions};
 use crossbeam_channel::Sender;
 use parking_lot::{Mutex, MutexGuard};
 use std::collections::BTreeMap;
@@ -93,7 +93,7 @@ impl ChannelManager {
                     ReceiveResult::Success(packets_received)
                 }
                 Err(err) => {
-                    println!(
+                    info!(
                         "Deserialize error on channel {}: {:?}, data={:x?}",
                         addr, err, data
                     );
@@ -156,7 +156,7 @@ impl ChannelManager {
         let send_result = channel_handle.send_next(count);
 
         send_result.unwrap_or_else(|err| {
-            println!("Send error: {:?}", err);
+            info!("Send error: {:?}", err);
             Vec::new()
         })
     }

--- a/src/game_server/handlers/command.rs
+++ b/src/game_server/handlers/command.rs
@@ -3,9 +3,12 @@ use std::io::Cursor;
 use byteorder::{LittleEndian, ReadBytesExt};
 use packet_serialize::DeserializePacket;
 
-use crate::game_server::{
-    packets::command::{CommandOpCode, SelectPlayer},
-    Broadcast, GameServer, ProcessPacketError,
+use crate::{
+    game_server::{
+        packets::command::{CommandOpCode, SelectPlayer},
+        Broadcast, GameServer, ProcessPacketError,
+    },
+    info,
 };
 
 use super::zone::interact_with_character;
@@ -22,12 +25,12 @@ pub fn process_command(
                 interact_with_character(req, game_server)
             }
             _ => {
-                println!("Unimplemented command: {:?}", op_code);
+                info!("Unimplemented command: {:?}", op_code);
                 Ok(Vec::new())
             }
         },
         Err(_) => {
-            println!("Unknown command: {}", raw_op_code);
+            info!("Unknown command: {}", raw_op_code);
             Ok(Vec::new())
         }
     }

--- a/src/game_server/handlers/housing.rs
+++ b/src/game_server/handlers/housing.rs
@@ -19,7 +19,7 @@ use crate::{
         },
         Broadcast, GameServer, ProcessPacketError, ProcessPacketErrorType,
     },
-    teleport_to_zone,
+    info, teleport_to_zone,
 };
 
 use super::{
@@ -467,21 +467,21 @@ pub fn process_housing_packet(
             _ => {
                 let mut buffer = Vec::new();
                 cursor.read_to_end(&mut buffer)?;
-                println!("Unimplemented housing packet: {:?}, {:x?}", op_code, buffer);
+                info!("Unimplemented housing packet: {:?}, {:x?}", op_code, buffer);
                 Ok(Vec::new())
             }
         },
         Err(_) => {
             let mut buffer = Vec::new();
             cursor.read_to_end(&mut buffer)?;
-            println!("Unknown housing packet: {}, {:x?}", raw_op_code, buffer);
+            info!("Unknown housing packet: {}, {:x?}", raw_op_code, buffer);
             Ok(Vec::new())
         }
     }
 }
 
 pub fn lookup_house(sender: u32, house_guid: u64) -> Result<House, ProcessPacketError> {
-    println!("Found test house {}", house_guid);
+    info!("Found test house {}", house_guid);
     Ok(House {
         owner: sender,
         owner_name: "BLASTER NICESHOt".to_string(),

--- a/src/game_server/handlers/inventory.rs
+++ b/src/game_server/handlers/inventory.rs
@@ -11,20 +11,23 @@ use packet_serialize::DeserializePacket;
 use parking_lot::RwLockWriteGuard;
 use serde::Deserialize;
 
-use crate::game_server::{
-    packets::{
-        client_update::{EquipItem, UnequipItem, UpdateCredits},
-        inventory::{
-            EquipCustomization, EquipGuid, InventoryOpCode, PreviewCustomization, UnequipSlot,
+use crate::{
+    game_server::{
+        packets::{
+            client_update::{EquipItem, UnequipItem, UpdateCredits},
+            inventory::{
+                EquipCustomization, EquipGuid, InventoryOpCode, PreviewCustomization, UnequipSlot,
+            },
+            item::{Attachment, EquipmentSlot, ItemDefinition, WieldType},
+            player_data::EquippedItem,
+            player_update::{Customization, UpdateCustomizations, UpdateWieldType},
+            tunnel::TunneledPacket,
+            ui::ExecuteScriptWithParams,
+            GamePacket,
         },
-        item::{Attachment, EquipmentSlot, ItemDefinition, WieldType},
-        player_data::EquippedItem,
-        player_update::{Customization, UpdateCustomizations, UpdateWieldType},
-        tunnel::TunneledPacket,
-        ui::ExecuteScriptWithParams,
-        GamePacket,
+        Broadcast, GameServer, ProcessPacketError, ProcessPacketErrorType,
     },
-    Broadcast, GameServer, ProcessPacketError, ProcessPacketErrorType,
+    info,
 };
 
 use super::{
@@ -385,7 +388,7 @@ pub fn process_inventory_packet(
             }
         },
         Err(_) => {
-            println!("Unknown inventory packet: {}, {:x?}", raw_op_code, cursor);
+            info!("Unknown inventory packet: {}, {:x?}", raw_op_code, cursor);
             Ok(Vec::new())
         }
     }
@@ -417,7 +420,7 @@ pub fn customizations_from_guids(
         if let Some(customization) = customizations.get(&customization_guid) {
             result.push(customization.clone());
         } else {
-            println!(
+            info!(
                 "Skipped adding unknown customization {}",
                 customization_guid
             )

--- a/src/game_server/handlers/mount.rs
+++ b/src/game_server/handlers/mount.rs
@@ -10,16 +10,19 @@ use packet_serialize::DeserializePacket;
 use parking_lot::{RwLockReadGuard, RwLockWriteGuard};
 use serde::Deserialize;
 
-use crate::game_server::{
-    packets::{
-        client_update::{Stat, StatId, Stats},
-        item::{BaseAttachmentGroup, WieldType},
-        mount::{DismountReply, MountOpCode, MountReply, MountSpawn},
-        player_update::{AddNpc, Icon, RemoveGracefully},
-        tunnel::TunneledPacket,
-        Effect, GamePacket, Pos,
+use crate::{
+    game_server::{
+        packets::{
+            client_update::{Stat, StatId, Stats},
+            item::{BaseAttachmentGroup, WieldType},
+            mount::{DismountReply, MountOpCode, MountReply, MountSpawn},
+            player_update::{AddNpc, Icon, RemoveGracefully},
+            tunnel::TunneledPacket,
+            Effect, GamePacket, Pos,
+        },
+        Broadcast, GameServer, ProcessPacketError, ProcessPacketErrorType,
     },
-    Broadcast, GameServer, ProcessPacketError, ProcessPacketErrorType,
+    info,
 };
 
 use super::{
@@ -281,7 +284,7 @@ pub fn process_mount_packet(
             MountOpCode::DismountRequest => process_dismount(sender, game_server),
             MountOpCode::MountSpawn => process_mount_spawn(cursor, sender, game_server),
             _ => {
-                println!("Unimplemented mount op code: {:?}", op_code);
+                info!("Unimplemented mount op code: {:?}", op_code);
                 Ok(Vec::new())
             }
         },

--- a/src/game_server/handlers/store.rs
+++ b/src/game_server/handlers/store.rs
@@ -8,10 +8,13 @@ use std::{
 use evalexpr::{context_map, eval_with_context, Value};
 use serde::Deserialize;
 
-use crate::game_server::packets::{
-    item::ItemDefinition,
-    reference_data::ItemGroupDefinition,
-    store::{StoreItem, StoreItemList},
+use crate::{
+    game_server::packets::{
+        item::ItemDefinition,
+        reference_data::ItemGroupDefinition,
+        store::{StoreItem, StoreItemList},
+    },
+    info,
 };
 
 const DEFAULT_COST_EXPRESSION: &str = "x";
@@ -82,7 +85,7 @@ fn cost_map_from_sales(
                             members: item_definition.cost,
                         }
                     } else {
-                        println!("Defaulting to 0 cost for unknown item {}", item_guid);
+                        info!("Defaulting to 0 cost for unknown item {}", item_guid);
                         CostEntry {
                             base: 0,
                             members: 0,
@@ -106,7 +109,7 @@ fn cost_map_from_sales(
                 )?;
             }
         } else {
-            println!(
+            info!(
                 "Skipping sale for unknown item group {}",
                 sale.item_group_guid
             )

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -42,7 +42,7 @@ use packets::zone::ZoneTeleportRequest;
 use packets::{GamePacket, OpCode};
 use rand::Rng;
 
-use crate::teleport_to_zone;
+use crate::{info, teleport_to_zone};
 use packet_serialize::{DeserializePacket, DeserializePacketError, SerializePacketError};
 
 mod handlers;
@@ -562,9 +562,9 @@ impl GameServer {
                 OpCode::Logout => {
                     // Allow the cleanup thread to log the player out on disconnect
                 }
-                _ => println!("Unimplemented: {:?}, {:x?}", op_code, data),
+                _ => info!("Unimplemented: {:?}, {:x?}", op_code, data),
             },
-            Err(_) => println!("Unknown op code: {}, {:x?}", raw_op_code, data),
+            Err(_) => info!("Unknown op code: {}, {:x?}", raw_op_code, data),
         }
 
         Ok(broadcasts)


### PR DESCRIPTION
Replace `println!` calls with the new macro `info!`. This macro automatically annotates all log statements with the client's address and GUID for easier debugging when packets are processed. Sample logs:

```
2024-10-13T00:07:44.847316200+00:00 [client=127.0.0.1:54489] [guid=1]   Received packet op code Data
2024-10-13T00:07:45.074667600+00:00 [client=127.0.0.1:54489] [guid=1]   Received packet op code Data
2024-10-13T00:07:45.276769600+00:00 [client=127.0.0.1:54489] [guid=1]   Received packet op code Data
2024-10-13T00:07:46.271223700+00:00 [client=127.0.0.1:54489] [guid=1]   Received packet op code Data
2024-10-13T00:07:46.271777800+00:00 [client=127.0.0.1:54489] [guid=1]   Unknown op code: 189, [bd, 0, 4, b, 0, 0, 0, 47, 61, 6d, 65, 4f, 70, 74, 69, 6f, 6e, 73, f, 0, 0, 0, 43, 6c, 69, 63, 6b, 45, 78, 69, 74, 42, 75, 74, 74, 6f, 6e, 0, 0, 0, 0]
2024-10-13T00:07:46.294608500+00:00 [client=127.0.0.1:54489] [guid=1]   Received packet op code Data
2024-10-13T00:07:48.295916400+00:00 [client=127.0.0.1:54489] [guid=1]   Received packet op code Disconnect
2024-10-13T00:07:48.297101200+00:00 [client=127.0.0.1:54489] [guid=1]   Client 127.0.0.1:54489 disconnected with reason Application
2024-10-13T00:07:48.298579400+00:00 [client=127.0.0.1:54489] [guid=1]   Disconnecting client 127.0.0.1:54489 with reason OtherSideTerminated
2024-10-13T00:07:48.684932700+00:00     Disconnecting client 127.0.0.1:54489 with reason OtherSideTerminated
```