### PR TITLE
Allow defining randomized transitions between tickable procedures

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -664,8 +664,8 @@
                 "pos_z": 379.9795,
                 "pos_w": 1.0,
                 "rot_x": 1.5708,
-                "tickable_procedures": [
-                    {
+                "tickable_procedures": {
+                    "lift": {
                         "steps": [
                             {
                                 "speed": 2.0,
@@ -679,7 +679,7 @@
                             }
                         ]
                     }
-                ]
+                }
             },
             {
                 "comment": "Training Room Dueling Platform Lift",
@@ -690,8 +690,8 @@
                 "pos_z": 379.9795,
                 "pos_w": 1.0,
                 "rot_x": -1.5708,
-                "tickable_procedures": [
-                    {
+                "tickable_procedures": {
+                    "lift": {
                         "steps": [
                             {
                                 "speed": 2.0,
@@ -705,7 +705,7 @@
                             }
                         ]
                     }
-                ]
+                }
             }
         ]
     },

--- a/src/game_server/handlers/zone.rs
+++ b/src/game_server/handlers/zone.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, HashMap},
     fs::File,
     io::Error,
     path::Path,
@@ -31,7 +31,7 @@ use super::{
     character::{
         coerce_to_broadcast_supplier, AmbientNpcConfig, Character, CharacterCategory,
         CharacterIndex, CharacterType, Chunk, DoorConfig, NpcTemplate, PreviousFixture,
-        TickableProcedureOrder, TransportConfig, WriteLockingBroadcastSupplier,
+        TransportConfig, WriteLockingBroadcastSupplier,
     },
     guid::{Guid, GuidTable, GuidTableIndexer, GuidTableWriteHandle, IndexedGuid},
     housing::prepare_init_house_packets,
@@ -254,8 +254,8 @@ impl Zone {
                 guid,
                 WieldType::None,
                 0,
+                HashMap::new(),
                 Vec::new(),
-                TickableProcedureOrder::default(),
             ));
         }
         template.to_zone(guid, Some(house), global_characters_table)
@@ -601,7 +601,10 @@ impl ZoneConfig {
                     },
                     scale: ambient_npc.base_npc.scale,
                     tickable_procedures: ambient_npc.base_npc.tickable_procedures.clone(),
-                    tickable_procedure_order: ambient_npc.base_npc.tickable_procedure_order,
+                    first_possible_procedures: ambient_npc
+                        .base_npc
+                        .first_possible_procedures
+                        .clone(),
                     animation_id: ambient_npc.base_npc.active_animation_slot,
                     character_type: CharacterType::AmbientNpc(ambient_npc.into()),
                     mount_id: None,
@@ -630,7 +633,7 @@ impl ZoneConfig {
                     },
                     scale: door.base_npc.scale,
                     tickable_procedures: door.base_npc.tickable_procedures.clone(),
-                    tickable_procedure_order: door.base_npc.tickable_procedure_order,
+                    first_possible_procedures: door.base_npc.first_possible_procedures.clone(),
                     animation_id: door.base_npc.active_animation_slot,
                     character_type: CharacterType::Door(door.into()),
                     mount_id: None,
@@ -659,7 +662,7 @@ impl ZoneConfig {
                     },
                     scale: transport.base_npc.scale,
                     tickable_procedures: transport.base_npc.tickable_procedures.clone(),
-                    tickable_procedure_order: transport.base_npc.tickable_procedure_order,
+                    first_possible_procedures: transport.base_npc.first_possible_procedures.clone(),
                     animation_id: transport.base_npc.active_animation_slot,
                     character_type: CharacterType::Transport(transport.into()),
                     mount_id: None,


### PR DESCRIPTION
Removes the `TickableProcedureOrder` in favor of a more flexible system where you can specify named procedures to execute next. Each list contains the names of multiple procedures that could be executed next, one of which will be selected randomly. The first procedure executed is also selected randomly from a provided list, if any. An empty or non-existent list means any of the procedures may be selected.