### PR TITLE
Refactor NPC tickable states, config

### DIFF
--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -66,7 +66,7 @@ const fn default_weight() -> u32 {
 }
 
 #[derive(Clone, Deserialize)]
-pub struct BaseNpc {
+pub struct BaseNpcConfig {
     #[serde(default)]
     pub model_id: u32,
     #[serde(default)]
@@ -110,6 +110,22 @@ pub struct BaseNpc {
     pub tickable_states: Vec<TickableCharacterStateConfig>,
     #[serde(default)]
     pub tickable_state_order: TickableCharacterStateOrder,
+}
+
+#[derive(Clone)]
+pub struct BaseNpc {
+    pub model_id: u32,
+    pub name_id: u32,
+    pub terrain_object_id: u32,
+    pub name_offset_x: f32,
+    pub name_offset_y: f32,
+    pub name_offset_z: f32,
+    pub cursor: Option<u8>,
+    pub show_name: bool,
+    pub visible: bool,
+    pub bounce_area_id: i32,
+    pub npc_type: u32,
+    pub enable_rotation_and_shadow: bool,
 }
 
 impl BaseNpc {
@@ -218,6 +234,25 @@ impl BaseNpc {
                 unknown1: false,
             },
         )
+    }
+}
+
+impl From<BaseNpcConfig> for BaseNpc {
+    fn from(value: BaseNpcConfig) -> Self {
+        BaseNpc {
+            model_id: value.model_id,
+            name_id: value.name_id,
+            terrain_object_id: value.terrain_object_id,
+            name_offset_x: value.name_offset_x,
+            name_offset_y: value.name_offset_y,
+            name_offset_z: value.name_offset_z,
+            cursor: value.cursor,
+            show_name: value.show_name,
+            visible: value.visible,
+            bounce_area_id: value.bounce_area_id,
+            npc_type: value.npc_type,
+            enable_rotation_and_shadow: value.enable_rotation_and_shadow,
+        }
     }
 }
 
@@ -440,8 +475,13 @@ impl TickableCharacterStateTracker {
 }
 
 #[derive(Clone, Deserialize)]
-pub struct AmbientNpc {
+pub struct AmbientNpcConfig {
     #[serde(flatten)]
+    pub base_npc: BaseNpcConfig,
+}
+
+#[derive(Clone)]
+pub struct AmbientNpc {
     pub base_npc: BaseNpc,
 }
 
@@ -465,9 +505,32 @@ impl AmbientNpc {
     }
 }
 
+impl From<AmbientNpcConfig> for AmbientNpc {
+    fn from(value: AmbientNpcConfig) -> Self {
+        AmbientNpc {
+            base_npc: value.base_npc.into(),
+        }
+    }
+}
+
 #[derive(Clone, Deserialize)]
-pub struct Door {
+pub struct DoorConfig {
     #[serde(flatten)]
+    pub base_npc: BaseNpcConfig,
+    pub destination_pos_x: f32,
+    pub destination_pos_y: f32,
+    pub destination_pos_z: f32,
+    pub destination_pos_w: f32,
+    pub destination_rot_x: f32,
+    pub destination_rot_y: f32,
+    pub destination_rot_z: f32,
+    pub destination_rot_w: f32,
+    pub destination_zone_template: Option<u8>,
+    pub destination_zone: Option<u64>,
+}
+
+#[derive(Clone)]
+pub struct Door {
     pub base_npc: BaseNpc,
     pub destination_pos_x: f32,
     pub destination_pos_y: f32,
@@ -574,9 +637,35 @@ impl Door {
     }
 }
 
+impl From<DoorConfig> for Door {
+    fn from(value: DoorConfig) -> Self {
+        Door {
+            base_npc: value.base_npc.into(),
+            destination_pos_x: value.destination_pos_x,
+            destination_pos_y: value.destination_pos_y,
+            destination_pos_z: value.destination_pos_z,
+            destination_pos_w: value.destination_pos_w,
+            destination_rot_x: value.destination_rot_x,
+            destination_rot_y: value.destination_rot_y,
+            destination_rot_z: value.destination_rot_z,
+            destination_rot_w: value.destination_rot_w,
+            destination_zone_template: value.destination_zone_template,
+            destination_zone: value.destination_zone,
+        }
+    }
+}
+
 #[derive(Clone, Deserialize)]
-pub struct Transport {
+pub struct TransportConfig {
     #[serde(flatten)]
+    pub base_npc: BaseNpcConfig,
+    pub show_icon: bool,
+    pub large_icon: bool,
+    pub show_hover_description: bool,
+}
+
+#[derive(Clone)]
+pub struct Transport {
     pub base_npc: BaseNpc,
     pub show_icon: bool,
     pub large_icon: bool,
@@ -639,6 +728,17 @@ impl Transport {
                 })?],
             )])
         })
