### PR TITLE
Support NPC tickable procedure synchronization

### DIFF
--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -67,6 +67,7 @@ const fn default_weight() -> u32 {
 
 #[derive(Clone, Deserialize)]
 pub struct BaseNpcConfig {
+    pub key: Option<String>,
     #[serde(default)]
     pub model_id: u32,
     #[serde(default)]
@@ -110,6 +111,7 @@ pub struct BaseNpcConfig {
     pub tickable_procedures: HashMap<String, TickableProcedureConfig>,
     #[serde(default)]
     pub first_possible_procedures: Vec<String>,
+    pub synchronize_with: Option<String>,
 }
 
 #[derive(Clone)]
@@ -449,6 +451,7 @@ impl TickableProcedure {
 pub struct TickableProcedureTracker {
     procedures: HashMap<String, TickableProcedure>,
     current_procedure_key: String,
+    last_procedure_change: Instant,
 }
 
 impl TickableProcedureTracker {
@@ -498,6 +501,32 @@ impl TickableProcedureTracker {
                     )
                 })
                 .collect(),
+            last_procedure_change: Instant::now(),
+        }
+    }
+
+    pub fn current_tickable_procedure(&self) -> Option<&String> {
+        if self.procedures.is_empty() {
+            None
+        } else {
+            Some(&self.current_procedure_key)
+        }
+    }
+
+    pub fn last_procedure_change(&self) -> Instant {
+        self.last_procedure_change
+    }
+
+    pub fn set_procedure_if_exists(&mut self, new_procedure_key: String, now: Instant) {
+        if self.procedures.contains_key(&new_procedure_key) {
+            let current_procedure = self
+                .procedures
+                .get_mut(&self.current_procedure_key)
+                .expect("Missing procedure");
+            current_procedure.reset();
+
+            self.current_procedure_key = new_procedure_key;
+            self.last_procedure_change = now;
         }
     }
 
@@ -525,6 +554,7 @@ impl TickableProcedureTracker {
                     .procedures
                     .get_mut(&self.current_procedure_key)
                     .expect("Missing procedure");
+                self.last_procedure_change = now;
             }
         }
     }
