### PR TITLE
Fix tickable NPC animation transitions

### DIFF
--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -15,8 +15,7 @@ use crate::{
             player_data::EquippedItem,
             player_update::{
                 AddNotifications, AddNpc, CustomizationSlot, Icon, NotificationData, NpcRelevance,
-                QueueAnimation, RemoveStandard, SingleNotification, SingleNpcRelevance,
-                UpdateSpeed,
+                RemoveStandard, SetAnimation, SingleNotification, SingleNpcRelevance, UpdateSpeed,
             },
             tunnel::TunneledPacket,
             ui::ExecuteScriptWithParams,
@@ -323,12 +322,11 @@ impl TickableStep {
             character.animation_id = animation_id;
             packets.push(GamePacket::serialize(&TunneledPacket {
                 unknown1: true,
-                inner: QueueAnimation {
+                inner: SetAnimation {
                     character_guid: Guid::guid(character),
                     animation_id,
-                    queue_pos: 1,
-                    delay_seconds: 0.0,
-                    duration_seconds: Duration::from_millis(self.duration_millis).as_secs_f32(),
+                    animation_group_id: -1,
+                    override_animation: true,
                 },
             })?);
         }

--- a/src/game_server/packets/player_update.rs
+++ b/src/game_server/packets/player_update.rs
@@ -479,7 +479,7 @@ pub struct SetAnimation {
     pub character_guid: u64,
     pub animation_id: i32,
     pub animation_group_id: i32,
-    pub enable_loop: bool,
+    pub override_animation: bool,
 }
 
 impl GamePacket for SetAnimation {


### PR DESCRIPTION
Currently, tickable NPCs do not change their animations properly when multiple looping animations are in a series. The boolean parameter of the `SetAnimation` packet determines whether to override the NPC's animation; it enables looping but does not solely control looping. For example, if you send a `SetAnimation` packet with a looped-by-default animation, any following `SetAnimation` packets will be ignored if the override parameter is `false`.

There seems to be a distinction between spawn animations and regular animations; we should investigate and update the NPC packet fields accordingly.