+    }
+}
+
+impl From<TransportConfig> for Transport {
+    fn from(value: TransportConfig) -> Self {
+        Transport {
+            base_npc: value.base_npc.into(),
+            show_icon: value.show_icon,
+            large_icon: value.large_icon,
+            show_hover_description: value.show_hover_description,
+        }
     }
 }
 

--- a/src/game_server/handlers/inventory.rs
+++ b/src/game_server/handlers/inventory.rs
@@ -183,7 +183,7 @@ fn process_unequip_slot(
                 if let Some(character_write_handle) = characters_write.get_mut(&player_guid(sender)) {
 
                     let mut brandished_wield_type = None;
-                    let mut result = if let CharacterType::Player(ref mut player_data) = character_write_handle.character_type {
+                    let mut result = if let CharacterType::Player(ref mut player_data) = character_write_handle.stats.character_type {
                         let possible_battle_class = player_data.battle_classes.get_mut(&unequip_slot.battle_class);
 
                         if let Some(battle_class) = possible_battle_class {
@@ -265,7 +265,7 @@ fn process_equip_guid(
                             characters_write.get(&player_guid(sender))
                         {
                             if let CharacterType::Player(player) =
-                                &character_write_handle.character_type
+                                &character_write_handle.stats.character_type
                             {
                                 if let Some(battle_class) =
                                     player.battle_classes.get(&player.active_battle_class)
@@ -412,7 +412,7 @@ fn process_equip_customization(
                 if let Some(character_write_handle) = characters_write.get_mut(&player_guid(sender))
                 {
                     if let CharacterType::Player(player) =
-                        &mut character_write_handle.character_type
+                        &mut character_write_handle.stats.character_type
                     {
                         let cost = if let Some(cost_entry) =
                             game_server.costs().get(&equip_customization.item_guid)
@@ -595,7 +595,7 @@ fn equip_item_in_slot(
         };
 
         let mut result = if let CharacterType::Player(ref mut player_data) =
-            character_write_handle.character_type
+            character_write_handle.stats.character_type
         {
             if player_data.inventory.contains(&equip_guid.item_guid) {
                 let possible_battle_class =

--- a/src/game_server/handlers/mount.rs
+++ b/src/game_server/handlers/mount.rs
@@ -76,8 +76,8 @@ pub fn reply_dismount(
     character: &mut RwLockWriteGuard<Character>,
     mounts: &BTreeMap<u32, MountConfig>,
 ) -> Result<Vec<Broadcast>, ProcessPacketError> {
-    if let Some(mount_id) = character.mount_id {
-        character.mount_id = None;
+    if let Some(mount_id) = character.stats.mount_id {
+        character.stats.mount_id = None;
         if let Some(mount) = mounts.get(&mount_id) {
             Ok(vec![Broadcast::Single(
                 sender,
@@ -155,11 +155,11 @@ fn process_dismount(
                 if let Some(character_write_handle) = characters_write.get_mut(&player_guid(sender))
                 {
                     zones_lock_enforcer.read_zones(|_| ZoneLockRequest {
-                        read_guids: vec![character_write_handle.instance_guid],
+                        read_guids: vec![character_write_handle.stats.instance_guid],
                         write_guids: Vec::new(),
                         zone_consumer: |_, zones_read, _| {
                             if let Some(zone_read_handle) =
-                                zones_read.get(&character_write_handle.instance_guid)
+                                zones_read.get(&character_write_handle.stats.instance_guid)
                             {
                                 reply_dismount(
                                     sender,
@@ -200,18 +200,18 @@ fn process_mount_spawn(
             character_consumer: |_, _, mut characters_write, zones_lock_enforcer| {
                 if let Some(character_write_handle) = characters_write.get_mut(&player_guid(sender)) {
                     zones_lock_enforcer.read_zones(|_| ZoneLockRequest {
-                        read_guids: vec![character_write_handle.instance_guid],
+                        read_guids: vec![character_write_handle.stats.instance_guid],
                         write_guids: Vec::new(),
                         zone_consumer: |_, zones_read, _| {
                             let mut packets = Vec::new();
 
-                            if let Some(zone_read_handle) = zones_read.get(&character_write_handle.instance_guid) {
+                            if let Some(zone_read_handle) = zones_read.get(&character_write_handle.stats.instance_guid) {
                                 packets.append(&mut spawn_mount_npc(
                                     mount_guid,
                                     player_guid(sender),
                                     mount,
-                                    character_write_handle.pos,
-                                    character_write_handle.rot,
+                                    character_write_handle.stats.pos,
+                                    character_write_handle.stats.rot,
                                 )?);
 
                                 packets.push(GamePacket::serialize(&TunneledPacket {
@@ -242,12 +242,12 @@ fn process_mount_spawn(
                                     },
                                 })?);
 
-                                if let Some(mount_id) = character_write_handle.mount_id {
+                                if let Some(mount_id) = character_write_handle.stats.mount_id {
                                     return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} tried to mount while already mounted on mount ID {}",
                                         sender, mount_id)));
                                 }
 
-                                character_write_handle.mount_id = Some(mount.guid());
+                                character_write_handle.stats.mount_id = Some(mount.guid());
 
                                 Ok(packets)
                             } else {

--- a/src/game_server/handlers/zone.rs
+++ b/src/game_server/handlers/zone.rs
@@ -393,46 +393,46 @@ impl Zone {
         pos_update: UpdatePlayerPosition,
     ) -> Result<Vec<u64>, ProcessPacketError> {
         if let Some(character_write_handle) = characters_write.get_mut(&pos_update.guid) {
-            let previous_pos = character_write_handle.pos;
-            character_write_handle.pos = Pos {
+            let previous_pos = character_write_handle.stats.pos;
+            character_write_handle.stats.pos = Pos {
                 x: pos_update.pos_x,
                 y: pos_update.pos_y,
                 z: pos_update.pos_z,
-                w: character_write_handle.pos.z,
+                w: character_write_handle.stats.pos.z,
             };
-            character_write_handle.rot = Pos {
+            character_write_handle.stats.rot = Pos {
                 x: pos_update.rot_x,
                 y: pos_update.rot_y,
                 z: pos_update.rot_z,
-                w: character_write_handle.rot.z,
+                w: character_write_handle.stats.rot.z,
             };
 
             let mut characters_to_interact = Vec::new();
             for npc_guid in auto_interact_npcs {
                 if let Some(npc_read_handle) = characters_read.get(&npc_guid) {
-                    if npc_read_handle.auto_interact_radius > 0.0 {
+                    if npc_read_handle.stats.auto_interact_radius > 0.0 {
                         let distance_now = distance3(
-                            character_write_handle.pos.x,
-                            character_write_handle.pos.y,
-                            character_write_handle.pos.z,
-                            npc_read_handle.pos.x,
-                            npc_read_handle.pos.y,
-                            npc_read_handle.pos.z,
+                            character_write_handle.stats.pos.x,
+                            character_write_handle.stats.pos.y,
+                            character_write_handle.stats.pos.z,
+                            npc_read_handle.stats.pos.x,
+                            npc_read_handle.stats.pos.y,
+                            npc_read_handle.stats.pos.z,
                         );
                         let distance_before = distance3(
                             previous_pos.x,
                             previous_pos.y,
                             previous_pos.z,
-                            npc_read_handle.pos.x,
-                            npc_read_handle.pos.y,
-                            npc_read_handle.pos.z,
+                            npc_read_handle.stats.pos.x,
+                            npc_read_handle.stats.pos.y,
+                            npc_read_handle.stats.pos.z,
                         );
 
                         // Only trigger the interaction when the player first enters the radius
-                        if distance_now <= npc_read_handle.auto_interact_radius
-                            && distance_before > npc_read_handle.auto_interact_radius
+                        if distance_now <= npc_read_handle.stats.auto_interact_radius
+                            && distance_before > npc_read_handle.stats.auto_interact_radius
                         {
-                            characters_to_interact.push(npc_read_handle.guid);
+                            characters_to_interact.push(npc_read_handle.guid());
                         }
                     }
                 }
@@ -749,11 +749,13 @@ pub fn enter_zone(
     let character = characters_table_write_handle.remove(player_guid(player));
     if let Some((character, (character_category, _, _))) = character {
         let mut character_write_handle = character.write();
-        character_write_handle.instance_guid = destination_read_handle.guid;
-        character_write_handle.pos = destination_pos;
-        character_write_handle.rot = destination_rot;
+        character_write_handle.stats.instance_guid = destination_read_handle.guid;
+        character_write_handle.stats.pos = destination_pos;
+        character_write_handle.stats.rot = destination_rot;
 
-        if let CharacterType::Player(ref mut player) = &mut character_write_handle.character_type {
+        if let CharacterType::Player(ref mut player) =
+            &mut character_write_handle.stats.character_type
+        {
             player.ready = false;
         }
 
@@ -875,10 +877,10 @@ pub fn interact_with_character(
                     let requester_y;
                     let requester_z;
                     if let Some(requester_read_handle) = characters_read.get(&request.requester) {
-                        source_zone_guid = requester_read_handle.instance_guid;
-                        requester_x = requester_read_handle.pos.x;
-                        requester_y = requester_read_handle.pos.y;
-                        requester_z = requester_read_handle.pos.z;
+                        source_zone_guid = requester_read_handle.stats.instance_guid;
+                        requester_x = requester_read_handle.stats.pos.x;
+                        requester_y = requester_read_handle.stats.pos.y;
+                        requester_z = requester_read_handle.stats.pos.z;
                     } else {
                         return coerce_to_broadcast_supplier(|_| Ok(Vec::new()));
                     }
@@ -889,11 +891,11 @@ pub fn interact_with_character(
                             requester_x,
                             requester_y,
                             requester_z,
-                            target_read_handle.pos.x,
-                            target_read_handle.pos.y,
-                            target_read_handle.pos.z,
+                            target_read_handle.stats.pos.x,
+                            target_read_handle.stats.pos.y,
+                            target_read_handle.stats.pos.z,
                         );
-                        if distance > target_read_handle.interact_radius {
+                        if distance > target_read_handle.stats.interact_radius {
                             return coerce_to_broadcast_supplier(|_| Ok(Vec::new()));
                         }
 
@@ -927,8 +929,8 @@ pub fn teleport_within_zone(
         characters_table_write_handle.remove(player_guid(sender))
     {
         let mut character_write_handle = character.write();
-        character_write_handle.pos = destination_pos;
-        character_write_handle.rot = destination_rot;
+        character_write_handle.stats.pos = destination_pos;
+        character_write_handle.stats.rot = destination_rot;
         let (_, _, new_chunk) = character_write_handle.index();
 
         let (diff_character_guids, diff_character_handles) = diff_character_handles!(

--- a/src/game_server/handlers/zone.rs
+++ b/src/game_server/handlers/zone.rs
@@ -29,9 +29,9 @@ use crate::{
 
 use super::{
     character::{
-        coerce_to_broadcast_supplier, AmbientNpc, Character, CharacterCategory, CharacterIndex,
-        CharacterType, Chunk, Door, NpcTemplate, PreviousFixture, TickableCharacterStateOrder,
-        Transport, WriteLockingBroadcastSupplier,
+        coerce_to_broadcast_supplier, AmbientNpcConfig, Character, CharacterCategory,
+        CharacterIndex, CharacterType, Chunk, DoorConfig, NpcTemplate, PreviousFixture,
+        TickableCharacterStateOrder, TransportConfig, WriteLockingBroadcastSupplier,
     },
     guid::{Guid, GuidTable, GuidTableIndexer, GuidTableWriteHandle, IndexedGuid},
     housing::prepare_init_house_packets,
@@ -69,11 +69,11 @@ struct ZoneConfig {
     speed: f32,
     jump_height_multiplier: f32,
     gravity_multiplier: f32,
-    doors: Vec<Door>,
+    doors: Vec<DoorConfig>,
     interact_radius: f32,
     door_auto_interact_radius: f32,
-    transports: Vec<Transport>,
-    ambient_npcs: Vec<AmbientNpc>,
+    transports: Vec<TransportConfig>,
+    ambient_npcs: Vec<AmbientNpcConfig>,
 }
 
 #[derive(Clone)]
@@ -599,7 +599,7 @@ impl ZoneConfig {
                     tickable_states: ambient_npc.base_npc.tickable_states.clone(),
                     tickable_state_order: ambient_npc.base_npc.tickable_state_order,
                     animation_id: ambient_npc.base_npc.active_animation_slot,
-                    character_type: CharacterType::AmbientNpc(ambient_npc),
+                    character_type: CharacterType::AmbientNpc(ambient_npc.into()),
                     mount_id: None,
                     interact_radius: self.interact_radius,
                     auto_interact_radius: 0.0,
@@ -628,7 +628,7 @@ impl ZoneConfig {
                     tickable_states: door.base_npc.tickable_states.clone(),
                     tickable_state_order: door.base_npc.tickable_state_order,
                     animation_id: door.base_npc.active_animation_slot,
-                    character_type: CharacterType::Door(door),
+                    character_type: CharacterType::Door(door.into()),
                     mount_id: None,
                     interact_radius: self.interact_radius,
                     auto_interact_radius: self.door_auto_interact_radius,
@@ -657,7 +657,7 @@ impl ZoneConfig {
                     tickable_states: transport.base_npc.tickable_states.clone(),
                     tickable_state_order: transport.base_npc.tickable_state_order,
                     animation_id: transport.base_npc.active_animation_slot,
-                    character_type: CharacterType::Transport(transport),
+                    character_type: CharacterType::Transport(transport.into()),
                     mount_id: None,
                     interact_radius: self.interact_radius,
                     auto_interact_radius: 0.0,

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -251,7 +251,7 @@ impl GameServer {
                                 Some((character, _)) => {
                                     let mut character_write_handle = character.write();
                                     if let CharacterType::Player(ref mut player) =
-                                        &mut character_write_handle.character_type
+                                        &mut character_write_handle.stats.character_type
                                     {
                                         player.ready = true;
                                     }
@@ -378,7 +378,7 @@ impl GameServer {
                                                 let mut character_broadcasts = Vec::new();
 
                                                 if let Some(character_write_handle) = characters_writes.get_mut(&player_guid(sender)) {
-                                                    character_write_handle.speed = zone.speed;
+                                                    character_write_handle.stats.speed = zone.speed;
                                                     let wield_type = TunneledPacket {
                                                         unknown1: true,
                                                         inner: UpdateWieldType {
@@ -388,7 +388,7 @@ impl GameServer {
                                                     };
                                                     global_packets.push(GamePacket::serialize(&wield_type)?);
 
-                                                    if let CharacterType::Player(player) = &character_write_handle.character_type {
+                                                    if let CharacterType::Player(player) = &character_write_handle.stats.character_type {
                                                         global_packets.push(GamePacket::serialize(&TunneledPacket {
                                                             unknown1: true,
                                                             inner: InitCustomizations {


### PR DESCRIPTION
* Refactored tickable state handling so we no longer need a changelog struct. Now, the step struct can update the character directly with extra indirection.
* Refactored NPC types so that there are `<type>Config` and `<type>` structs. This reduces characters' memory footprint because we don't store duplicate fields (pos, tickable states, etc.) multiple times. It also makes it clear which pos field should be used when sending NPC packets (i.e. the character's real pos, not the one that was part of config).