### PR TITLE
Allow tickable state order to be randomized

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ miniz_oxide = "0.7.2"
 num_enum = "0.7.2"
 parking_lot = "0.12.1"
 rand = "0.8.5"
+rand_distr = "0.4.3"
 serde_json = "1.0.1"
 serde = { version = "1.0.196", features = ["derive"] }
 strum = { version = "0.26.2", features = ["derive"] }


### PR DESCRIPTION
Allow tickable characters to use a random sequence of states instead of always switching between states sequentially.