@@ -900,6 +930,7 @@ pub enum CharacterCategory {
 
 #[derive(Clone)]
 pub struct NpcTemplate {
+    pub key: Option<String>,
     pub discriminant: u8,
     pub index: u16,
     pub pos: Pos,
@@ -913,13 +944,22 @@ pub struct NpcTemplate {
     pub wield_type: WieldType,
     pub tickable_procedures: HashMap<String, TickableProcedureConfig>,
     pub first_possible_procedures: Vec<String>,
+    pub synchronize_with: Option<String>,
 }
 
 impl NpcTemplate {
-    pub fn to_character(&self, instance_guid: u64) -> Character {
+    pub fn guid(&self, instance_guid: u64) -> u64 {
+        npc_guid(self.discriminant, instance_guid, self.index)
+    }
+
+    pub fn to_character(
+        &self,
+        instance_guid: u64,
+        keys_to_guid: &HashMap<&String, u64>,
+    ) -> Character {
         Character {
             stats: CharacterStats {
-                guid: npc_guid(self.discriminant, instance_guid, self.index),
+                guid: self.guid(instance_guid),
                 pos: self.pos,
                 rot: self.rot,
                 scale: self.scale,
@@ -937,6 +977,10 @@ impl NpcTemplate {
                 self.tickable_procedures.clone(),
                 self.first_possible_procedures.clone(),
             ),
+            synchronize_with: match &self.synchronize_with {
+                Some(key) => keys_to_guid.get(key).copied(),
+                None => None,
+            },
         }
     }
 }
@@ -971,6 +1015,7 @@ impl Guid<u64> for CharacterStats {
 pub struct Character {
     pub stats: CharacterStats,
     tickable_procedure_tracker: TickableProcedureTracker,
+    pub synchronize_with: Option<u64>,
 }
 
 impl IndexedGuid<u64, CharacterIndex> for Character {
@@ -1018,6 +1063,7 @@ impl Character {
         animation_id: i32,
         tickable_procedures: HashMap<String, TickableProcedureConfig>,
         first_possible_procedures: Vec<String>,
+        synchronize_with: Option<u64>,
     ) -> Character {
         Character {
             stats: CharacterStats {
@@ -1039,6 +1085,7 @@ impl Character {
                 tickable_procedures,
                 first_possible_procedures,
             ),
+            synchronize_with,
         }
     }
 
@@ -1091,6 +1138,7 @@ impl Character {
                 speed: 0.0,
             },
             tickable_procedure_tracker: TickableProcedureTracker::new(HashMap::new(), Vec::new()),
+            synchronize_with: None,
         }
     }
 
@@ -1147,6 +1195,15 @@ impl Character {
         Ok(packets)
     }
 
+    pub fn set_tickable_procedure_if_exists(
+        &mut self,
+        new_tickable_procedure: String,
+        now: Instant,
+    ) {
+        self.tickable_procedure_tracker
+            .set_procedure_if_exists(new_tickable_procedure, now);
+    }
+
     pub fn tick<'a>(
         &mut self,
         now: Instant,
@@ -1162,6 +1219,14 @@ impl Character {
 
         let packets = self.tickable_procedure_tracker.tick(&mut self.stats, now)?;
         Ok(vec![Broadcast::Multi(everyone, packets)])
+    }
+
+    pub fn current_tickable_procedure(&self) -> Option<&String> {
+        self.tickable_procedure_tracker.current_tickable_procedure()
+    }
+
+    pub fn last_procedure_change(&self) -> Instant {
+        self.tickable_procedure_tracker.last_procedure_change()
     }
 
     pub fn wield_type(&self) -> WieldType {

--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -977,10 +977,12 @@ impl NpcTemplate {
                 self.tickable_procedures.clone(),
                 self.first_possible_procedures.clone(),
             ),
-            synchronize_with: match &self.synchronize_with {
-                Some(key) => keys_to_guid.get(key).copied(),
-                None => None,
-            },
+            synchronize_with: self.synchronize_with.as_ref().map(|key| {
+                keys_to_guid
+                    .get(key)
+                    .copied()
+                    .unwrap_or_else(|| panic!("Tried to synchronize with unknown NPC {}", key))
+            }),
         }
     }
 }

--- a/src/game_server/handlers/zone.rs
+++ b/src/game_server/handlers/zone.rs
@@ -125,8 +125,20 @@ impl ZoneTemplate {
         house_data: Option<House>,
         global_characters_table: &mut GuidTableWriteHandle<u64, Character, CharacterIndex>,
     ) -> Zone {
+        let keys_to_guid: HashMap<&String, u64> = self
+            .characters
+            .iter()
+            .filter_map(|template| {
+                template
+                    .key
+                    .as_ref()
+                    .map(|key| (key, template.guid(instance_guid)))
+            })
+            .collect();
+
         for character_template in self.characters.iter() {
-            global_characters_table.insert(character_template.to_character(instance_guid));
+            let character = character_template.to_character(instance_guid, &keys_to_guid);
+            global_characters_table.insert(character);
         }
 
         Zone {
@@ -256,6 +268,7 @@ impl Zone {
                 0,
                 HashMap::new(),
                 Vec::new(),
+                None,
             ));
         }
         template.to_zone(guid, Some(house), global_characters_table)
@@ -585,6 +598,7 @@ impl ZoneConfig {
         {
             for ambient_npc in self.ambient_npcs {
                 characters.push(NpcTemplate {
+                    key: ambient_npc.base_npc.key.clone(),
                     discriminant: AMBIENT_NPC_DISCRIMINANT,
                     index,
                     pos: Pos {
@@ -605,6 +619,7 @@ impl ZoneConfig {
                         .base_npc
                         .first_possible_procedures
                         .clone(),
+                    synchronize_with: ambient_npc.base_npc.synchronize_with.clone(),
                     animation_id: ambient_npc.base_npc.active_animation_slot,
                     character_type: CharacterType::AmbientNpc(ambient_npc.into()),
                     mount_id: None,
@@ -617,6 +632,7 @@ impl ZoneConfig {
 
             for door in self.doors {
                 characters.push(NpcTemplate {
+                    key: door.base_npc.key.clone(),
                     discriminant: AMBIENT_NPC_DISCRIMINANT,
                     index,
                     pos: Pos {
@@ -634,6 +650,7 @@ impl ZoneConfig {
                     scale: door.base_npc.scale,
                     tickable_procedures: door.base_npc.tickable_procedures.clone(),
                     first_possible_procedures: door.base_npc.first_possible_procedures.clone(),
+                    synchronize_with: door.base_npc.synchronize_with.clone(),
                     animation_id: door.base_npc.active_animation_slot,
                     character_type: CharacterType::Door(door.into()),
                     mount_id: None,
@@ -646,6 +663,7 @@ impl ZoneConfig {
 
             for transport in self.transports {
                 characters.push(NpcTemplate {
+                    key: transport.base_npc.key.clone(),
                     discriminant: AMBIENT_NPC_DISCRIMINANT,
                     index,
                     pos: Pos {
@@ -663,6 +681,7 @@ impl ZoneConfig {
                     scale: transport.base_npc.scale,
                     tickable_procedures: transport.base_npc.tickable_procedures.clone(),
                     first_possible_procedures: transport.base_npc.first_possible_procedures.clone(),
+                    synchronize_with: transport.base_npc.synchronize_with.clone(),
                     animation_id: transport.base_npc.active_animation_slot,
                     character_type: CharacterType::Transport(transport.into()),
                     mount_id: None,


### PR DESCRIPTION
Implements tickable procedure synchronization between NPCs. NPCc can optionally have an identifying `key` so that the `synchronize_with` field can reference them by name, rather than GUID or index, which are not necessarily stable.

The config requires that an NPC with the key provided in `synchronize_with` exist in the config. Internally, however, the implementation synchronizes to an NPC with the matching GUID. The GUID is resolved from the key when processing the config, _not_ when actually performing the synchronization. (Consider the case where we have multiple instances of the same zone. We want to synchronize with the NPC in the same zone, which has a unique GUID but not a unique key.)

We can describe the synchronized NPC as the "follower" and the NPC it is synchronized to as the "leader." Assume both the leader and follower are present. Every tick, the follower's current tickable procedure will be **interrupted** and changed to its own procedure with the same name as the leader's current procedure. If the follower does not have such a procedure, or if the leader no longer exists, the follower simply acts as if it was not synchronized until it is interrupted again.

Tickable procedure trackers now know the last time the procedure changed to determine whether the follower's procedure needs to be reset. Furthermore, leaders cannot be the follower of another NPC. In other words, an NPC cannot be synchronized to another NPC that is synchronized.

## Why can't an NPC be synchronized to another NPC that is synchronized?
The main issue here is ticking the NPCs in the correct order; non-synchronized NPCs have to be ticked first. We could support this behavior if we built a directed acyclic graph (DAG) of all the NPCs based on the synchronization relationships, but this adds complexity and requires more memory to store the graph when we can just disallow it. This also naturally prevents cycles where NPCs are synchronized to each other.

It also seems cleaner to define one NPC that serves as a source of events to coordinate all the other NPCs, rather than having transitive synchronization relationships that would require a DAG to visualize.