### PR TITLE
Chunkify NPC ticking, only broadcast NPC chats in limited radius

### DIFF
--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -52,7 +52,7 @@ pub fn coerce_to_broadcast_supplier(
     Ok(Box::new(f))
 }
 
-pub const CHAT_MAX_DISTANCE: f32 = 32.0;
+pub const CHAT_BUBBLE_VISIBLE_RADIUS: f32 = 32.0;
 
 const fn default_scale() -> f32 {
     1.0
@@ -405,7 +405,7 @@ impl TickableStep {
                         nearby_players[&player_guid(**guid)].stats.pos,
                         character.pos,
                     );
-                    pos <= CHAT_MAX_DISTANCE
+                    pos <= CHAT_BUBBLE_VISIBLE_RADIUS
                 })
                 .cloned()
                 .collect();

--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -31,6 +31,7 @@ use crate::{
 };
 
 use super::{
+    distance3_pos,
     guid::{Guid, IndexedGuid},
     housing::fixture_packets,
     inventory::wield_type_from_slot,
@@ -50,6 +51,8 @@ pub fn coerce_to_broadcast_supplier(
 ) -> WriteLockingBroadcastSupplier {
     Ok(Box::new(f))
 }
+
+pub const CHAT_MAX_DISTANCE: f32 = 32.0;
 
 const fn default_scale() -> f32 {
     1.0
@@ -302,12 +305,14 @@ impl TickableStep {
     pub fn apply(
         &self,
         character: &mut CharacterStats,
-    ) -> Result<Vec<Vec<u8>>, ProcessPacketError> {
-        let mut packets = Vec::new();
+        nearby_player_guids: &[u32],
+        nearby_players: &BTreeMap<u64, CharacterReadGuard>,
+    ) -> Result<Vec<Broadcast>, ProcessPacketError> {
+        let mut packets_for_all = Vec::new();
 
         if let Some(speed) = self.speed {
             character.speed = speed;
-            packets.push(GamePacket::serialize(&TunneledPacket {
+            packets_for_all.push(GamePacket::serialize(&TunneledPacket {
                 unknown1: true,
                 inner: UpdateSpeed {
                     guid: Guid::guid(character),
@@ -318,7 +323,7 @@ impl TickableStep {
 
         let new_pos = self.new_pos(character.pos);
         character.pos = new_pos;
-        packets.push(GamePacket::serialize(&TunneledPacket {
+        packets_for_all.push(GamePacket::serialize(&TunneledPacket {
             unknown1: true,
             inner: UpdatePlayerPosition {
                 guid: Guid::guid(character),
@@ -335,7 +340,7 @@ impl TickableStep {
 
         if let Some(animation_id) = self.animation_id {
             character.animation_id = animation_id;
-            packets.push(GamePacket::serialize(&TunneledPacket {
+            packets_for_all.push(GamePacket::serialize(&TunneledPacket {
                 unknown1: true,
                 inner: SetAnimation {
                     character_guid: Guid::guid(character),
@@ -347,7 +352,7 @@ impl TickableStep {
         }
 
         if let Some(animation_id) = self.one_shot_animation_id {
-            packets.push(GamePacket::serialize(&TunneledPacket {
+            packets_for_all.push(GamePacket::serialize(&TunneledPacket {
                 unknown1: true,
                 inner: QueueAnimation {
                     character_guid: Guid::guid(character),
@@ -359,8 +364,26 @@ impl TickableStep {
             })?);
         }
 
+        if let Some(sound_id) = self.sound_id {
+            packets_for_all.push(GamePacket::serialize(&TunneledPacket {
+                unknown1: true,
+                inner: PlaySoundIdOnTarget {
+                    sound_id,
+                    target: Target::Guid(GuidTarget {
+                        fallback_pos: character.pos,
+                        guid: Guid::guid(character),
+                    }),
+                },
+            })?);
+        }
+
+        let mut broadcasts = vec![Broadcast::Multi(
+            nearby_player_guids.to_vec(),
+            packets_for_all,
+        )];
+
         if let Some(chat_message_id) = self.chat_message_id {
-            packets.push(GamePacket::serialize(&TunneledPacket {
+            let chat_packets = vec![GamePacket::serialize(&TunneledPacket {
                 unknown1: true,
                 inner: SendStringId {
                     sender_guid: Guid::guid(character),
@@ -373,23 +396,24 @@ impl TickableStep {
                     owner_guid: 0,
                     unknown7: 0,
                 },
-            })?);
+            })?];
+
+            let recipients = nearby_player_guids
+                .iter()
+                .filter(|guid| {
+                    let pos = distance3_pos(
+                        nearby_players[&player_guid(**guid)].stats.pos,
+                        character.pos,
+                    );
+                    pos <= CHAT_MAX_DISTANCE
+                })
+                .cloned()
+                .collect();
+
+            broadcasts.push(Broadcast::Multi(recipients, chat_packets));
         }
 
-        if let Some(sound_id) = self.sound_id {
-            packets.push(GamePacket::serialize(&TunneledPacket {
-                unknown1: true,
-                inner: PlaySoundIdOnTarget {
-                    sound_id,
-                    target: Target::Guid(GuidTarget {
-                        fallback_pos: character.pos,
-                        guid: Guid::guid(character),
-                    }),
-                },
-            })?);
-        }
-
-        Ok(packets)
+        Ok(broadcasts)
     }
 }
 
@@ -403,7 +427,7 @@ pub struct TickableProcedureConfig {
 }
 
 pub enum TickResult {
-    TickedCurrentProcedure(Result<Vec<Vec<u8>>, ProcessPacketError>),
+    TickedCurrentProcedure(Result<Vec<Broadcast>, ProcessPacketError>),
     MustChangeProcedure(String),
 }
 
@@ -457,7 +481,13 @@ impl TickableProcedure {
         }
     }
 
-    pub fn tick(&mut self, character: &mut CharacterStats, now: Instant) -> TickResult {
+    pub fn tick(
+        &mut self,
+        character: &mut CharacterStats,
+        now: Instant,
+        nearby_player_guids: &[u32],
+        nearby_players: &BTreeMap<u64, CharacterReadGuard>,
+    ) -> TickResult {
         self.panic_if_empty();
 
         let should_change_steps =
@@ -479,7 +509,11 @@ impl TickableProcedure {
                 TickResult::MustChangeProcedure(self.next_procedure())
             } else {
                 self.current_step = Some((new_step_index, now));
-                TickResult::TickedCurrentProcedure(self.steps[new_step_index].apply(character))
+                TickResult::TickedCurrentProcedure(self.steps[new_step_index].apply(
+                    character,
+                    nearby_player_guids,
+                    nearby_players,
+                ))
             }
         } else {
             TickResult::TickedCurrentProcedure(Ok(Vec::new()))
@@ -589,7 +623,9 @@ impl TickableProcedureTracker {
         &mut self,
         character: &mut CharacterStats,
         now: Instant,
-    ) -> Result<Vec<Vec<u8>>, ProcessPacketError> {
+        nearby_player_guids: &[u32],
+        nearby_players: &BTreeMap<u64, CharacterReadGuard>,
+    ) -> Result<Vec<Broadcast>, ProcessPacketError> {
         if self.procedures.is_empty() {
             return Ok(Vec::new());
         }
@@ -599,7 +635,8 @@ impl TickableProcedureTracker {
             .get_mut(&self.current_procedure_key)
             .expect("Missing procedure");
         loop {
-            let tick_result = current_procedure.tick(character, now);
+            let tick_result =
+                current_procedure.tick(character, now, nearby_player_guids, nearby_players);
             if let TickResult::TickedCurrentProcedure(result) = tick_result {
                 break result;
             } else if let TickResult::MustChangeProcedure(procedure_key) = tick_result {
@@ -1263,14 +1300,18 @@ impl Character {
             .set_procedure_if_exists(new_tickable_procedure, now);
     }
 
-    pub fn tick<'a>(
+    pub fn tick(
         &mut self,
         now: Instant,
-        nearby_player_guids: Vec<u32>,
+        nearby_player_guids: &[u32],
         nearby_players: &BTreeMap<u64, CharacterReadGuard>,
     ) -> Result<Vec<Broadcast>, ProcessPacketError> {
-        let packets = self.tickable_procedure_tracker.tick(&mut self.stats, now)?;
-        Ok(vec![Broadcast::Multi(nearby_player_guids, packets)])
+        self.tickable_procedure_tracker.tick(
+            &mut self.stats,
+            now,
+            nearby_player_guids,
+            nearby_players,
+        )
     }
 
     pub fn current_tickable_procedure(&self) -> Option<&String> {

--- a/src/game_server/handlers/mod.rs
+++ b/src/game_server/handlers/mod.rs
@@ -1,3 +1,5 @@
+use super::packets::Pos;
+
 pub mod character;
 pub mod chat;
 pub mod command;
@@ -14,3 +16,14 @@ pub mod test_data;
 pub mod time;
 pub mod unique_guid;
 pub mod zone;
+
+pub fn distance3_pos(pos1: Pos, pos2: Pos) -> f32 {
+    distance3(pos1.x, pos1.y, pos1.z, pos2.x, pos2.y, pos2.z)
+}
+
+pub fn distance3(x1: f32, y1: f32, z1: f32, x2: f32, y2: f32, z2: f32) -> f32 {
+    let diff_x = x2 - x1;
+    let diff_y = y2 - y1;
+    let diff_z = z2 - z1;
+    (diff_x * diff_x + diff_y * diff_y + diff_z * diff_z).sqrt()
+}

--- a/src/game_server/handlers/zone.rs
+++ b/src/game_server/handlers/zone.rs
@@ -33,6 +33,7 @@ use super::{
         CharacterIndex, CharacterType, Chunk, DoorConfig, NpcTemplate, PreviousFixture,
         TransportConfig, WriteLockingBroadcastSupplier,
     },
+    distance3,
     guid::{Guid, GuidTable, GuidTableIndexer, GuidTableWriteHandle, IndexedGuid},
     housing::prepare_init_house_packets,
     lock_enforcer::{
@@ -1001,11 +1002,4 @@ pub fn teleport_within_zone(
     })?);
 
     Ok(vec![Broadcast::Single(sender, packets)])
-}
-
-fn distance3(x1: f32, y1: f32, z1: f32, x2: f32, y2: f32, z2: f32) -> f32 {
-    let diff_x = x2 - x1;
-    let diff_y = y2 - y1;
-    let diff_z = z2 - z1;
-    (diff_x * diff_x + diff_y * diff_y + diff_z * diff_z).sqrt()
 }

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -728,10 +728,11 @@ impl GameServer {
                 let tickable_characters_by_chunk = tickable_characters.into_iter().fold(
                     BTreeMap::new(),
                     |mut acc: BTreeMap<(u64, Chunk), Vec<u64>>, guid| {
-                        let (_, instance_guid, chunk) = characters_table_read_handle
-                            .index(guid)
-                            .expect("Tickable character disappeared despite table being locked");
-                        acc.entry((instance_guid, chunk)).or_default().push(guid);
+                        if let Some((_, instance_guid, chunk)) =
+                            characters_table_read_handle.index(guid)
+                        {
+                            acc.entry((instance_guid, chunk)).or_default().push(guid);
+                        }
                         acc
                     },
                 );

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 use std::vec;
 
 use byteorder::{LittleEndian, ReadBytesExt};
-use handlers::character::{Character, CharacterCategory, CharacterIndex, CharacterType};
+use handlers::character::{Character, CharacterCategory, CharacterIndex, CharacterType, Chunk};
 use handlers::chat::process_chat_packet;
 use handlers::command::process_command;
 use handlers::guid::{GuidTable, GuidTableIndexer, GuidTableWriteHandle, IndexedGuid};
@@ -188,87 +188,25 @@ impl GameServer {
 
     pub fn tick(&self) -> Result<Vec<Broadcast>, ProcessPacketError> {
         let now = Instant::now();
-        self.lock_enforcer()
-            .read_characters(|characters_table_read_handle| {
-                let range = (
-                    CharacterCategory::NpcTickable,
-                    u64::MIN,
-                    Character::MIN_CHUNK,
-                )
-                    ..=(
-                        CharacterCategory::NpcTickable,
-                        u64::MAX,
-                        Character::MAX_CHUNK,
-                    );
-                let tickable_characters: Vec<u64> =
-                    characters_table_read_handle.keys_by_range(range).collect();
-                CharacterLockRequest {
-                    read_guids: Vec::new(),
-                    write_guids: tickable_characters,
-                    character_consumer: |characters_table_read_handle,
-                                         _,
-                                         mut characters_write,
-                                         _| {
-                        let mut broadcasts = Vec::new();
+        let tickable_characters_by_chunk = self.tickable_characters_by_chunk();
 
-                        // We need to tick characters who update independently first, so that their dependent
-                        // characters' previous procedures are not ticked
-                        let mut characters_not_updated = Vec::new();
-                        for tickable_character in characters_write.values_mut() {
-                            if tickable_character.synchronize_with.is_none() {
-                                broadcasts.append(
-                                    &mut tickable_character.tick(now, characters_table_read_handle)?,
-                                );
-                            } else {
-                                characters_not_updated.push(tickable_character.guid());
-                            }
-                        }
+        let mut broadcasts = Vec::new();
 
-                        // Determine which procedures to update in the dependent characters
-                        let mut new_procedures = BTreeMap::new();
-                        for guid in characters_not_updated.iter() {
-                            let tickable_character = characters_write.get(guid).unwrap();
-                            if let Some(synchronize_with) = &tickable_character.synchronize_with {
-                                if let Some(synchronized_character) =
-                                    characters_write.get(synchronize_with)
-                                {
-                                    if let Some(synchronized_guid) = synchronized_character.synchronize_with {
-                                        panic!(
-                                            "Cannot synchronize character {} to a character {} because they are synchronized to character {}",
-                                            guid,
-                                            synchronized_character.guid(),
-                                            synchronized_guid
-                                        );
-                                    }
+        // Lock once for each chunk to avoid holding the lock for an extended period of time,
+        // because we are considering all characters in all worlds
+        for ((instance_guid, chunk), tickable_characters) in
+            tickable_characters_by_chunk.into_iter()
+        {
+            self.tick_single_chunk(
+                now,
+                instance_guid,
+                chunk,
+                tickable_characters,
+                &mut broadcasts,
+            )?;
+        }
 
-                                    if synchronized_character.last_procedure_change() > tickable_character.last_procedure_change() {
-                                        if let Some(key) =
-                                            synchronized_character.current_tickable_procedure()
-                                        {
-                                            new_procedures
-                                                .insert(guid, key.clone());
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        // Tick all the dependent characters
-                        for guid in characters_not_updated.iter() {
-                            let tickable_character = characters_write.get_mut(guid).unwrap();
-                            if let Some(key) = new_procedures.remove(&tickable_character.guid()) {
-                                tickable_character.set_tickable_procedure_if_exists(key, now);
-                            }
-
-                            broadcasts.append(
-                                &mut tickable_character.tick(now, characters_table_read_handle)?,
-                            );
-                        }
-
-                        Ok(broadcasts)
-                    },
-                }
-            })
+        Ok(broadcasts)
     }
 
     pub fn process_packet(
@@ -769,5 +707,126 @@ impl GameServer {
 
     pub fn zones_by_template(zones: &ZoneTableReadHandle<'_>, template_guid: u8) -> Vec<u64> {
         zones.keys_by_index(template_guid).collect()
+    }
+
+    fn tickable_characters_by_chunk(&self) -> BTreeMap<(u64, Chunk), Vec<u64>> {
+        self.lock_enforcer()
+            .read_characters(|characters_table_read_handle| {
+                let range = (
+                    CharacterCategory::NpcTickable,
+                    u64::MIN,
+                    Character::MIN_CHUNK,
+                )
+                    ..=(
+                        CharacterCategory::NpcTickable,
+                        u64::MAX,
+                        Character::MAX_CHUNK,
+                    );
+                let tickable_characters: Vec<u64> =
+                    characters_table_read_handle.keys_by_range(range).collect();
+
+                let tickable_characters_by_chunk =
+                    tickable_characters
+                        .into_iter()
+                        .fold(BTreeMap::new(), |mut acc, guid| {
+                            let (_, instance_guid, chunk) =
+                                characters_table_read_handle.index(guid).expect(
+                                    "Tickable character disappeared despite table being locked",
+                                );
+                            acc.entry((instance_guid, chunk))
+                                .or_insert_with(Vec::new)
+                                .push(guid);
+                            acc
+                        });
+
+                CharacterLockRequest {
+                    read_guids: Vec::new(),
+                    write_guids: Vec::new(),
+                    character_consumer: |_, _, _, _| tickable_characters_by_chunk,
+                }
+            })
+    }
+
+    fn tick_single_chunk(
+        &self,
+        now: Instant,
+        instance_guid: u64,
+        chunk: Chunk,
+        tickable_characters: Vec<u64>,
+        broadcasts: &mut Vec<Broadcast>,
+    ) -> Result<(), ProcessPacketError> {
+        self.lock_enforcer().read_characters(|characters_table_read_handle| {
+            let nearby_player_guids = Zone::all_players_nearby(None, chunk, instance_guid, characters_table_read_handle)
+                .unwrap_or_default();
+            let nearby_players: Vec<u64> = nearby_player_guids.iter()
+                .map(|guid| *guid as u64)
+                .collect();
+
+            CharacterLockRequest {
+                read_guids: nearby_players.clone(),
+                write_guids: tickable_characters,
+                character_consumer: move |_,
+                characters_read,
+                mut characters_write,
+                _| {
+
+                    // We need to tick characters who update independently first, so that their dependent
+                    // characters' previous procedures are not ticked
+                    let mut characters_not_updated = Vec::new();
+                    for tickable_character in characters_write.values_mut() {
+                        if tickable_character.synchronize_with.is_none() {
+                            broadcasts.append(
+                                &mut tickable_character.tick(now, nearby_player_guids.clone(), &characters_read)?,
+                            );
+                        } else {
+                            characters_not_updated.push(tickable_character.guid());
+                        }
+                    }
+
+                    // Determine which procedures to update in the dependent characters
+                    let mut new_procedures = BTreeMap::new();
+                    for guid in characters_not_updated.iter() {
+                        let tickable_character = characters_write.get(guid).unwrap();
+                        if let Some(synchronize_with) = &tickable_character.synchronize_with {
+                            if let Some(synchronized_character) =
+                                characters_write.get(synchronize_with)
+                            {
+                                if let Some(synchronized_guid) = synchronized_character.synchronize_with {
+                                    panic!(
+                                        "Cannot synchronize character {} to a character {} because they are synchronized to character {}",
+                                        guid,
+                                        synchronized_character.guid(),
+                                        synchronized_guid
+                                    );
+                                }
+
+                                if synchronized_character.last_procedure_change() > tickable_character.last_procedure_change() {
+                                    if let Some(key) =
+                                        synchronized_character.current_tickable_procedure()
+                                    {
+                                        new_procedures
+                                            .insert(guid, key.clone());
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // Tick all the dependent characters
+                    for guid in characters_not_updated.iter() {
+                        let tickable_character = characters_write.get_mut(guid).unwrap();
+                        if let Some(key) = new_procedures.remove(&tickable_character.guid()) {
+                            tickable_character.set_tickable_procedure_if_exists(key, now);
+                        }
+
+                        broadcasts.append(
+                            &mut tickable_character.tick(now, nearby_player_guids.clone(), &characters_read)?,
+                        );
+                    }
+
+                    Ok(())
+                },
+            }
+        })
     }
 }

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -728,6 +728,7 @@ impl GameServer {
                 let tickable_characters_by_chunk = tickable_characters.into_iter().fold(
                     BTreeMap::new(),
                     |mut acc: BTreeMap<(u64, Chunk), Vec<u64>>, guid| {
+                        // The NPC could have been removed since we last acquired the table read lock
                         if let Some((_, instance_guid, chunk)) =
                             characters_table_read_handle.index(guid)
                         {


### PR DESCRIPTION
The current NPC ticking implementation has multiple flaws:
* We lock all tickable characters, in all instances, in all worlds at the same time. It is expensive to both acquire and hold all these locks when there are many characters.
* We don't yet know whether combat NPCs will have to be tickable. It is possible that we will have a much larger number of tickable NPCs than we expect, meaning the previous point would have even larger impact.
* If we need to perform any operations on the surrounding players, we would have to read lock _all_ players, everywhere. This is because we cannot acquire the tickable NPC write locks and then acquire the player read locks. We have to acquire all character locks in GUID order to avoid deadlock, as required by the lock enforcer.

The new implementation only ticks NPCs in one chunk at a time. We release the lock on the characters table in between ticking chunks, which allows packet handlers in other threads to proceed in between chunks if they have been waiting for a long time. This implementation also allows us to only lock players in the NPC's chunk and neighboring chunks, which means it's feasible to read data from those players.

This enables us to limit NPC chat messages to a smaller area than the chunk-based broadcasting allows. For example, we don't want the joke clones to spam the entire hangar with chat messages, or have players 600 units away receive NPC attack messages in a combat zone. See [this footage](https://www.youtube.com/watch?v=RN-yG9DGstk&ab_channel=HarleenQuinzel) from live that demonstrates that players did not receive the joke clones' messages from everywhere in the hangar.

The 32 unit radius for NPC chat messages is the radius at which chat bubbles are visible.