### PR TITLE
Fix item names being used as descriptions

### DIFF
--- a/config/items.json
+++ b/config/items.json
@@ -2,7 +2,7 @@
     {
         "guid": 6,
         "name_id": 0,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1756,
         "unknown6": 0,
         "tint": 0,
@@ -46,7 +46,7 @@
     {
         "guid": 7,
         "name_id": 0,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 0,
         "unknown6": 0,
         "tint": 0,
@@ -90,7 +90,7 @@
     {
         "guid": 8,
         "name_id": 0,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 0,
         "unknown6": 0,
         "tint": 0,
@@ -134,7 +134,7 @@
     {
         "guid": 9,
         "name_id": 0,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 0,
         "unknown6": 0,
         "tint": 0,
@@ -178,7 +178,7 @@
     {
         "guid": 10,
         "name_id": 0,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 0,
         "unknown6": 0,
         "tint": 0,
@@ -222,7 +222,7 @@
     {
         "guid": 10000,
         "name_id": 914,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 432,
         "unknown6": 0,
         "tint": 0,
@@ -266,7 +266,7 @@
     {
         "guid": 10001,
         "name_id": 44503,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1986,
         "unknown6": 0,
         "tint": 0,
@@ -310,7 +310,7 @@
     {
         "guid": 10002,
         "name_id": 2667,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2298,
         "unknown6": 0,
         "tint": 0,
@@ -354,7 +354,7 @@
     {
         "guid": 10003,
         "name_id": 44378,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1978,
         "unknown6": 0,
         "tint": 0,
@@ -398,7 +398,7 @@
     {
         "guid": 10004,
         "name_id": 920,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 436,
         "unknown6": 0,
         "tint": 0,
@@ -442,7 +442,7 @@
     {
         "guid": 10005,
         "name_id": 1897,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1444,
         "unknown6": 0,
         "tint": 0,
@@ -486,7 +486,7 @@
     {
         "guid": 10006,
         "name_id": 44191,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1957,
         "unknown6": 0,
         "tint": 0,
@@ -530,7 +530,7 @@
     {
         "guid": 10007,
         "name_id": 4450,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2508,
         "unknown6": 0,
         "tint": 0,
@@ -574,7 +574,7 @@
     {
         "guid": 10008,
         "name_id": 2899,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2323,
         "unknown6": 0,
         "tint": 0,
@@ -618,7 +618,7 @@
     {
         "guid": 10009,
         "name_id": 2514,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 80,
         "unknown6": 0,
         "tint": 0,
@@ -662,7 +662,7 @@
     {
         "guid": 10010,
         "name_id": 1903,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1445,
         "unknown6": 0,
         "tint": 0,
@@ -706,7 +706,7 @@
     {
         "guid": 10011,
         "name_id": 43963,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1947,
         "unknown6": 0,
         "tint": 0,
@@ -750,7 +750,7 @@
     {
         "guid": 10012,
         "name_id": 44842,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2099,
         "unknown6": 0,
         "tint": 0,
@@ -794,7 +794,7 @@
     {
         "guid": 10013,
         "name_id": 44669,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2008,
         "unknown6": 0,
         "tint": 0,
@@ -838,7 +838,7 @@
     {
         "guid": 10014,
         "name_id": 2673,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 673,
         "unknown6": 0,
         "tint": 0,
@@ -882,7 +882,7 @@
     {
         "guid": 10015,
         "name_id": 4671,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2731,
         "unknown6": 0,
         "tint": 0,
@@ -926,7 +926,7 @@
     {
         "guid": 10016,
         "name_id": 138,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 81,
         "unknown6": 0,
         "tint": 0,
@@ -970,7 +970,7 @@
     {
         "guid": 10017,
         "name_id": 146,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 82,
         "unknown6": 0,
         "tint": 0,
@@ -1014,7 +1014,7 @@
     {
         "guid": 10018,
         "name_id": 1727,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1406,
         "unknown6": 0,
         "tint": 0,
@@ -1058,7 +1058,7 @@
     {
         "guid": 10019,
         "name_id": 1612,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1244,
         "unknown6": 0,
         "tint": 0,
@@ -1102,7 +1102,7 @@
     {
         "guid": 10020,
         "name_id": 2949,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2388,
         "unknown6": 0,
         "tint": 0,
@@ -1146,7 +1146,7 @@
     {
         "guid": 10021,
         "name_id": 54470,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3714,
         "unknown6": 0,
         "tint": 0,
@@ -1190,7 +1190,7 @@
     {
         "guid": 10022,
         "name_id": 54508,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3763,
         "unknown6": 0,
         "tint": 0,
@@ -1234,7 +1234,7 @@
     {
         "guid": 10023,
         "name_id": 4552,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2634,
         "unknown6": 0,
         "tint": 0,
@@ -1278,7 +1278,7 @@
     {
         "guid": 10024,
         "name_id": 54255,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3634,
         "unknown6": 0,
         "tint": 0,
@@ -1322,7 +1322,7 @@
     {
         "guid": 10025,
         "name_id": 4703,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2751,
         "unknown6": 0,
         "tint": 0,
@@ -1366,7 +1366,7 @@
     {
         "guid": 10026,
         "name_id": 60670,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3781,
         "unknown6": 0,
         "tint": 0,
@@ -1410,7 +1410,7 @@
     {
         "guid": 10027,
         "name_id": 1454,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 673,
         "unknown6": 0,
         "tint": 0,
@@ -1454,7 +1454,7 @@
     {
         "guid": 10028,
         "name_id": 154,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 83,
         "unknown6": 0,
         "tint": 0,
@@ -1498,7 +1498,7 @@
     {
         "guid": 10029,
         "name_id": 2390,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2366,
         "unknown6": 0,
         "tint": 0,
@@ -1542,7 +1542,7 @@
     {
         "guid": 10030,
         "name_id": 4739,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2779,
         "unknown6": 0,
         "tint": 0,
@@ -1586,7 +1586,7 @@
     {
         "guid": 10031,
         "name_id": 814,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 439,
         "unknown6": 0,
         "tint": 0,
@@ -1630,7 +1630,7 @@
     {
         "guid": 10032,
         "name_id": 8510,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 84,
         "unknown6": 0,
         "tint": 0,
@@ -1674,7 +1674,7 @@
     {
         "guid": 10033,
         "name_id": 4586,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2652,
         "unknown6": 0,
         "tint": 0,
@@ -1718,7 +1718,7 @@
     {
         "guid": 10034,
         "name_id": 2340,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2328,
         "unknown6": 0,
         "tint": 0,
@@ -1762,7 +1762,7 @@
     {
         "guid": 10035,
         "name_id": 52062,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2971,
         "unknown6": 0,
         "tint": 0,
@@ -1806,7 +1806,7 @@
     {
         "guid": 10036,
         "name_id": 820,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 442,
         "unknown6": 0,
         "tint": 0,
@@ -1850,7 +1850,7 @@
     {
         "guid": 10037,
         "name_id": 1642,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1323,
         "unknown6": 0,
         "tint": 0,
@@ -1894,7 +1894,7 @@
     {
         "guid": 10038,
         "name_id": 20052,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1469,
         "unknown6": 0,
         "tint": 0,
@@ -1938,7 +1938,7 @@
     {
         "guid": 10039,
         "name_id": 43058,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1743,
         "unknown6": 0,
         "tint": 0,
@@ -1982,7 +1982,7 @@
     {
         "guid": 10040,
         "name_id": 1297,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1121,
         "unknown6": 0,
         "tint": 0,
@@ -2026,7 +2026,7 @@
     {
         "guid": 10041,
         "name_id": 1299,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1125,
         "unknown6": 0,
         "tint": 0,
@@ -2070,7 +2070,7 @@
     {
         "guid": 10042,
         "name_id": 1301,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1129,
         "unknown6": 0,
         "tint": 0,
@@ -2114,7 +2114,7 @@
     {
         "guid": 10043,
         "name_id": 1303,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1133,
         "unknown6": 0,
         "tint": 0,
@@ -2158,7 +2158,7 @@
     {
         "guid": 10044,
         "name_id": 43062,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1747,
         "unknown6": 0,
         "tint": 0,
@@ -2202,7 +2202,7 @@
     {
         "guid": 10045,
         "name_id": 1307,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1137,
         "unknown6": 0,
         "tint": 0,
@@ -2246,7 +2246,7 @@
     {
         "guid": 10046,
         "name_id": 836,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 454,
         "unknown6": 0,
         "tint": 0,
@@ -2290,7 +2290,7 @@
     {
         "guid": 10047,
         "name_id": 2506,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 89,
         "unknown6": 0,
         "tint": 0,
@@ -2334,7 +2334,7 @@
     {
         "guid": 10048,
         "name_id": 8926,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 87,
         "unknown6": 0,
         "tint": 0,
@@ -2378,7 +2378,7 @@
     {
         "guid": 10049,
         "name_id": 8934,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 88,
         "unknown6": 0,
         "tint": 0,
@@ -2422,7 +2422,7 @@
     {
         "guid": 10050,
         "name_id": 162,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 85,
         "unknown6": 0,
         "tint": 0,
@@ -2466,7 +2466,7 @@
     {
         "guid": 10051,
         "name_id": 186,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 86,
         "unknown6": 0,
         "tint": 0,
@@ -2510,7 +2510,7 @@
     {
         "guid": 10052,
         "name_id": 1178,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 372,
         "unknown6": 0,
         "tint": 0,
@@ -2554,7 +2554,7 @@
     {
         "guid": 10053,
         "name_id": 936,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 468,
         "unknown6": 0,
         "tint": 0,
@@ -2598,7 +2598,7 @@
     {
         "guid": 10054,
         "name_id": 20313,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1484,
         "unknown6": 0,
         "tint": 0,
@@ -2642,7 +2642,7 @@
     {
         "guid": 10055,
         "name_id": 43687,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1864,
         "unknown6": 0,
         "tint": 0,
@@ -2686,7 +2686,7 @@
     {
         "guid": 10056,
         "name_id": 2709,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 673,
         "unknown6": 0,
         "tint": 0,
@@ -2730,7 +2730,7 @@
     {
         "guid": 10057,
         "name_id": 2705,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 673,
         "unknown6": 0,
         "tint": 0,
@@ -2774,7 +2774,7 @@
     {
         "guid": 10058,
         "name_id": 14164,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 446,
         "unknown6": 0,
         "tint": 0,
@@ -2818,7 +2818,7 @@
     {
         "guid": 10059,
         "name_id": 44752,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2014,
         "unknown6": 0,
         "tint": 0,
@@ -2862,7 +2862,7 @@
     {
         "guid": 10060,
         "name_id": 54532,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3800,
         "unknown6": 0,
         "tint": 0,
@@ -2906,7 +2906,7 @@
     {
         "guid": 10061,
         "name_id": 53966,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3268,
         "unknown6": 0,
         "tint": 0,
@@ -2950,7 +2950,7 @@
     {
         "guid": 10062,
         "name_id": 2681,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 673,
         "unknown6": 0,
         "tint": 0,
@@ -2994,7 +2994,7 @@
     {
         "guid": 10063,
         "name_id": 43683,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1860,
         "unknown6": 0,
         "tint": 0,
@@ -3038,7 +3038,7 @@
     {
         "guid": 10064,
         "name_id": 33103,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1648,
         "unknown6": 0,
         "tint": 0,
@@ -3082,7 +3082,7 @@
     {
         "guid": 10065,
         "name_id": 43715,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1892,
         "unknown6": 0,
         "tint": 0,
@@ -3126,7 +3126,7 @@
     {
         "guid": 10066,
         "name_id": 43723,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1900,
         "unknown6": 0,
         "tint": 0,
@@ -3170,7 +3170,7 @@
     {
         "guid": 10067,
         "name_id": 43719,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1896,
         "unknown6": 0,
         "tint": 0,
@@ -3214,7 +3214,7 @@
     {
         "guid": 10068,
         "name_id": 43727,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1904,
         "unknown6": 0,
         "tint": 0,
@@ -3258,7 +3258,7 @@
     {
         "guid": 10069,
         "name_id": 43679,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1856,
         "unknown6": 0,
         "tint": 0,
@@ -3302,7 +3302,7 @@
     {
         "guid": 10070,
         "name_id": 54085,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3338,
         "unknown6": 0,
         "tint": 0,
@@ -3346,7 +3346,7 @@
     {
         "guid": 10071,
         "name_id": 33107,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1652,
         "unknown6": 0,
         "tint": 0,
@@ -3390,7 +3390,7 @@
     {
         "guid": 10072,
         "name_id": 60181,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3722,
         "unknown6": 0,
         "tint": 0,
@@ -3434,7 +3434,7 @@
     {
         "guid": 10073,
         "name_id": 828,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 450,
         "unknown6": 0,
         "tint": 0,
@@ -3478,7 +3478,7 @@
     {
         "guid": 10074,
         "name_id": 3074,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 673,
         "unknown6": 0,
         "tint": 0,
@@ -3522,7 +3522,7 @@
     {
         "guid": 10075,
         "name_id": 1559,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2836,
         "unknown6": 0,
         "tint": 0,
@@ -3566,7 +3566,7 @@
     {
         "guid": 10076,
         "name_id": 4356,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2466,
         "unknown6": 0,
         "tint": 0,
@@ -3610,7 +3610,7 @@
     {
         "guid": 10077,
         "name_id": 54514,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3768,
         "unknown6": 0,
         "tint": 0,
@@ -3654,7 +3654,7 @@
     {
         "guid": 10078,
         "name_id": 54543,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3809,
         "unknown6": 0,
         "tint": 0,
@@ -3698,7 +3698,7 @@
     {
         "guid": 10079,
         "name_id": 54281,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3651,
         "unknown6": 0,
         "tint": 0,
@@ -3742,7 +3742,7 @@
     {
         "guid": 10080,
         "name_id": 52799,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3104,
         "unknown6": 0,
         "tint": 0,
@@ -3786,7 +3786,7 @@
     {
         "guid": 10081,
         "name_id": 866,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 476,
         "unknown6": 0,
         "tint": 0,
@@ -3830,7 +3830,7 @@
     {
         "guid": 10082,
         "name_id": 4388,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2470,
         "unknown6": 0,
         "tint": 0,
@@ -3874,7 +3874,7 @@
     {
         "guid": 10083,
         "name_id": 20321,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1488,
         "unknown6": 0,
         "tint": 0,
@@ -3918,7 +3918,7 @@
     {
         "guid": 10084,
         "name_id": 0,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 373,
         "unknown6": 0,
         "tint": 0,
@@ -3962,7 +3962,7 @@
     {
         "guid": 10085,
         "name_id": 44893,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2128,
         "unknown6": 0,
         "tint": 0,
@@ -4006,7 +4006,7 @@
     {
         "guid": 10086,
         "name_id": 4307,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2411,
         "unknown6": 0,
         "tint": 0,
@@ -4050,7 +4050,7 @@
     {
         "guid": 10087,
         "name_id": 2382,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2348,
         "unknown6": 0,
         "tint": 0,
@@ -4094,7 +4094,7 @@
     {
         "guid": 10088,
         "name_id": 2370,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2344,
         "unknown6": 0,
         "tint": 0,
@@ -4138,7 +4138,7 @@
     {
         "guid": 10089,
         "name_id": 43699,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 89,
         "unknown6": 0,
         "tint": 0,
@@ -4182,7 +4182,7 @@
     {
         "guid": 10090,
         "name_id": 4915,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2945,
         "unknown6": 0,
         "tint": 0,
@@ -4226,7 +4226,7 @@
     {
         "guid": 10091,
         "name_id": 4911,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2941,
         "unknown6": 0,
         "tint": 0,
@@ -4270,7 +4270,7 @@
     {
         "guid": 10092,
         "name_id": 53725,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3242,
         "unknown6": 0,
         "tint": 0,
@@ -4314,7 +4314,7 @@
     {
         "guid": 10093,
         "name_id": 54275,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3646,
         "unknown6": 0,
         "tint": 0,
@@ -4358,7 +4358,7 @@
     {
         "guid": 10094,
         "name_id": 54411,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3681,
         "unknown6": 0,
         "tint": 0,
@@ -4402,7 +4402,7 @@
     {
         "guid": 10095,
         "name_id": 54579,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3824,
         "unknown6": 0,
         "tint": 0,
@@ -4446,7 +4446,7 @@
     {
         "guid": 10096,
         "name_id": 4278,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2397,
         "unknown6": 0,
         "tint": 0,
@@ -4490,7 +4490,7 @@
     {
         "guid": 10097,
         "name_id": 4919,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2949,
         "unknown6": 0,
         "tint": 0,
@@ -4534,7 +4534,7 @@
     {
         "guid": 10098,
         "name_id": 4392,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2485,
         "unknown6": 0,
         "tint": 0,
@@ -4578,7 +4578,7 @@
     {
         "guid": 10099,
         "name_id": 4544,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2626,
         "unknown6": 0,
         "tint": 0,
@@ -4622,7 +4622,7 @@
     {
         "guid": 10100,
         "name_id": 54269,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3642,
         "unknown6": 0,
         "tint": 0,
@@ -4666,7 +4666,7 @@
     {
         "guid": 10101,
         "name_id": 2943,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2378,
         "unknown6": 0,
         "tint": 0,
@@ -4710,7 +4710,7 @@
     {
         "guid": 10102,
         "name_id": 4480,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2569,
         "unknown6": 0,
         "tint": 0,
@@ -4754,7 +4754,7 @@
     {
         "guid": 10103,
         "name_id": 8530,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 90,
         "unknown6": 0,
         "tint": 0,
@@ -4798,7 +4798,7 @@
     {
         "guid": 10104,
         "name_id": 8532,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 93,
         "unknown6": 0,
         "tint": 0,
@@ -4842,7 +4842,7 @@
     {
         "guid": 10105,
         "name_id": 8908,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 92,
         "unknown6": 0,
         "tint": 0,
@@ -4886,7 +4886,7 @@
     {
         "guid": 10106,
         "name_id": 170,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 91,
         "unknown6": 0,
         "tint": 0,
@@ -4930,7 +4930,7 @@
     {
         "guid": 10107,
         "name_id": 1458,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1076,
         "unknown6": 0,
         "tint": 0,
@@ -4974,7 +4974,7 @@
     {
         "guid": 10108,
         "name_id": 32977,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1608,
         "unknown6": 0,
         "tint": 0,
@@ -5018,7 +5018,7 @@
     {
         "guid": 10109,
         "name_id": 43711,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1888,
         "unknown6": 0,
         "tint": 0,
@@ -5062,7 +5062,7 @@
     {
         "guid": 10110,
         "name_id": 54554,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3818,
         "unknown6": 0,
         "tint": 0,
@@ -5106,7 +5106,7 @@
     {
         "guid": 10111,
         "name_id": 8888,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 94,
         "unknown6": 0,
         "tint": 0,
@@ -5150,7 +5150,7 @@
     {
         "guid": 10112,
         "name_id": 20301,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1504,
         "unknown6": 0,
         "tint": 0,
@@ -5194,7 +5194,7 @@
     {
         "guid": 10113,
         "name_id": 44757,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2030,
         "unknown6": 0,
         "tint": 0,
@@ -5238,7 +5238,7 @@
     {
         "guid": 10114,
         "name_id": 14172,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 491,
         "unknown6": 0,
         "tint": 0,
@@ -5282,7 +5282,7 @@
     {
         "guid": 10115,
         "name_id": 53650,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3217,
         "unknown6": 0,
         "tint": 0,
@@ -5326,7 +5326,7 @@
     {
         "guid": 10116,
         "name_id": 44888,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2122,
         "unknown6": 0,
         "tint": 0,
@@ -5370,7 +5370,7 @@
     {
         "guid": 10117,
         "name_id": 44883,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2115,
         "unknown6": 0,
         "tint": 0,
@@ -5414,7 +5414,7 @@
     {
         "guid": 10118,
         "name_id": 1186,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 374,
         "unknown6": 0,
         "tint": 0,
@@ -5458,7 +5458,7 @@
     {
         "guid": 10119,
         "name_id": 842,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 458,
         "unknown6": 0,
         "tint": 0,
@@ -5502,7 +5502,7 @@
     {
         "guid": 10120,
         "name_id": 1911,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1448,
         "unknown6": 0,
         "tint": 0,
@@ -5546,7 +5546,7 @@
     {
         "guid": 10121,
         "name_id": 1202,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 375,
         "unknown6": 0,
         "tint": 0,
@@ -5590,7 +5590,7 @@
     {
         "guid": 10122,
         "name_id": 1309,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1080,
         "unknown6": 0,
         "tint": 0,
@@ -5634,7 +5634,7 @@
     {
         "guid": 10123,
         "name_id": 32929,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1080,
         "unknown6": 0,
         "tint": 0,
@@ -5678,7 +5678,7 @@
     {
         "guid": 10124,
         "name_id": 54495,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3748,
         "unknown6": 0,
         "tint": 0,
@@ -5722,7 +5722,7 @@
     {
         "guid": 10125,
         "name_id": 33885,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1669,
         "unknown6": 0,
         "tint": 0,
@@ -5766,7 +5766,7 @@
     {
         "guid": 10126,
         "name_id": 43731,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1908,
         "unknown6": 0,
         "tint": 0,
@@ -5810,7 +5810,7 @@
     {
         "guid": 10127,
         "name_id": 43691,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1868,
         "unknown6": 0,
         "tint": 0,
@@ -5854,7 +5854,7 @@
     {
         "guid": 10128,
         "name_id": 4747,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2787,
         "unknown6": 0,
         "tint": 0,
@@ -5898,7 +5898,7 @@
     {
         "guid": 10129,
         "name_id": 4743,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2783,
         "unknown6": 0,
         "tint": 0,
@@ -5942,7 +5942,7 @@
     {
         "guid": 10130,
         "name_id": 2685,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2852,
         "unknown6": 0,
         "tint": 0,
@@ -5986,7 +5986,7 @@
     {
         "guid": 10131,
         "name_id": 4926,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1876,
         "unknown6": 0,
         "tint": 0,
@@ -6030,7 +6030,7 @@
     {
         "guid": 10132,
         "name_id": 43703,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1880,
         "unknown6": 0,
         "tint": 0,
@@ -6074,7 +6074,7 @@
     {
         "guid": 10133,
         "name_id": 54481,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3706,
         "unknown6": 0,
         "tint": 0,
@@ -6118,7 +6118,7 @@
     {
         "guid": 10134,
         "name_id": 14780,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 461,
         "unknown6": 0,
         "tint": 0,
@@ -6162,7 +6162,7 @@
     {
         "guid": 10135,
         "name_id": 1565,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 673,
         "unknown6": 0,
         "tint": 0,
@@ -6206,7 +6206,7 @@
     {
         "guid": 10136,
         "name_id": 53717,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3234,
         "unknown6": 0,
         "tint": 0,
@@ -6250,7 +6250,7 @@
     {
         "guid": 10137,
         "name_id": 53713,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3230,
         "unknown6": 0,
         "tint": 0,
@@ -6294,7 +6294,7 @@
     {
         "guid": 10138,
         "name_id": 53709,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3226,
         "unknown6": 0,
         "tint": 0,
@@ -6338,7 +6338,7 @@
     {
         "guid": 10139,
         "name_id": 53721,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3238,
         "unknown6": 0,
         "tint": 0,
@@ -6382,7 +6382,7 @@
     {
         "guid": 10140,
         "name_id": 4905,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2936,
         "unknown6": 0,
         "tint": 0,
@@ -6426,7 +6426,7 @@
     {
         "guid": 10141,
         "name_id": 54249,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3629,
         "unknown6": 0,
         "tint": 0,
@@ -6470,7 +6470,7 @@
     {
         "guid": 10142,
         "name_id": 178,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 95,
         "unknown6": 0,
         "tint": 0,
@@ -6514,7 +6514,7 @@
     {
         "guid": 10143,
         "name_id": 1194,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 376,
         "unknown6": 0,
         "tint": 0,
@@ -6558,7 +6558,7 @@
     {
         "guid": 10144,
         "name_id": 2697,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2591,
         "unknown6": 0,
         "tint": 0,
@@ -6602,7 +6602,7 @@
     {
         "guid": 10145,
         "name_id": 2701,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 673,
         "unknown6": 0,
         "tint": 0,
@@ -6646,7 +6646,7 @@
     {
         "guid": 10146,
         "name_id": 2693,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2741,
         "unknown6": 0,
         "tint": 0,
@@ -6690,7 +6690,7 @@
     {
         "guid": 10147,
         "name_id": 4303,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2423,
         "unknown6": 0,
         "tint": 0,
@@ -6734,7 +6734,7 @@
     {
         "guid": 10148,
         "name_id": 2664,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2164,
         "unknown6": 0,
         "tint": 0,
@@ -6778,7 +6778,7 @@
     {
         "guid": 10149,
         "name_id": 4683,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2737,
         "unknown6": 0,
         "tint": 0,
@@ -6822,7 +6822,7 @@
     {
         "guid": 10150,
         "name_id": 4625,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2690,
         "unknown6": 0,
         "tint": 0,
@@ -6866,7 +6866,7 @@
     {
         "guid": 10151,
         "name_id": 1460,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1092,
         "unknown6": 0,
         "tint": 0,
@@ -6910,7 +6910,7 @@
     {
         "guid": 10152,
         "name_id": 1311,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1084,
         "unknown6": 0,
         "tint": 0,
@@ -6954,7 +6954,7 @@
     {
         "guid": 10153,
         "name_id": 1845,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1378,
         "unknown6": 0,
         "tint": 0,
@@ -6998,7 +6998,7 @@
     {
         "guid": 10154,
         "name_id": 1313,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1088,
         "unknown6": 0,
         "tint": 0,
@@ -7042,7 +7042,7 @@
     {
         "guid": 10155,
         "name_id": 44891,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2125,
         "unknown6": 0,
         "tint": 0,
@@ -7086,7 +7086,7 @@
     {
         "guid": 10156,
         "name_id": 54600,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3833,
         "unknown6": 0,
         "tint": 0,
@@ -7130,7 +7130,7 @@
     {
         "guid": 10157,
         "name_id": 60289,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3738,
         "unknown6": 0,
         "tint": 0,
@@ -7174,7 +7174,7 @@
     {
         "guid": 10158,
         "name_id": 894,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 498,
         "unknown6": 0,
         "tint": 0,
@@ -7218,7 +7218,7 @@
     {
         "guid": 10159,
         "name_id": 43695,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1872,
         "unknown6": 0,
         "tint": 0,
@@ -7262,7 +7262,7 @@
     {
         "guid": 10160,
         "name_id": 850,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 464,
         "unknown6": 0,
         "tint": 0,
@@ -7306,7 +7306,7 @@
     {
         "guid": 10161,
         "name_id": 43515,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1838,
         "unknown6": 0,
         "tint": 0,
@@ -7350,7 +7350,7 @@
     {
         "guid": 10162,
         "name_id": 856,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 471,
         "unknown6": 0,
         "tint": 0,
@@ -7394,7 +7394,7 @@
     {
         "guid": 10163,
         "name_id": 2356,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2331,
         "unknown6": 0,
         "tint": 0,
@@ -7438,7 +7438,7 @@
     {
         "guid": 10164,
         "name_id": 302,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 96,
         "unknown6": 0,
         "tint": 0,
@@ -7482,7 +7482,7 @@
     {
         "guid": 10165,
         "name_id": 302,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 673,
         "unknown6": 0,
         "tint": 0,
@@ -7526,7 +7526,7 @@
     {
         "guid": 10166,
         "name_id": 302,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3839,
         "unknown6": 0,
         "tint": 0,
@@ -7570,7 +7570,7 @@
     {
         "guid": 10167,
         "name_id": 1315,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1096,
         "unknown6": 0,
         "tint": 0,
@@ -7614,7 +7614,7 @@
     {
         "guid": 10168,
         "name_id": 1650,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 673,
         "unknown6": 0,
         "tint": 0,
@@ -7658,7 +7658,7 @@
     {
         "guid": 10169,
         "name_id": 1573,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1319,
         "unknown6": 0,
         "tint": 0,
@@ -7702,7 +7702,7 @@
     {
         "guid": 10170,
         "name_id": 54476,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3710,
         "unknown6": 0,
         "tint": 0,
@@ -7746,7 +7746,7 @@
     {
         "guid": 10171,
         "name_id": 194,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 97,
         "unknown6": 0,
         "tint": 0,
@@ -7790,7 +7790,7 @@
     {
         "guid": 10172,
         "name_id": 52886,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3813,
         "unknown6": 0,
         "tint": 0,
@@ -7834,7 +7834,7 @@
     {
         "guid": 10173,
         "name_id": 198,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 98,
         "unknown6": 0,
         "tint": 0,
@@ -7878,7 +7878,7 @@
     {
         "guid": 10174,
         "name_id": 43511,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1842,
         "unknown6": 0,
         "tint": 0,
@@ -7922,7 +7922,7 @@
     {
         "guid": 10175,
         "name_id": 1620,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1246,
         "unknown6": 0,
         "tint": 0,
@@ -7966,7 +7966,7 @@
     {
         "guid": 10176,
         "name_id": 44879,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2110,
         "unknown6": 0,
         "tint": 0,
@@ -8010,7 +8010,7 @@
     {
         "guid": 10177,
         "name_id": 2677,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3334,
         "unknown6": 0,
         "tint": 0,
@@ -8054,7 +8054,7 @@
     {
         "guid": 10178,
         "name_id": 8902,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 99,
         "unknown6": 0,
         "tint": 0,
@@ -8098,7 +8098,7 @@
     {
         "guid": 10179,
         "name_id": 4715,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2762,
         "unknown6": 0,
         "tint": 0,
@@ -8142,7 +8142,7 @@
     {
         "guid": 10180,
         "name_id": 204,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 100,
         "unknown6": 0,
         "tint": 0,
@@ -8186,7 +8186,7 @@
     {
         "guid": 10181,
         "name_id": 204,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 673,
         "unknown6": 0,
         "tint": 0,
@@ -8230,7 +8230,7 @@
     {
         "guid": 10182,
         "name_id": 54605,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3837,
         "unknown6": 0,
         "tint": 0,
@@ -8274,7 +8274,7 @@
     {
         "guid": 10183,
         "name_id": 1577,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1237,
         "unknown6": 0,
         "tint": 0,
@@ -8318,7 +8318,7 @@
     {
         "guid": 10184,
         "name_id": 1462,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1100,
         "unknown6": 0,
         "tint": 0,
@@ -8362,7 +8362,7 @@
     {
         "guid": 10185,
         "name_id": 1462,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3841,
         "unknown6": 0,
         "tint": 0,
@@ -8406,7 +8406,7 @@
     {
         "guid": 10186,
         "name_id": 1462,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 673,
         "unknown6": 0,
         "tint": 0,
@@ -8450,7 +8450,7 @@
     {
         "guid": 10187,
         "name_id": 4821,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2855,
         "unknown6": 0,
         "tint": 0,
@@ -8494,7 +8494,7 @@
     {
         "guid": 10188,
         "name_id": 20305,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1480,
         "unknown6": 0,
         "tint": 0,
@@ -8538,7 +8538,7 @@
     {
         "guid": 10189,
         "name_id": 52787,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3110,
         "unknown6": 0,
         "tint": 0,
@@ -8582,7 +8582,7 @@
     {
         "guid": 10190,
         "name_id": 361,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 101,
         "unknown6": 0,
         "tint": 0,
@@ -8626,7 +8626,7 @@
     {
         "guid": 10191,
         "name_id": 210,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 102,
         "unknown6": 0,
         "tint": 0,
@@ -8670,7 +8670,7 @@
     {
         "guid": 10192,
         "name_id": 0,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 673,
         "unknown6": 0,
         "tint": 0,
@@ -8714,7 +8714,7 @@
     {
         "guid": 10193,
         "name_id": 4548,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2630,
         "unknown6": 0,
         "tint": 0,
@@ -8758,7 +8758,7 @@
     {
         "guid": 10194,
         "name_id": 8896,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 103,
         "unknown6": 0,
         "tint": 0,
@@ -8802,7 +8802,7 @@
     {
         "guid": 10195,
         "name_id": 4764,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2806,
         "unknown6": 0,
         "tint": 0,
@@ -8846,7 +8846,7 @@
     {
         "guid": 10196,
         "name_id": 1848,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1383,
         "unknown6": 0,
         "tint": 0,
@@ -8890,7 +8890,7 @@
     {
         "guid": 10197,
         "name_id": 1769,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1374,
         "unknown6": 0,
         "tint": 0,
@@ -8934,7 +8934,7 @@
     {
         "guid": 10198,
         "name_id": 1743,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1342,
         "unknown6": 0,
         "tint": 0,
@@ -8978,7 +8978,7 @@
     {
         "guid": 10199,
         "name_id": 43707,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1884,
         "unknown6": 0,
         "tint": 0,
@@ -9022,7 +9022,7 @@
     {
         "guid": 10200,
         "name_id": 54416,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3687,
         "unknown6": 0,
         "tint": 0,
@@ -9066,7 +9066,7 @@
     {
         "guid": 10201,
         "name_id": 54435,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3699,
         "unknown6": 0,
         "tint": 0,
@@ -9110,7 +9110,7 @@
     {
         "guid": 10202,
         "name_id": 216,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 104,
         "unknown6": 0,
         "tint": 0,
@@ -9154,7 +9154,7 @@
     {
         "guid": 10203,
         "name_id": 52806,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3139,
         "unknown6": 0,
         "tint": 0,
@@ -9198,7 +9198,7 @@
     {
         "guid": 10204,
         "name_id": 1923,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1452,
         "unknown6": 0,
         "tint": 0,
@@ -9242,7 +9242,7 @@
     {
         "guid": 10205,
         "name_id": 52855,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3083,
         "unknown6": 0,
         "tint": 0,
@@ -9286,7 +9286,7 @@
     {
         "guid": 10206,
         "name_id": 52835,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3061,
         "unknown6": 0,
         "tint": 0,
@@ -9330,7 +9330,7 @@
     {
         "guid": 10207,
         "name_id": 52835,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 673,
         "unknown6": 0,
         "tint": 0,
@@ -9374,7 +9374,7 @@
     {
         "guid": 10208,
         "name_id": 4588,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2660,
         "unknown6": 0,
         "tint": 0,
@@ -9418,7 +9418,7 @@
     {
         "guid": 10209,
         "name_id": 33784,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1665,
         "unknown6": 0,
         "tint": 0,
@@ -9462,7 +9462,7 @@
     {
         "guid": 10210,
         "name_id": 33559,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1659,
         "unknown6": 0,
         "tint": 0,
@@ -9506,7 +9506,7 @@
     {
         "guid": 10211,
         "name_id": 32931,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1595,
         "unknown6": 0,
         "tint": 0,
@@ -9550,7 +9550,7 @@
     {
         "guid": 10212,
         "name_id": 32940,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1598,
         "unknown6": 0,
         "tint": 0,
@@ -9594,7 +9594,7 @@
     {
         "guid": 10213,
         "name_id": 1583,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1929,
         "unknown6": 0,
         "tint": 0,
@@ -9638,7 +9638,7 @@
     {
         "guid": 10214,
         "name_id": 32985,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1625,
         "unknown6": 0,
         "tint": 0,
@@ -9682,7 +9682,7 @@
     {
         "guid": 10215,
         "name_id": 60771,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3855,
         "unknown6": 0,
         "tint": 0,
@@ -9726,7 +9726,7 @@
     {
         "guid": 10216,
         "name_id": 8534,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 105,
         "unknown6": 0,
         "tint": 0,
@@ -9770,7 +9770,7 @@
     {
         "guid": 10217,
         "name_id": 32936,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1602,
         "unknown6": 0,
         "tint": 0,
@@ -9814,7 +9814,7 @@
     {
         "guid": 10218,
         "name_id": 44500,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1983,
         "unknown6": 0,
         "tint": 0,
@@ -9858,7 +9858,7 @@
     {
         "guid": 10219,
         "name_id": 2661,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2161,
         "unknown6": 0,
         "tint": 0,
@@ -9902,7 +9902,7 @@
     {
         "guid": 10220,
         "name_id": 44829,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2063,
         "unknown6": 0,
         "tint": 0,
@@ -9946,7 +9946,7 @@
     {
         "guid": 10221,
         "name_id": 2670,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2295,
         "unknown6": 0,
         "tint": 0,
@@ -9990,7 +9990,7 @@
     {
         "guid": 10222,
         "name_id": 4510,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2580,
         "unknown6": 0,
         "tint": 0,
@@ -10034,7 +10034,7 @@
     {
         "guid": 10223,
         "name_id": 8540,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 106,
         "unknown6": 0,
         "tint": 0,
@@ -10078,7 +10078,7 @@
     {
         "guid": 10224,
         "name_id": 874,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 377,
         "unknown6": 0,
         "tint": 0,
@@ -10122,7 +10122,7 @@
     {
         "guid": 10225,
         "name_id": 53542,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3182,
         "unknown6": 0,
         "tint": 0,
@@ -10166,7 +10166,7 @@
     {
         "guid": 10226,
         "name_id": 52912,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3155,
         "unknown6": 0,
         "tint": 0,
@@ -10210,7 +10210,7 @@
     {
         "guid": 10227,
         "name_id": 878,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 481,
         "unknown6": 0,
         "tint": 0,
@@ -10254,7 +10254,7 @@
     {
         "guid": 10228,
         "name_id": 43189,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1787,
         "unknown6": 0,
         "tint": 0,
@@ -10298,7 +10298,7 @@
     {
         "guid": 10229,
         "name_id": 20387,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1102,
         "unknown6": 0,
         "tint": 0,
@@ -10342,7 +10342,7 @@
     {
         "guid": 10230,
         "name_id": 53605,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3204,
         "unknown6": 0,
         "tint": 0,
@@ -10386,7 +10386,7 @@
     {
         "guid": 10231,
         "name_id": 2973,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2384,
         "unknown6": 0,
         "tint": 0,
@@ -10430,7 +10430,7 @@
     {
         "guid": 10232,
         "name_id": 44875,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2105,
         "unknown6": 0,
         "tint": 0,
@@ -10474,7 +10474,7 @@
     {
         "guid": 10233,
         "name_id": 232,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 107,
         "unknown6": 0,
         "tint": 0,
@@ -10518,7 +10518,7 @@
     {
         "guid": 10234,
         "name_id": 54427,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3697,
         "unknown6": 0,
         "tint": 0,
@@ -10562,7 +10562,7 @@
     {
         "guid": 10235,
         "name_id": 2362,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2334,
         "unknown6": 0,
         "tint": 0,
@@ -10606,7 +10606,7 @@
     {
         "guid": 10236,
         "name_id": 1319,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1104,
         "unknown6": 0,
         "tint": 0,
@@ -10650,7 +10650,7 @@
     {
         "guid": 10237,
         "name_id": 60676,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3786,
         "unknown6": 0,
         "tint": 0,
@@ -10694,7 +10694,7 @@
     {
         "guid": 10238,
         "name_id": 1753,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1433,
         "unknown6": 0,
         "tint": 0,
@@ -10738,7 +10738,7 @@
     {
         "guid": 10239,
         "name_id": 4593,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2657,
         "unknown6": 0,
         "tint": 0,
@@ -10782,7 +10782,7 @@
     {
         "guid": 10240,
         "name_id": 240,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 108,
         "unknown6": 0,
         "tint": 0,
@@ -10826,7 +10826,7 @@
     {
         "guid": 10241,
         "name_id": 240,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 673,
         "unknown6": 0,
         "tint": 0,
@@ -10870,7 +10870,7 @@
     {
         "guid": 10242,
         "name_id": 240,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 673,
         "unknown6": 0,
         "tint": 0,
@@ -10914,7 +10914,7 @@
     {
         "guid": 10243,
         "name_id": 20055,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1472,
         "unknown6": 0,
         "tint": 0,
@@ -10958,7 +10958,7 @@
     {
         "guid": 10244,
         "name_id": 44894,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2130,
         "unknown6": 0,
         "tint": 0,
@@ -11002,7 +11002,7 @@
     {
         "guid": 10245,
         "name_id": 43186,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1789,
         "unknown6": 0,
         "tint": 0,
@@ -11046,7 +11046,7 @@
     {
         "guid": 10246,
         "name_id": 44852,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1108,
         "unknown6": 0,
         "tint": 0,
@@ -11090,7 +11090,7 @@
     {
         "guid": 10247,
         "name_id": 4818,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2848,
         "unknown6": 0,
         "tint": 0,
@@ -11134,7 +11134,7 @@
     {
         "guid": 10248,
         "name_id": 53972,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3272,
         "unknown6": 0,
         "tint": 0,
@@ -11178,7 +11178,7 @@
     {
         "guid": 10249,
         "name_id": 1761,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1349,
         "unknown6": 0,
         "tint": 0,
@@ -11222,7 +11222,7 @@
     {
         "guid": 10250,
         "name_id": 32973,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1605,
         "unknown6": 0,
         "tint": 0,
@@ -11266,7 +11266,7 @@
     {
         "guid": 10251,
         "name_id": 44885,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2118,
         "unknown6": 0,
         "tint": 0,
@@ -11310,7 +11310,7 @@
     {
         "guid": 10252,
         "name_id": 8918,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 109,
         "unknown6": 0,
         "tint": 0,
@@ -11354,7 +11354,7 @@
     {
         "guid": 10253,
         "name_id": 1654,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1927,
         "unknown6": 0,
         "tint": 0,
@@ -11398,7 +11398,7 @@
     {
         "guid": 10254,
         "name_id": 248,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 110,
         "unknown6": 0,
         "tint": 0,
@@ -11442,7 +11442,7 @@
     {
         "guid": 10255,
         "name_id": 1464,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1111,
         "unknown6": 0,
         "tint": 0,
@@ -11486,7 +11486,7 @@
     {
         "guid": 10256,
         "name_id": 1323,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1082,
         "unknown6": 0,
         "tint": 0,
@@ -11530,7 +11530,7 @@
     {
         "guid": 10257,
         "name_id": 8611,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 112,
         "unknown6": 0,
         "tint": 0,
@@ -11574,7 +11574,7 @@
     {
         "guid": 10258,
         "name_id": 8610,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 111,
         "unknown6": 0,
         "tint": 0,
@@ -11618,7 +11618,7 @@
     {
         "guid": 10259,
         "name_id": 8609,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 113,
         "unknown6": 0,
         "tint": 0,
@@ -11662,7 +11662,7 @@
     {
         "guid": 10260,
         "name_id": 924,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 480,
         "unknown6": 0,
         "tint": 0,
@@ -11706,7 +11706,7 @@
     {
         "guid": 10261,
         "name_id": 4947,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3005,
         "unknown6": 0,
         "tint": 0,
@@ -11750,7 +11750,7 @@
     {
         "guid": 10262,
         "name_id": 4951,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3009,
         "unknown6": 0,
         "tint": 0,
@@ -11794,7 +11794,7 @@
     {
         "guid": 10263,
         "name_id": 4955,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3013,
         "unknown6": 0,
         "tint": 0,
@@ -11838,7 +11838,7 @@
     {
         "guid": 10264,
         "name_id": 52793,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3114,
         "unknown6": 0,
         "tint": 0,
@@ -11882,7 +11882,7 @@
     {
         "guid": 10265,
         "name_id": 930,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 495,
         "unknown6": 0,
         "tint": 0,
@@ -11926,7 +11926,7 @@
     {
         "guid": 10266,
         "name_id": 43514,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1844,
         "unknown6": 0,
         "tint": 0,
@@ -11970,7 +11970,7 @@
     {
         "guid": 10267,
         "name_id": 1325,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1113,
         "unknown6": 0,
         "tint": 0,
@@ -12014,7 +12014,7 @@
     {
         "guid": 10268,
         "name_id": 4619,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2686,
         "unknown6": 0,
         "tint": 0,
@@ -12058,7 +12058,7 @@
     {
         "guid": 10269,
         "name_id": 60196,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3717,
         "unknown6": 0,
         "tint": 0,
@@ -12102,7 +12102,7 @@
     {
         "guid": 10270,
         "name_id": 1327,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1117,
         "unknown6": 0,
         "tint": 0,
@@ -12146,7 +12146,7 @@
     {
         "guid": 10271,
         "name_id": 52906,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3149,
         "unknown6": 0,
         "tint": 0,
@@ -12190,7 +12190,7 @@
     {
         "guid": 10272,
         "name_id": 1773,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1346,
         "unknown6": 0,
         "tint": 0,
@@ -12234,7 +12234,7 @@
     {
         "guid": 10273,
         "name_id": 1662,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1250,
         "unknown6": 0,
         "tint": 0,
@@ -12278,7 +12278,7 @@
     {
         "guid": 10274,
         "name_id": 256,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 115,
         "unknown6": 0,
         "tint": 0,
@@ -12322,7 +12322,7 @@
     {
         "guid": 10275,
         "name_id": 224,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 114,
         "unknown6": 0,
         "tint": 0,
@@ -12366,7 +12366,7 @@
     {
         "guid": 10276,
         "name_id": 4614,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2682,
         "unknown6": 0,
         "tint": 0,
@@ -12410,7 +12410,7 @@
     {
         "guid": 10277,
         "name_id": 1329,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1197,
         "unknown6": 0,
         "tint": 0,
@@ -12454,7 +12454,7 @@
     {
         "guid": 10278,
         "name_id": 4780,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2821,
         "unknown6": 0,
         "tint": 0,
@@ -12498,7 +12498,7 @@
     {
         "guid": 10279,
         "name_id": 4776,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2817,
         "unknown6": 0,
         "tint": 0,
@@ -12542,7 +12542,7 @@
     {
         "guid": 10280,
         "name_id": 4772,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2813,
         "unknown6": 0,
         "tint": 0,
@@ -12586,7 +12586,7 @@
     {
         "guid": 10281,
         "name_id": 4299,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2408,
         "unknown6": 0,
         "tint": 0,
@@ -12630,7 +12630,7 @@
     {
         "guid": 10282,
         "name_id": 886,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 487,
         "unknown6": 0,
         "tint": 0,
@@ -12674,7 +12674,7 @@
     {
         "guid": 10283,
         "name_id": 32981,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1612,
         "unknown6": 0,
         "tint": 0,
@@ -12718,7 +12718,7 @@
     {
         "guid": 10284,
         "name_id": 938,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 483,
         "unknown6": 0,
         "tint": 0,
@@ -12762,7 +12762,7 @@
     {
         "guid": 10285,
         "name_id": 940,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 502,
         "unknown6": 0,
         "tint": 0,
@@ -12806,7 +12806,7 @@
     {
         "guid": 10286,
         "name_id": 53546,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3187,
         "unknown6": 0,
         "tint": 0,
@@ -12850,7 +12850,7 @@
     {
         "guid": 10287,
         "name_id": 136,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 116,
         "unknown6": 0,
         "tint": 0,
@@ -12894,7 +12894,7 @@
     {
         "guid": 10288,
         "name_id": 1587,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1238,
         "unknown6": 0,
         "tint": 0,
@@ -12938,7 +12938,7 @@
     {
         "guid": 10289,
         "name_id": 44315,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1970,
         "unknown6": 0,
         "tint": 0,
@@ -12982,7 +12982,7 @@
     {
         "guid": 10290,
         "name_id": 44317,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1972,
         "unknown6": 0,
         "tint": 0,
@@ -13026,7 +13026,7 @@
     {
         "guid": 10291,
         "name_id": 1506,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1141,
         "unknown6": 0,
         "tint": 0,
@@ -13070,7 +13070,7 @@
     {
         "guid": 10292,
         "name_id": 1331,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1144,
         "unknown6": 0,
         "tint": 0,
@@ -13114,7 +13114,7 @@
     {
         "guid": 10293,
         "name_id": 4453,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2511,
         "unknown6": 0,
         "tint": 0,
@@ -13158,7 +13158,7 @@
     {
         "guid": 10294,
         "name_id": 4461,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2516,
         "unknown6": 0,
         "tint": 0,
@@ -13202,7 +13202,7 @@
     {
         "guid": 20000,
         "name_id": 962,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 435,
         "unknown6": 0,
         "tint": 0,
@@ -13246,7 +13246,7 @@
     {
         "guid": 20001,
         "name_id": 2344,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2326,
         "unknown6": 0,
         "tint": 0,
@@ -13290,7 +13290,7 @@
     {
         "guid": 20002,
         "name_id": 8916,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 184,
         "unknown6": 0,
         "tint": 0,
@@ -13334,7 +13334,7 @@
     {
         "guid": 20003,
         "name_id": 8932,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 185,
         "unknown6": 0,
         "tint": 0,
@@ -13378,7 +13378,7 @@
     {
         "guid": 20004,
         "name_id": 8940,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 186,
         "unknown6": 0,
         "tint": 0,
@@ -13422,7 +13422,7 @@
     {
         "guid": 20005,
         "name_id": 964,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 684,
         "unknown6": 0,
         "tint": 0,
@@ -13466,7 +13466,7 @@
     {
         "guid": 20006,
         "name_id": 32975,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1611,
         "unknown6": 0,
         "tint": 0,
@@ -13510,7 +13510,7 @@
     {
         "guid": 20007,
         "name_id": 44886,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2120,
         "unknown6": 0,
         "tint": 0,
@@ -13554,7 +13554,7 @@
     {
         "guid": 20008,
         "name_id": 142,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 187,
         "unknown6": 0,
         "tint": 0,
@@ -13598,7 +13598,7 @@
     {
         "guid": 20009,
         "name_id": 1725,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1408,
         "unknown6": 0,
         "tint": 0,
@@ -13642,7 +13642,7 @@
     {
         "guid": 20010,
         "name_id": 2947,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2390,
         "unknown6": 0,
         "tint": 0,
@@ -13686,7 +13686,7 @@
     {
         "guid": 20011,
         "name_id": 54468,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3712,
         "unknown6": 0,
         "tint": 0,
@@ -13730,7 +13730,7 @@
     {
         "guid": 20012,
         "name_id": 54506,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3762,
         "unknown6": 0,
         "tint": 0,
@@ -13774,7 +13774,7 @@
     {
         "guid": 20013,
         "name_id": 4550,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2632,
         "unknown6": 0,
         "tint": 0,
@@ -13818,7 +13818,7 @@
     {
         "guid": 20014,
         "name_id": 54253,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3632,
         "unknown6": 0,
         "tint": 0,
@@ -13862,7 +13862,7 @@
     {
         "guid": 20015,
         "name_id": 4701,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2749,
         "unknown6": 0,
         "tint": 0,
@@ -13906,7 +13906,7 @@
     {
         "guid": 20016,
         "name_id": 60668,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3779,
         "unknown6": 0,
         "tint": 0,
@@ -13950,7 +13950,7 @@
     {
         "guid": 20017,
         "name_id": 150,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 188,
         "unknown6": 0,
         "tint": 0,
@@ -13994,7 +13994,7 @@
     {
         "guid": 20018,
         "name_id": 2389,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2365,
         "unknown6": 0,
         "tint": 0,
@@ -14038,7 +14038,7 @@
     {
         "guid": 20019,
         "name_id": 8513,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 189,
         "unknown6": 0,
         "tint": 0,
@@ -14082,7 +14082,7 @@
     {
         "guid": 20020,
         "name_id": 4584,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2650,
         "unknown6": 0,
         "tint": 0,
@@ -14126,7 +14126,7 @@
     {
         "guid": 20021,
         "name_id": 2338,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2330,
         "unknown6": 0,
         "tint": 0,
@@ -14170,7 +14170,7 @@
     {
         "guid": 20022,
         "name_id": 1638,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1326,
         "unknown6": 0,
         "tint": 0,
@@ -14214,7 +14214,7 @@
     {
         "guid": 20023,
         "name_id": 20050,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1467,
         "unknown6": 0,
         "tint": 0,
@@ -14258,7 +14258,7 @@
     {
         "guid": 20024,
         "name_id": 54577,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3822,
         "unknown6": 0,
         "tint": 0,
@@ -14302,7 +14302,7 @@
     {
         "guid": 20025,
         "name_id": 1396,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1124,
         "unknown6": 0,
         "tint": 0,
@@ -14346,7 +14346,7 @@
     {
         "guid": 20026,
         "name_id": 1398,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1128,
         "unknown6": 0,
         "tint": 0,
@@ -14390,7 +14390,7 @@
     {
         "guid": 20027,
         "name_id": 1400,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1132,
         "unknown6": 0,
         "tint": 0,
@@ -14434,7 +14434,7 @@
     {
         "guid": 20028,
         "name_id": 1402,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1136,
         "unknown6": 0,
         "tint": 0,
@@ -14478,7 +14478,7 @@
     {
         "guid": 20029,
         "name_id": 43056,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1741,
         "unknown6": 0,
         "tint": 0,
@@ -14522,7 +14522,7 @@
     {
         "guid": 20030,
         "name_id": 43060,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1745,
         "unknown6": 0,
         "tint": 0,
@@ -14566,7 +14566,7 @@
     {
         "guid": 20031,
         "name_id": 1406,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1140,
         "unknown6": 0,
         "tint": 0,
@@ -14610,7 +14610,7 @@
     {
         "guid": 20032,
         "name_id": 14170,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 449,
         "unknown6": 0,
         "tint": 0,
@@ -14654,7 +14654,7 @@
     {
         "guid": 20033,
         "name_id": 44750,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2017,
         "unknown6": 0,
         "tint": 0,
@@ -14698,7 +14698,7 @@
     {
         "guid": 20034,
         "name_id": 54530,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3798,
         "unknown6": 0,
         "tint": 0,
@@ -14742,7 +14742,7 @@
     {
         "guid": 20035,
         "name_id": 54512,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3766,
         "unknown6": 0,
         "tint": 0,
@@ -14786,7 +14786,7 @@
     {
         "guid": 20036,
         "name_id": 54541,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3807,
         "unknown6": 0,
         "tint": 0,
@@ -14830,7 +14830,7 @@
     {
         "guid": 20037,
         "name_id": 53964,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3266,
         "unknown6": 0,
         "tint": 0,
@@ -14874,7 +14874,7 @@
     {
         "guid": 20038,
         "name_id": 54083,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3336,
         "unknown6": 0,
         "tint": 0,
@@ -14918,7 +14918,7 @@
     {
         "guid": 20039,
         "name_id": 33102,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1651,
         "unknown6": 0,
         "tint": 0,
@@ -14962,7 +14962,7 @@
     {
         "guid": 20040,
         "name_id": 33106,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1655,
         "unknown6": 0,
         "tint": 0,
@@ -15006,7 +15006,7 @@
     {
         "guid": 20041,
         "name_id": 33884,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1672,
         "unknown6": 0,
         "tint": 0,
@@ -15050,7 +15050,7 @@
     {
         "guid": 20042,
         "name_id": 43729,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1911,
         "unknown6": 0,
         "tint": 0,
@@ -15094,7 +15094,7 @@
     {
         "guid": 20043,
         "name_id": 43689,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1871,
         "unknown6": 0,
         "tint": 0,
@@ -15138,7 +15138,7 @@
     {
         "guid": 20044,
         "name_id": 43717,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1899,
         "unknown6": 0,
         "tint": 0,
@@ -15182,7 +15182,7 @@
     {
         "guid": 20045,
         "name_id": 43713,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1895,
         "unknown6": 0,
         "tint": 0,
@@ -15226,7 +15226,7 @@
     {
         "guid": 20046,
         "name_id": 43677,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1859,
         "unknown6": 0,
         "tint": 0,
@@ -15270,7 +15270,7 @@
     {
         "guid": 20047,
         "name_id": 43725,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1907,
         "unknown6": 0,
         "tint": 0,
@@ -15314,7 +15314,7 @@
     {
         "guid": 20048,
         "name_id": 43721,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1903,
         "unknown6": 0,
         "tint": 0,
@@ -15358,7 +15358,7 @@
     {
         "guid": 20049,
         "name_id": 60179,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3725,
         "unknown6": 0,
         "tint": 0,
@@ -15402,7 +15402,7 @@
     {
         "guid": 20050,
         "name_id": 824,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 453,
         "unknown6": 0,
         "tint": 0,
@@ -15446,7 +15446,7 @@
     {
         "guid": 20051,
         "name_id": 1555,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2834,
         "unknown6": 0,
         "tint": 0,
@@ -15490,7 +15490,7 @@
     {
         "guid": 20052,
         "name_id": 4382,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2464,
         "unknown6": 0,
         "tint": 0,
@@ -15534,7 +15534,7 @@
     {
         "guid": 20053,
         "name_id": 54279,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3649,
         "unknown6": 0,
         "tint": 0,
@@ -15578,7 +15578,7 @@
     {
         "guid": 20054,
         "name_id": 52802,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3107,
         "unknown6": 0,
         "tint": 0,
@@ -15622,7 +15622,7 @@
     {
         "guid": 20055,
         "name_id": 862,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 479,
         "unknown6": 0,
         "tint": 0,
@@ -15666,7 +15666,7 @@
     {
         "guid": 20056,
         "name_id": 2505,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 192,
         "unknown6": 0,
         "tint": 0,
@@ -15710,7 +15710,7 @@
     {
         "guid": 20057,
         "name_id": 182,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 190,
         "unknown6": 0,
         "tint": 0,
@@ -15754,7 +15754,7 @@
     {
         "guid": 20058,
         "name_id": 190,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 191,
         "unknown6": 0,
         "tint": 0,
@@ -15798,7 +15798,7 @@
     {
         "guid": 20059,
         "name_id": 1184,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 390,
         "unknown6": 0,
         "tint": 0,
@@ -15842,7 +15842,7 @@
     {
         "guid": 20060,
         "name_id": 832,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 457,
         "unknown6": 0,
         "tint": 0,
@@ -15886,7 +15886,7 @@
     {
         "guid": 20061,
         "name_id": 20309,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1482,
         "unknown6": 0,
         "tint": 0,
@@ -15930,7 +15930,7 @@
     {
         "guid": 20062,
         "name_id": 43685,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1867,
         "unknown6": 0,
         "tint": 0,
@@ -15974,7 +15974,7 @@
     {
         "guid": 20063,
         "name_id": 2707,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 677,
         "unknown6": 0,
         "tint": 0,
@@ -16018,7 +16018,7 @@
     {
         "guid": 20064,
         "name_id": 2703,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 677,
         "unknown6": 0,
         "tint": 0,
@@ -16062,7 +16062,7 @@
     {
         "guid": 20065,
         "name_id": 54552,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3816,
         "unknown6": 0,
         "tint": 0,
@@ -16106,7 +16106,7 @@
     {
         "guid": 20066,
         "name_id": 166,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 193,
         "unknown6": 0,
         "tint": 0,
@@ -16150,7 +16150,7 @@
     {
         "guid": 20067,
         "name_id": 43709,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1891,
         "unknown6": 0,
         "tint": 0,
@@ -16194,7 +16194,7 @@
     {
         "guid": 20068,
         "name_id": 8914,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 195,
         "unknown6": 0,
         "tint": 0,
@@ -16238,7 +16238,7 @@
     {
         "guid": 20069,
         "name_id": 158,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 194,
         "unknown6": 0,
         "tint": 0,
@@ -16282,7 +16282,7 @@
     {
         "guid": 20070,
         "name_id": 44881,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2113,
         "unknown6": 0,
         "tint": 0,
@@ -16326,7 +16326,7 @@
     {
         "guid": 20071,
         "name_id": 8518,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 196,
         "unknown6": 0,
         "tint": 0,
@@ -16370,7 +16370,7 @@
     {
         "guid": 20072,
         "name_id": 1486,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1079,
         "unknown6": 0,
         "tint": 0,
@@ -16414,7 +16414,7 @@
     {
         "guid": 20073,
         "name_id": 2679,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 677,
         "unknown6": 0,
         "tint": 0,
@@ -16458,7 +16458,7 @@
     {
         "guid": 20074,
         "name_id": 43681,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1863,
         "unknown6": 0,
         "tint": 0,
@@ -16502,7 +16502,7 @@
     {
         "guid": 20075,
         "name_id": 244,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 197,
         "unknown6": 0,
         "tint": 0,
@@ -16546,7 +16546,7 @@
     {
         "guid": 20076,
         "name_id": 8528,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 198,
         "unknown6": 0,
         "tint": 0,
@@ -16590,7 +16590,7 @@
     {
         "guid": 20077,
         "name_id": 20317,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1486,
         "unknown6": 0,
         "tint": 0,
@@ -16634,7 +16634,7 @@
     {
         "guid": 20078,
         "name_id": 0,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 391,
         "unknown6": 0,
         "tint": 0,
@@ -16678,7 +16678,7 @@
     {
         "guid": 20079,
         "name_id": 4305,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2414,
         "unknown6": 0,
         "tint": 0,
@@ -16722,7 +16722,7 @@
     {
         "guid": 20080,
         "name_id": 2378,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2351,
         "unknown6": 0,
         "tint": 0,
@@ -16766,7 +16766,7 @@
     {
         "guid": 20081,
         "name_id": 4390,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2483,
         "unknown6": 0,
         "tint": 0,
@@ -16810,7 +16810,7 @@
     {
         "guid": 20082,
         "name_id": 4478,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2567,
         "unknown6": 0,
         "tint": 0,
@@ -16854,7 +16854,7 @@
     {
         "guid": 20083,
         "name_id": 2366,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2347,
         "unknown6": 0,
         "tint": 0,
@@ -16898,7 +16898,7 @@
     {
         "guid": 20084,
         "name_id": 1216,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 677,
         "unknown6": 0,
         "tint": 0,
@@ -16942,7 +16942,7 @@
     {
         "guid": 20085,
         "name_id": 4386,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2468,
         "unknown6": 0,
         "tint": 0,
@@ -16986,7 +16986,7 @@
     {
         "guid": 20086,
         "name_id": 862,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 479,
         "unknown6": 0,
         "tint": 0,
@@ -17030,7 +17030,7 @@
     {
         "guid": 20087,
         "name_id": 4909,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2939,
         "unknown6": 0,
         "tint": 0,
@@ -17074,7 +17074,7 @@
     {
         "guid": 20088,
         "name_id": 4913,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2943,
         "unknown6": 0,
         "tint": 0,
@@ -17118,7 +17118,7 @@
     {
         "guid": 20089,
         "name_id": 53723,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3240,
         "unknown6": 0,
         "tint": 0,
@@ -17162,7 +17162,7 @@
     {
         "guid": 20090,
         "name_id": 54267,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3640,
         "unknown6": 0,
         "tint": 0,
@@ -17206,7 +17206,7 @@
     {
         "guid": 20091,
         "name_id": 54273,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3645,
         "unknown6": 0,
         "tint": 0,
@@ -17250,7 +17250,7 @@
     {
         "guid": 20092,
         "name_id": 54409,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3679,
         "unknown6": 0,
         "tint": 0,
@@ -17294,7 +17294,7 @@
     {
         "guid": 20093,
         "name_id": 4276,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2395,
         "unknown6": 0,
         "tint": 0,
@@ -17338,7 +17338,7 @@
     {
         "guid": 20094,
         "name_id": 4917,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2947,
         "unknown6": 0,
         "tint": 0,
@@ -17382,7 +17382,7 @@
     {
         "guid": 20095,
         "name_id": 4545,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2627,
         "unknown6": 0,
         "tint": 0,
@@ -17426,7 +17426,7 @@
     {
         "guid": 20096,
         "name_id": 2388,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2364,
         "unknown6": 0,
         "tint": 0,
@@ -17470,7 +17470,7 @@
     {
         "guid": 20097,
         "name_id": 8894,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 199,
         "unknown6": 0,
         "tint": 0,
@@ -17514,7 +17514,7 @@
     {
         "guid": 20098,
         "name_id": 20299,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1507,
         "unknown6": 0,
         "tint": 0,
@@ -17558,7 +17558,7 @@
     {
         "guid": 20099,
         "name_id": 44755,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2028,
         "unknown6": 0,
         "tint": 0,
@@ -17602,7 +17602,7 @@
     {
         "guid": 20100,
         "name_id": 14178,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 494,
         "unknown6": 0,
         "tint": 0,
@@ -17646,7 +17646,7 @@
     {
         "guid": 20101,
         "name_id": 53648,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3215,
         "unknown6": 0,
         "tint": 0,
@@ -17690,7 +17690,7 @@
     {
         "guid": 20102,
         "name_id": 1192,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 392,
         "unknown6": 0,
         "tint": 0,
@@ -17734,7 +17734,7 @@
     {
         "guid": 20103,
         "name_id": 1907,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1451,
         "unknown6": 0,
         "tint": 0,
@@ -17778,7 +17778,7 @@
     {
         "guid": 20104,
         "name_id": 1208,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 393,
         "unknown6": 0,
         "tint": 0,
@@ -17822,7 +17822,7 @@
     {
         "guid": 20105,
         "name_id": 4745,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2785,
         "unknown6": 0,
         "tint": 0,
@@ -17866,7 +17866,7 @@
     {
         "guid": 20106,
         "name_id": 4741,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2781,
         "unknown6": 0,
         "tint": 0,
@@ -17910,7 +17910,7 @@
     {
         "guid": 20107,
         "name_id": 2683,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2850,
         "unknown6": 0,
         "tint": 0,
@@ -17954,7 +17954,7 @@
     {
         "guid": 20108,
         "name_id": 4924,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1879,
         "unknown6": 0,
         "tint": 0,
@@ -17998,7 +17998,7 @@
     {
         "guid": 20109,
         "name_id": 43701,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1883,
         "unknown6": 0,
         "tint": 0,
@@ -18042,7 +18042,7 @@
     {
         "guid": 20110,
         "name_id": 4903,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2934,
         "unknown6": 0,
         "tint": 0,
@@ -18086,7 +18086,7 @@
     {
         "guid": 20111,
         "name_id": 53715,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3232,
         "unknown6": 0,
         "tint": 0,
@@ -18130,7 +18130,7 @@
     {
         "guid": 20112,
         "name_id": 53711,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3228,
         "unknown6": 0,
         "tint": 0,
@@ -18174,7 +18174,7 @@
     {
         "guid": 20113,
         "name_id": 53707,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3224,
         "unknown6": 0,
         "tint": 0,
@@ -18218,7 +18218,7 @@
     {
         "guid": 20114,
         "name_id": 53719,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3236,
         "unknown6": 0,
         "tint": 0,
@@ -18262,7 +18262,7 @@
     {
         "guid": 20115,
         "name_id": 174,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 200,
         "unknown6": 0,
         "tint": 0,
@@ -18306,7 +18306,7 @@
     {
         "guid": 20116,
         "name_id": 1200,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 394,
         "unknown6": 0,
         "tint": 0,
@@ -18350,7 +18350,7 @@
     {
         "guid": 20117,
         "name_id": 2695,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2589,
         "unknown6": 0,
         "tint": 0,
@@ -18394,7 +18394,7 @@
     {
         "guid": 20118,
         "name_id": 2699,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 677,
         "unknown6": 0,
         "tint": 0,
@@ -18438,7 +18438,7 @@
     {
         "guid": 20119,
         "name_id": 52061,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2974,
         "unknown6": 0,
         "tint": 0,
@@ -18482,7 +18482,7 @@
     {
         "guid": 20120,
         "name_id": 2691,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2739,
         "unknown6": 0,
         "tint": 0,
@@ -18526,7 +18526,7 @@
     {
         "guid": 20121,
         "name_id": 4301,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2426,
         "unknown6": 0,
         "tint": 0,
@@ -18570,7 +18570,7 @@
     {
         "guid": 20122,
         "name_id": 2662,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2167,
         "unknown6": 0,
         "tint": 0,
@@ -18614,7 +18614,7 @@
     {
         "guid": 20123,
         "name_id": 54247,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3627,
         "unknown6": 0,
         "tint": 0,
@@ -18658,7 +18658,7 @@
     {
         "guid": 20124,
         "name_id": 4681,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2735,
         "unknown6": 0,
         "tint": 0,
@@ -18702,7 +18702,7 @@
     {
         "guid": 20125,
         "name_id": 4623,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2688,
         "unknown6": 0,
         "tint": 0,
@@ -18746,7 +18746,7 @@
     {
         "guid": 20126,
         "name_id": 1488,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1095,
         "unknown6": 0,
         "tint": 0,
@@ -18790,7 +18790,7 @@
     {
         "guid": 20127,
         "name_id": 1408,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1087,
         "unknown6": 0,
         "tint": 0,
@@ -18834,7 +18834,7 @@
     {
         "guid": 20128,
         "name_id": 1837,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1380,
         "unknown6": 0,
         "tint": 0,
@@ -18878,7 +18878,7 @@
     {
         "guid": 20129,
         "name_id": 1410,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1091,
         "unknown6": 0,
         "tint": 0,
@@ -18922,7 +18922,7 @@
     {
         "guid": 20130,
         "name_id": 54598,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3831,
         "unknown6": 0,
         "tint": 0,
@@ -18966,7 +18966,7 @@
     {
         "guid": 20131,
         "name_id": 60287,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3736,
         "unknown6": 0,
         "tint": 0,
@@ -19010,7 +19010,7 @@
     {
         "guid": 20132,
         "name_id": 890,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 501,
         "unknown6": 0,
         "tint": 0,
@@ -19054,7 +19054,7 @@
     {
         "guid": 20133,
         "name_id": 43693,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1875,
         "unknown6": 0,
         "tint": 0,
@@ -19098,7 +19098,7 @@
     {
         "guid": 20134,
         "name_id": 846,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 467,
         "unknown6": 0,
         "tint": 0,
@@ -19142,7 +19142,7 @@
     {
         "guid": 20135,
         "name_id": 1490,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 474,
         "unknown6": 0,
         "tint": 0,
@@ -19186,7 +19186,7 @@
     {
         "guid": 20136,
         "name_id": 860,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 475,
         "unknown6": 0,
         "tint": 0,
@@ -19230,7 +19230,7 @@
     {
         "guid": 20137,
         "name_id": 1624,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1386,
         "unknown6": 0,
         "tint": 0,
@@ -19274,7 +19274,7 @@
     {
         "guid": 20138,
         "name_id": 1626,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1387,
         "unknown6": 0,
         "tint": 0,
@@ -19318,7 +19318,7 @@
     {
         "guid": 20139,
         "name_id": 2352,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2333,
         "unknown6": 0,
         "tint": 0,
@@ -19362,7 +19362,7 @@
     {
         "guid": 20140,
         "name_id": 53065,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3144,
         "unknown6": 0,
         "tint": 0,
@@ -19406,7 +19406,7 @@
     {
         "guid": 20141,
         "name_id": 53066,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3145,
         "unknown6": 0,
         "tint": 0,
@@ -19450,7 +19450,7 @@
     {
         "guid": 20142,
         "name_id": 53067,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3146,
         "unknown6": 0,
         "tint": 0,
@@ -19494,7 +19494,7 @@
     {
         "guid": 20143,
         "name_id": 1414,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1099,
         "unknown6": 0,
         "tint": 0,
@@ -19538,7 +19538,7 @@
     {
         "guid": 20144,
         "name_id": 1646,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 677,
         "unknown6": 0,
         "tint": 0,
@@ -19582,7 +19582,7 @@
     {
         "guid": 20145,
         "name_id": 1569,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1322,
         "unknown6": 0,
         "tint": 0,
@@ -19626,7 +19626,7 @@
     {
         "guid": 20146,
         "name_id": 1842,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1388,
         "unknown6": 0,
         "tint": 0,
@@ -19670,7 +19670,7 @@
     {
         "guid": 20147,
         "name_id": 54474,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3708,
         "unknown6": 0,
         "tint": 0,
@@ -19714,7 +19714,7 @@
     {
         "guid": 20148,
         "name_id": 1616,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1249,
         "unknown6": 0,
         "tint": 0,
@@ -19758,7 +19758,7 @@
     {
         "guid": 20149,
         "name_id": 44877,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2108,
         "unknown6": 0,
         "tint": 0,
@@ -19802,7 +19802,7 @@
     {
         "guid": 20150,
         "name_id": 2675,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3332,
         "unknown6": 0,
         "tint": 0,
@@ -19846,7 +19846,7 @@
     {
         "guid": 20151,
         "name_id": 4713,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2760,
         "unknown6": 0,
         "tint": 0,
@@ -19890,7 +19890,7 @@
     {
         "guid": 20152,
         "name_id": 52790,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3113,
         "unknown6": 0,
         "tint": 0,
@@ -19934,7 +19934,7 @@
     {
         "guid": 20153,
         "name_id": 363,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 201,
         "unknown6": 0,
         "tint": 0,
@@ -19978,7 +19978,7 @@
     {
         "guid": 20154,
         "name_id": 208,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 202,
         "unknown6": 0,
         "tint": 0,
@@ -20022,7 +20022,7 @@
     {
         "guid": 20155,
         "name_id": 0,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 677,
         "unknown6": 0,
         "tint": 0,
@@ -20066,7 +20066,7 @@
     {
         "guid": 20156,
         "name_id": 4546,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2628,
         "unknown6": 0,
         "tint": 0,
@@ -20110,7 +20110,7 @@
     {
         "guid": 20157,
         "name_id": 1846,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1381,
         "unknown6": 0,
         "tint": 0,
@@ -20154,7 +20154,7 @@
     {
         "guid": 20158,
         "name_id": 1739,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1345,
         "unknown6": 0,
         "tint": 0,
@@ -20198,7 +20198,7 @@
     {
         "guid": 20159,
         "name_id": 1765,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1377,
         "unknown6": 0,
         "tint": 0,
@@ -20242,7 +20242,7 @@
     {
         "guid": 20160,
         "name_id": 43705,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1887,
         "unknown6": 0,
         "tint": 0,
@@ -20286,7 +20286,7 @@
     {
         "guid": 20161,
         "name_id": 54414,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3685,
         "unknown6": 0,
         "tint": 0,
@@ -20330,7 +20330,7 @@
     {
         "guid": 20162,
         "name_id": 54433,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3700,
         "unknown6": 0,
         "tint": 0,
@@ -20374,7 +20374,7 @@
     {
         "guid": 20163,
         "name_id": 1630,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1389,
         "unknown6": 0,
         "tint": 0,
@@ -20418,7 +20418,7 @@
     {
         "guid": 20164,
         "name_id": 52809,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3142,
         "unknown6": 0,
         "tint": 0,
@@ -20462,7 +20462,7 @@
     {
         "guid": 20165,
         "name_id": 52853,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3081,
         "unknown6": 0,
         "tint": 0,
@@ -20506,7 +20506,7 @@
     {
         "guid": 20166,
         "name_id": 33783,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1667,
         "unknown6": 0,
         "tint": 0,
@@ -20550,7 +20550,7 @@
     {
         "guid": 20167,
         "name_id": 33557,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1657,
         "unknown6": 0,
         "tint": 0,
@@ -20594,7 +20594,7 @@
     {
         "guid": 20168,
         "name_id": 32932,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1597,
         "unknown6": 0,
         "tint": 0,
@@ -20638,7 +20638,7 @@
     {
         "guid": 20169,
         "name_id": 32938,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1601,
         "unknown6": 0,
         "tint": 0,
@@ -20682,7 +20682,7 @@
     {
         "guid": 20170,
         "name_id": 60774,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3858,
         "unknown6": 0,
         "tint": 0,
@@ -20726,7 +20726,7 @@
     {
         "guid": 20171,
         "name_id": 8542,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 203,
         "unknown6": 0,
         "tint": 0,
@@ -20770,7 +20770,7 @@
     {
         "guid": 20172,
         "name_id": 870,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 395,
         "unknown6": 0,
         "tint": 0,
@@ -20814,7 +20814,7 @@
     {
         "guid": 20173,
         "name_id": 53540,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3180,
         "unknown6": 0,
         "tint": 0,
@@ -20858,7 +20858,7 @@
     {
         "guid": 20174,
         "name_id": 52910,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3153,
         "unknown6": 0,
         "tint": 0,
@@ -20902,7 +20902,7 @@
     {
         "guid": 20175,
         "name_id": 1856,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1390,
         "unknown6": 0,
         "tint": 0,
@@ -20946,7 +20946,7 @@
     {
         "guid": 20176,
         "name_id": 2358,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2327,
         "unknown6": 0,
         "tint": 0,
@@ -20990,7 +20990,7 @@
     {
         "guid": 20177,
         "name_id": 1858,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1391,
         "unknown6": 0,
         "tint": 0,
@@ -21034,7 +21034,7 @@
     {
         "guid": 20178,
         "name_id": 53603,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3202,
         "unknown6": 0,
         "tint": 0,
@@ -21078,7 +21078,7 @@
     {
         "guid": 20179,
         "name_id": 2969,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2382,
         "unknown6": 0,
         "tint": 0,
@@ -21122,7 +21122,7 @@
     {
         "guid": 20180,
         "name_id": 228,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 204,
         "unknown6": 0,
         "tint": 0,
@@ -21166,7 +21166,7 @@
     {
         "guid": 20181,
         "name_id": 44873,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2103,
         "unknown6": 0,
         "tint": 0,
@@ -21210,7 +21210,7 @@
     {
         "guid": 20182,
         "name_id": 54425,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3695,
         "unknown6": 0,
         "tint": 0,
@@ -21254,7 +21254,7 @@
     {
         "guid": 20183,
         "name_id": 2360,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2336,
         "unknown6": 0,
         "tint": 0,
@@ -21298,7 +21298,7 @@
     {
         "guid": 20184,
         "name_id": 1860,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1392,
         "unknown6": 0,
         "tint": 0,
@@ -21342,7 +21342,7 @@
     {
         "guid": 20185,
         "name_id": 1416,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1107,
         "unknown6": 0,
         "tint": 0,
@@ -21386,7 +21386,7 @@
     {
         "guid": 20186,
         "name_id": 60674,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3784,
         "unknown6": 0,
         "tint": 0,
@@ -21430,7 +21430,7 @@
     {
         "guid": 20187,
         "name_id": 4591,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2655,
         "unknown6": 0,
         "tint": 0,
@@ -21474,7 +21474,7 @@
     {
         "guid": 20188,
         "name_id": 236,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 205,
         "unknown6": 0,
         "tint": 0,
@@ -21518,7 +21518,7 @@
     {
         "guid": 20189,
         "name_id": 236,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 677,
         "unknown6": 0,
         "tint": 0,
@@ -21562,7 +21562,7 @@
     {
         "guid": 20190,
         "name_id": 236,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 677,
         "unknown6": 0,
         "tint": 0,
@@ -21606,7 +21606,7 @@
     {
         "guid": 20191,
         "name_id": 4979,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3015,
         "unknown6": 0,
         "tint": 0,
@@ -21650,7 +21650,7 @@
     {
         "guid": 20192,
         "name_id": 4978,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3016,
         "unknown6": 0,
         "tint": 0,
@@ -21694,7 +21694,7 @@
     {
         "guid": 20193,
         "name_id": 4977,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3017,
         "unknown6": 0,
         "tint": 0,
@@ -21738,7 +21738,7 @@
     {
         "guid": 20194,
         "name_id": 20054,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1471,
         "unknown6": 0,
         "tint": 0,
@@ -21782,7 +21782,7 @@
     {
         "guid": 20195,
         "name_id": 4816,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2846,
         "unknown6": 0,
         "tint": 0,
@@ -21826,7 +21826,7 @@
     {
         "guid": 20196,
         "name_id": 53970,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3270,
         "unknown6": 0,
         "tint": 0,
@@ -21870,7 +21870,7 @@
     {
         "guid": 20197,
         "name_id": 4508,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2578,
         "unknown6": 0,
         "tint": 0,
@@ -21914,7 +21914,7 @@
     {
         "guid": 20198,
         "name_id": 1757,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1352,
         "unknown6": 0,
         "tint": 0,
@@ -21958,7 +21958,7 @@
     {
         "guid": 20199,
         "name_id": 8924,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 206,
         "unknown6": 0,
         "tint": 0,
@@ -22002,7 +22002,7 @@
     {
         "guid": 20200,
         "name_id": 246,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 207,
         "unknown6": 0,
         "tint": 0,
@@ -22046,7 +22046,7 @@
     {
         "guid": 20201,
         "name_id": 1418,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1083,
         "unknown6": 0,
         "tint": 0,
@@ -22090,7 +22090,7 @@
     {
         "guid": 20202,
         "name_id": 4945,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3003,
         "unknown6": 0,
         "tint": 0,
@@ -22134,7 +22134,7 @@
     {
         "guid": 20203,
         "name_id": 4949,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3007,
         "unknown6": 0,
         "tint": 0,
@@ -22178,7 +22178,7 @@
     {
         "guid": 20204,
         "name_id": 4953,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3011,
         "unknown6": 0,
         "tint": 0,
@@ -22222,7 +22222,7 @@
     {
         "guid": 20205,
         "name_id": 52796,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3117,
         "unknown6": 0,
         "tint": 0,
@@ -22266,7 +22266,7 @@
     {
         "guid": 20206,
         "name_id": 43513,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1845,
         "unknown6": 0,
         "tint": 0,
@@ -22310,7 +22310,7 @@
     {
         "guid": 20207,
         "name_id": 1420,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1116,
         "unknown6": 0,
         "tint": 0,
@@ -22354,7 +22354,7 @@
     {
         "guid": 20208,
         "name_id": 4617,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2684,
         "unknown6": 0,
         "tint": 0,
@@ -22398,7 +22398,7 @@
     {
         "guid": 20209,
         "name_id": 60194,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3720,
         "unknown6": 0,
         "tint": 0,
@@ -22442,7 +22442,7 @@
     {
         "guid": 20210,
         "name_id": 1422,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1120,
         "unknown6": 0,
         "tint": 0,
@@ -22486,7 +22486,7 @@
     {
         "guid": 20211,
         "name_id": 1813,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1348,
         "unknown6": 0,
         "tint": 0,
@@ -22530,7 +22530,7 @@
     {
         "guid": 20212,
         "name_id": 1658,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1253,
         "unknown6": 0,
         "tint": 0,
@@ -22574,7 +22574,7 @@
     {
         "guid": 20213,
         "name_id": 928,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 497,
         "unknown6": 0,
         "tint": 0,
@@ -22618,7 +22618,7 @@
     {
         "guid": 20214,
         "name_id": 252,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 209,
         "unknown6": 0,
         "tint": 0,
@@ -22662,7 +22662,7 @@
     {
         "guid": 20215,
         "name_id": 220,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 208,
         "unknown6": 0,
         "tint": 0,
@@ -22706,7 +22706,7 @@
     {
         "guid": 20216,
         "name_id": 1424,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1200,
         "unknown6": 0,
         "tint": 0,
@@ -22750,7 +22750,7 @@
     {
         "guid": 20217,
         "name_id": 882,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 490,
         "unknown6": 0,
         "tint": 0,
@@ -22794,7 +22794,7 @@
     {
         "guid": 20218,
         "name_id": 54413,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3684,
         "unknown6": 0,
         "tint": 0,
@@ -22838,7 +22838,7 @@
     {
         "guid": 20219,
         "name_id": 32979,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1615,
         "unknown6": 0,
         "tint": 0,
@@ -22882,7 +22882,7 @@
     {
         "guid": 20220,
         "name_id": 970,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 505,
         "unknown6": 0,
         "tint": 0,
@@ -22926,7 +22926,7 @@
     {
         "guid": 20221,
         "name_id": 968,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 486,
         "unknown6": 0,
         "tint": 0,
@@ -22970,7 +22970,7 @@
     {
         "guid": 20222,
         "name_id": 53544,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3185,
         "unknown6": 0,
         "tint": 0,
@@ -23014,7 +23014,7 @@
     {
         "guid": 20223,
         "name_id": 1666,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1393,
         "unknown6": 0,
         "tint": 0,
@@ -23058,7 +23058,7 @@
     {
         "guid": 20224,
         "name_id": 8546,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 211,
         "unknown6": 0,
         "tint": 0,
@@ -23102,7 +23102,7 @@
     {
         "guid": 20225,
         "name_id": 8882,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 210,
         "unknown6": 0,
         "tint": 0,
@@ -23146,7 +23146,7 @@
     {
         "guid": 20226,
         "name_id": 1426,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1147,
         "unknown6": 0,
         "tint": 0,
@@ -23190,7 +23190,7 @@
     {
         "guid": 20227,
         "name_id": 4452,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2510,
         "unknown6": 0,
         "tint": 0,
@@ -23234,7 +23234,7 @@
     {
         "guid": 20228,
         "name_id": 4459,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2514,
         "unknown6": 0,
         "tint": 0,
@@ -23278,7 +23278,7 @@
     {
         "guid": 30000,
         "name_id": 44377,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1980,
         "unknown6": 0,
         "tint": 0,
@@ -23322,7 +23322,7 @@
     {
         "guid": 30001,
         "name_id": 44502,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1985,
         "unknown6": 0,
         "tint": 0,
@@ -23366,7 +23366,7 @@
     {
         "guid": 30002,
         "name_id": 2666,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2297,
         "unknown6": 0,
         "tint": 0,
@@ -23410,7 +23410,7 @@
     {
         "guid": 30003,
         "name_id": 918,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 438,
         "unknown6": 0,
         "tint": 0,
@@ -23454,7 +23454,7 @@
     {
         "guid": 30004,
         "name_id": 1893,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1443,
         "unknown6": 0,
         "tint": 0,
@@ -23498,7 +23498,7 @@
     {
         "guid": 30005,
         "name_id": 44190,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1959,
         "unknown6": 0,
         "tint": 0,
@@ -23542,7 +23542,7 @@
     {
         "guid": 30006,
         "name_id": 2516,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 154,
         "unknown6": 0,
         "tint": 0,
@@ -23586,7 +23586,7 @@
     {
         "guid": 30007,
         "name_id": 840,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 460,
         "unknown6": 0,
         "tint": 0,
@@ -23630,7 +23630,7 @@
     {
         "guid": 30008,
         "name_id": 2346,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2325,
         "unknown6": 0,
         "tint": 0,
@@ -23674,7 +23674,7 @@
     {
         "guid": 30009,
         "name_id": 1901,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1447,
         "unknown6": 0,
         "tint": 0,
@@ -23718,7 +23718,7 @@
     {
         "guid": 30010,
         "name_id": 43962,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1949,
         "unknown6": 0,
         "tint": 0,
@@ -23762,7 +23762,7 @@
     {
         "guid": 30011,
         "name_id": 44841,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2098,
         "unknown6": 0,
         "tint": 0,
@@ -23806,7 +23806,7 @@
     {
         "guid": 30012,
         "name_id": 44668,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2010,
         "unknown6": 0,
         "tint": 0,
@@ -23850,7 +23850,7 @@
     {
         "guid": 30013,
         "name_id": 2672,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 676,
         "unknown6": 0,
         "tint": 0,
@@ -23894,7 +23894,7 @@
     {
         "guid": 30014,
         "name_id": 4670,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2730,
         "unknown6": 0,
         "tint": 0,
@@ -23938,7 +23938,7 @@
     {
         "guid": 30015,
         "name_id": 144,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 155,
         "unknown6": 0,
         "tint": 0,
@@ -23982,7 +23982,7 @@
     {
         "guid": 30016,
         "name_id": 54469,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3713,
         "unknown6": 0,
         "tint": 0,
@@ -24026,7 +24026,7 @@
     {
         "guid": 30017,
         "name_id": 4551,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2633,
         "unknown6": 0,
         "tint": 0,
@@ -24070,7 +24070,7 @@
     {
         "guid": 30018,
         "name_id": 4904,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2935,
         "unknown6": 0,
         "tint": 0,
@@ -24114,7 +24114,7 @@
     {
         "guid": 30019,
         "name_id": 53716,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3233,
         "unknown6": 0,
         "tint": 0,
@@ -24158,7 +24158,7 @@
     {
         "guid": 30020,
         "name_id": 53712,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3229,
         "unknown6": 0,
         "tint": 0,
@@ -24202,7 +24202,7 @@
     {
         "guid": 30021,
         "name_id": 53708,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3225,
         "unknown6": 0,
         "tint": 0,
@@ -24246,7 +24246,7 @@
     {
         "guid": 30022,
         "name_id": 53720,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3237,
         "unknown6": 0,
         "tint": 0,
@@ -24290,7 +24290,7 @@
     {
         "guid": 30023,
         "name_id": 54254,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3633,
         "unknown6": 0,
         "tint": 0,
@@ -24334,7 +24334,7 @@
     {
         "guid": 30024,
         "name_id": 4702,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2750,
         "unknown6": 0,
         "tint": 0,
@@ -24378,7 +24378,7 @@
     {
         "guid": 30025,
         "name_id": 60669,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3780,
         "unknown6": 0,
         "tint": 0,
@@ -24422,7 +24422,7 @@
     {
         "guid": 30026,
         "name_id": 152,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 156,
         "unknown6": 0,
         "tint": 0,
@@ -24466,7 +24466,7 @@
     {
         "guid": 30027,
         "name_id": 1478,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 676,
         "unknown6": 0,
         "tint": 0,
@@ -24510,7 +24510,7 @@
     {
         "guid": 30028,
         "name_id": 8512,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 157,
         "unknown6": 0,
         "tint": 0,
@@ -24554,7 +24554,7 @@
     {
         "guid": 30029,
         "name_id": 4585,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2651,
         "unknown6": 0,
         "tint": 0,
@@ -24598,7 +24598,7 @@
     {
         "guid": 30030,
         "name_id": 52063,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2973,
         "unknown6": 0,
         "tint": 0,
@@ -24642,7 +24642,7 @@
     {
         "guid": 30031,
         "name_id": 818,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 444,
         "unknown6": 0,
         "tint": 0,
@@ -24686,7 +24686,7 @@
     {
         "guid": 30032,
         "name_id": 20051,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1468,
         "unknown6": 0,
         "tint": 0,
@@ -24730,7 +24730,7 @@
     {
         "guid": 30033,
         "name_id": 43057,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1742,
         "unknown6": 0,
         "tint": 0,
@@ -24774,7 +24774,7 @@
     {
         "guid": 30034,
         "name_id": 43061,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1746,
         "unknown6": 0,
         "tint": 0,
@@ -24818,7 +24818,7 @@
     {
         "guid": 30035,
         "name_id": 14168,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 448,
         "unknown6": 0,
         "tint": 0,
@@ -24862,7 +24862,7 @@
     {
         "guid": 30036,
         "name_id": 44751,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2016,
         "unknown6": 0,
         "tint": 0,
@@ -24906,7 +24906,7 @@
     {
         "guid": 30037,
         "name_id": 54513,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3767,
         "unknown6": 0,
         "tint": 0,
@@ -24950,7 +24950,7 @@
     {
         "guid": 30038,
         "name_id": 54542,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3808,
         "unknown6": 0,
         "tint": 0,
@@ -24994,7 +24994,7 @@
     {
         "guid": 30039,
         "name_id": 33104,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1650,
         "unknown6": 0,
         "tint": 0,
@@ -25038,7 +25038,7 @@
     {
         "guid": 30040,
         "name_id": 33108,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1654,
         "unknown6": 0,
         "tint": 0,
@@ -25082,7 +25082,7 @@
     {
         "guid": 30041,
         "name_id": 33886,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1671,
         "unknown6": 0,
         "tint": 0,
@@ -25126,7 +25126,7 @@
     {
         "guid": 30042,
         "name_id": 43690,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1870,
         "unknown6": 0,
         "tint": 0,
@@ -25170,7 +25170,7 @@
     {
         "guid": 30043,
         "name_id": 43730,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1910,
         "unknown6": 0,
         "tint": 0,
@@ -25214,7 +25214,7 @@
     {
         "guid": 30044,
         "name_id": 43726,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1906,
         "unknown6": 0,
         "tint": 0,
@@ -25258,7 +25258,7 @@
     {
         "guid": 30045,
         "name_id": 43714,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1894,
         "unknown6": 0,
         "tint": 0,
@@ -25302,7 +25302,7 @@
     {
         "guid": 30046,
         "name_id": 43678,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1858,
         "unknown6": 0,
         "tint": 0,
@@ -25346,7 +25346,7 @@
     {
         "guid": 30047,
         "name_id": 43718,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1898,
         "unknown6": 0,
         "tint": 0,
@@ -25390,7 +25390,7 @@
     {
         "guid": 30048,
         "name_id": 43722,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1902,
         "unknown6": 0,
         "tint": 0,
@@ -25434,7 +25434,7 @@
     {
         "guid": 30049,
         "name_id": 54084,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3337,
         "unknown6": 0,
         "tint": 0,
@@ -25478,7 +25478,7 @@
     {
         "guid": 30050,
         "name_id": 60180,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3724,
         "unknown6": 0,
         "tint": 0,
@@ -25522,7 +25522,7 @@
     {
         "guid": 30051,
         "name_id": 826,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 452,
         "unknown6": 0,
         "tint": 0,
@@ -25566,7 +25566,7 @@
     {
         "guid": 30052,
         "name_id": 1557,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2835,
         "unknown6": 0,
         "tint": 0,
@@ -25610,7 +25610,7 @@
     {
         "guid": 30053,
         "name_id": 4383,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2465,
         "unknown6": 0,
         "tint": 0,
@@ -25654,7 +25654,7 @@
     {
         "guid": 30054,
         "name_id": 4479,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2568,
         "unknown6": 0,
         "tint": 0,
@@ -25698,7 +25698,7 @@
     {
         "guid": 30055,
         "name_id": 2507,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 167,
         "unknown6": 0,
         "tint": 0,
@@ -25742,7 +25742,7 @@
     {
         "guid": 30056,
         "name_id": 8524,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 162,
         "unknown6": 0,
         "tint": 0,
@@ -25786,7 +25786,7 @@
     {
         "guid": 30057,
         "name_id": 8526,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 163,
         "unknown6": 0,
         "tint": 0,
@@ -25830,7 +25830,7 @@
     {
         "guid": 30058,
         "name_id": 8912,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 164,
         "unknown6": 0,
         "tint": 0,
@@ -25874,7 +25874,7 @@
     {
         "guid": 30059,
         "name_id": 8930,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 165,
         "unknown6": 0,
         "tint": 0,
@@ -25918,7 +25918,7 @@
     {
         "guid": 30060,
         "name_id": 8938,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 166,
         "unknown6": 0,
         "tint": 0,
@@ -25962,7 +25962,7 @@
     {
         "guid": 30061,
         "name_id": 160,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 158,
         "unknown6": 0,
         "tint": 0,
@@ -26006,7 +26006,7 @@
     {
         "guid": 30062,
         "name_id": 184,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 160,
         "unknown6": 0,
         "tint": 0,
@@ -26050,7 +26050,7 @@
     {
         "guid": 30063,
         "name_id": 192,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 161,
         "unknown6": 0,
         "tint": 0,
@@ -26094,7 +26094,7 @@
     {
         "guid": 30064,
         "name_id": 168,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 159,
         "unknown6": 0,
         "tint": 0,
@@ -26138,7 +26138,7 @@
     {
         "guid": 30065,
         "name_id": 0,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 385,
         "unknown6": 0,
         "tint": 0,
@@ -26182,7 +26182,7 @@
     {
         "guid": 30066,
         "name_id": 1182,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 384,
         "unknown6": 0,
         "tint": 0,
@@ -26226,7 +26226,7 @@
     {
         "guid": 30067,
         "name_id": 834,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 456,
         "unknown6": 0,
         "tint": 0,
@@ -26270,7 +26270,7 @@
     {
         "guid": 30068,
         "name_id": 864,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 478,
         "unknown6": 0,
         "tint": 0,
@@ -26314,7 +26314,7 @@
     {
         "guid": 30069,
         "name_id": 954,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 470,
         "unknown6": 0,
         "tint": 0,
@@ -26358,7 +26358,7 @@
     {
         "guid": 30070,
         "name_id": 1368,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1123,
         "unknown6": 0,
         "tint": 0,
@@ -26402,7 +26402,7 @@
     {
         "guid": 30071,
         "name_id": 1370,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1127,
         "unknown6": 0,
         "tint": 0,
@@ -26446,7 +26446,7 @@
     {
         "guid": 30072,
         "name_id": 1372,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1131,
         "unknown6": 0,
         "tint": 0,
@@ -26490,7 +26490,7 @@
     {
         "guid": 30073,
         "name_id": 1374,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1135,
         "unknown6": 0,
         "tint": 0,
@@ -26534,7 +26534,7 @@
     {
         "guid": 30074,
         "name_id": 1480,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1078,
         "unknown6": 0,
         "tint": 0,
@@ -26578,7 +26578,7 @@
     {
         "guid": 30075,
         "name_id": 20311,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1483,
         "unknown6": 0,
         "tint": 0,
@@ -26622,7 +26622,7 @@
     {
         "guid": 30076,
         "name_id": 32976,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1610,
         "unknown6": 0,
         "tint": 0,
@@ -26666,7 +26666,7 @@
     {
         "guid": 30077,
         "name_id": 2680,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 676,
         "unknown6": 0,
         "tint": 0,
@@ -26710,7 +26710,7 @@
     {
         "guid": 30078,
         "name_id": 43686,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1866,
         "unknown6": 0,
         "tint": 0,
@@ -26754,7 +26754,7 @@
     {
         "guid": 30079,
         "name_id": 43710,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1890,
         "unknown6": 0,
         "tint": 0,
@@ -26798,7 +26798,7 @@
     {
         "guid": 30080,
         "name_id": 43682,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1862,
         "unknown6": 0,
         "tint": 0,
@@ -26842,7 +26842,7 @@
     {
         "guid": 30081,
         "name_id": 44882,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2114,
         "unknown6": 0,
         "tint": 0,
@@ -26886,7 +26886,7 @@
     {
         "guid": 30082,
         "name_id": 44887,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2121,
         "unknown6": 0,
         "tint": 0,
@@ -26930,7 +26930,7 @@
     {
         "guid": 30083,
         "name_id": 2708,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 676,
         "unknown6": 0,
         "tint": 0,
@@ -26974,7 +26974,7 @@
     {
         "guid": 30084,
         "name_id": 2704,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 676,
         "unknown6": 0,
         "tint": 0,
@@ -27018,7 +27018,7 @@
     {
         "guid": 30085,
         "name_id": 1376,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1139,
         "unknown6": 0,
         "tint": 0,
@@ -27062,7 +27062,7 @@
     {
         "guid": 30086,
         "name_id": 52800,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3106,
         "unknown6": 0,
         "tint": 0,
@@ -27106,7 +27106,7 @@
     {
         "guid": 30087,
         "name_id": 20319,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1487,
         "unknown6": 0,
         "tint": 0,
@@ -27150,7 +27150,7 @@
     {
         "guid": 30088,
         "name_id": 2380,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2350,
         "unknown6": 0,
         "tint": 0,
@@ -27194,7 +27194,7 @@
     {
         "guid": 30089,
         "name_id": 4306,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2413,
         "unknown6": 0,
         "tint": 0,
@@ -27238,7 +27238,7 @@
     {
         "guid": 30090,
         "name_id": 53724,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3241,
         "unknown6": 0,
         "tint": 0,
@@ -27282,7 +27282,7 @@
     {
         "guid": 30091,
         "name_id": 2368,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2346,
         "unknown6": 0,
         "tint": 0,
@@ -27326,7 +27326,7 @@
     {
         "guid": 30092,
         "name_id": 43698,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 676,
         "unknown6": 0,
         "tint": 0,
@@ -27370,7 +27370,7 @@
     {
         "guid": 30093,
         "name_id": 4387,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2469,
         "unknown6": 0,
         "tint": 0,
@@ -27414,7 +27414,7 @@
     {
         "guid": 30094,
         "name_id": 4391,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2484,
         "unknown6": 0,
         "tint": 0,
@@ -27458,7 +27458,7 @@
     {
         "guid": 30095,
         "name_id": 4914,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2944,
         "unknown6": 0,
         "tint": 0,
@@ -27502,7 +27502,7 @@
     {
         "guid": 30096,
         "name_id": 4910,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2940,
         "unknown6": 0,
         "tint": 0,
@@ -27546,7 +27546,7 @@
     {
         "guid": 30097,
         "name_id": 53965,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3267,
         "unknown6": 0,
         "tint": 0,
@@ -27590,7 +27590,7 @@
     {
         "guid": 30098,
         "name_id": 54268,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3641,
         "unknown6": 0,
         "tint": 0,
@@ -27634,7 +27634,7 @@
     {
         "guid": 30099,
         "name_id": 54280,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3650,
         "unknown6": 0,
         "tint": 0,
@@ -27678,7 +27678,7 @@
     {
         "guid": 30100,
         "name_id": 54410,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3680,
         "unknown6": 0,
         "tint": 0,
@@ -27722,7 +27722,7 @@
     {
         "guid": 30101,
         "name_id": 54531,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3799,
         "unknown6": 0,
         "tint": 0,
@@ -27766,7 +27766,7 @@
     {
         "guid": 30102,
         "name_id": 54553,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3817,
         "unknown6": 0,
         "tint": 0,
@@ -27810,7 +27810,7 @@
     {
         "guid": 30103,
         "name_id": 54578,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3823,
         "unknown6": 0,
         "tint": 0,
@@ -27854,7 +27854,7 @@
     {
         "guid": 30104,
         "name_id": 4277,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2396,
         "unknown6": 0,
         "tint": 0,
@@ -27898,7 +27898,7 @@
     {
         "guid": 30105,
         "name_id": 4918,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2948,
         "unknown6": 0,
         "tint": 0,
@@ -27942,7 +27942,7 @@
     {
         "guid": 30106,
         "name_id": 2941,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2380,
         "unknown6": 0,
         "tint": 0,
@@ -27986,7 +27986,7 @@
     {
         "guid": 30107,
         "name_id": 8892,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 168,
         "unknown6": 0,
         "tint": 0,
@@ -28030,7 +28030,7 @@
     {
         "guid": 30108,
         "name_id": 1378,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1115,
         "unknown6": 0,
         "tint": 0,
@@ -28074,7 +28074,7 @@
     {
         "guid": 30109,
         "name_id": 20297,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1506,
         "unknown6": 0,
         "tint": 0,
@@ -28118,7 +28118,7 @@
     {
         "guid": 30110,
         "name_id": 44756,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2029,
         "unknown6": 0,
         "tint": 0,
@@ -28162,7 +28162,7 @@
     {
         "guid": 30111,
         "name_id": 4618,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2685,
         "unknown6": 0,
         "tint": 0,
@@ -28206,7 +28206,7 @@
     {
         "guid": 30112,
         "name_id": 60195,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3719,
         "unknown6": 0,
         "tint": 0,
@@ -28250,7 +28250,7 @@
     {
         "guid": 30113,
         "name_id": 14176,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 493,
         "unknown6": 0,
         "tint": 0,
@@ -28294,7 +28294,7 @@
     {
         "guid": 30114,
         "name_id": 53649,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3216,
         "unknown6": 0,
         "tint": 0,
@@ -28338,7 +28338,7 @@
     {
         "guid": 30115,
         "name_id": 1190,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 386,
         "unknown6": 0,
         "tint": 0,
@@ -28382,7 +28382,7 @@
     {
         "guid": 30116,
         "name_id": 1909,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1450,
         "unknown6": 0,
         "tint": 0,
@@ -28426,7 +28426,7 @@
     {
         "guid": 30117,
         "name_id": 1206,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 387,
         "unknown6": 0,
         "tint": 0,
@@ -28470,7 +28470,7 @@
     {
         "guid": 30118,
         "name_id": 54494,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3747,
         "unknown6": 0,
         "tint": 0,
@@ -28514,7 +28514,7 @@
     {
         "guid": 30119,
         "name_id": 4746,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2786,
         "unknown6": 0,
         "tint": 0,
@@ -28558,7 +28558,7 @@
     {
         "guid": 30120,
         "name_id": 4742,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2782,
         "unknown6": 0,
         "tint": 0,
@@ -28602,7 +28602,7 @@
     {
         "guid": 30121,
         "name_id": 2684,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2851,
         "unknown6": 0,
         "tint": 0,
@@ -28646,7 +28646,7 @@
     {
         "guid": 30122,
         "name_id": 4925,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1878,
         "unknown6": 0,
         "tint": 0,
@@ -28690,7 +28690,7 @@
     {
         "guid": 30123,
         "name_id": 43702,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1882,
         "unknown6": 0,
         "tint": 0,
@@ -28734,7 +28734,7 @@
     {
         "guid": 30124,
         "name_id": 52794,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3116,
         "unknown6": 0,
         "tint": 0,
@@ -28778,7 +28778,7 @@
     {
         "guid": 30125,
         "name_id": 54480,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3705,
         "unknown6": 0,
         "tint": 0,
@@ -28822,7 +28822,7 @@
     {
         "guid": 30126,
         "name_id": 1563,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 676,
         "unknown6": 0,
         "tint": 0,
@@ -28866,7 +28866,7 @@
     {
         "guid": 30127,
         "name_id": 44890,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2124,
         "unknown6": 0,
         "tint": 0,
@@ -28910,7 +28910,7 @@
     {
         "guid": 30128,
         "name_id": 176,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 169,
         "unknown6": 0,
         "tint": 0,
@@ -28954,7 +28954,7 @@
     {
         "guid": 30129,
         "name_id": 1198,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 388,
         "unknown6": 0,
         "tint": 0,
@@ -28998,7 +28998,7 @@
     {
         "guid": 30130,
         "name_id": 2696,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2590,
         "unknown6": 0,
         "tint": 0,
@@ -29042,7 +29042,7 @@
     {
         "guid": 30131,
         "name_id": 2700,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 676,
         "unknown6": 0,
         "tint": 0,
@@ -29086,7 +29086,7 @@
     {
         "guid": 30132,
         "name_id": 2692,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2740,
         "unknown6": 0,
         "tint": 0,
@@ -29130,7 +29130,7 @@
     {
         "guid": 30133,
         "name_id": 4302,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2425,
         "unknown6": 0,
         "tint": 0,
@@ -29174,7 +29174,7 @@
     {
         "guid": 30134,
         "name_id": 2663,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2166,
         "unknown6": 0,
         "tint": 0,
@@ -29218,7 +29218,7 @@
     {
         "guid": 30135,
         "name_id": 54248,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3628,
         "unknown6": 0,
         "tint": 0,
@@ -29262,7 +29262,7 @@
     {
         "guid": 30136,
         "name_id": 4682,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2736,
         "unknown6": 0,
         "tint": 0,
@@ -29306,7 +29306,7 @@
     {
         "guid": 30137,
         "name_id": 4624,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2689,
         "unknown6": 0,
         "tint": 0,
@@ -29350,7 +29350,7 @@
     {
         "guid": 30138,
         "name_id": 1482,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1094,
         "unknown6": 0,
         "tint": 0,
@@ -29394,7 +29394,7 @@
     {
         "guid": 30139,
         "name_id": 1380,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1086,
         "unknown6": 0,
         "tint": 0,
@@ -29438,7 +29438,7 @@
     {
         "guid": 30140,
         "name_id": 1382,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1090,
         "unknown6": 0,
         "tint": 0,
@@ -29482,7 +29482,7 @@
     {
         "guid": 30141,
         "name_id": 60288,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3737,
         "unknown6": 0,
         "tint": 0,
@@ -29526,7 +29526,7 @@
     {
         "guid": 30142,
         "name_id": 54599,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3832,
         "unknown6": 0,
         "tint": 0,
@@ -29570,7 +29570,7 @@
     {
         "guid": 30143,
         "name_id": 892,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 500,
         "unknown6": 0,
         "tint": 0,
@@ -29614,7 +29614,7 @@
     {
         "guid": 30144,
         "name_id": 43694,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1874,
         "unknown6": 0,
         "tint": 0,
@@ -29658,7 +29658,7 @@
     {
         "guid": 30145,
         "name_id": 854,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 473,
         "unknown6": 0,
         "tint": 0,
@@ -29702,7 +29702,7 @@
     {
         "guid": 30146,
         "name_id": 4592,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2656,
         "unknown6": 0,
         "tint": 0,
@@ -29746,7 +29746,7 @@
     {
         "guid": 30147,
         "name_id": 43185,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1791,
         "unknown6": 0,
         "tint": 0,
@@ -29790,7 +29790,7 @@
     {
         "guid": 30148,
         "name_id": 2354,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2332,
         "unknown6": 0,
         "tint": 0,
@@ -29834,7 +29834,7 @@
     {
         "guid": 30149,
         "name_id": 1384,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1098,
         "unknown6": 0,
         "tint": 0,
@@ -29878,7 +29878,7 @@
     {
         "guid": 30150,
         "name_id": 1571,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1321,
         "unknown6": 0,
         "tint": 0,
@@ -29922,7 +29922,7 @@
     {
         "guid": 30151,
         "name_id": 54475,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3709,
         "unknown6": 0,
         "tint": 0,
@@ -29966,7 +29966,7 @@
     {
         "guid": 30152,
         "name_id": 54547,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3812,
         "unknown6": 0,
         "tint": 0,
@@ -30010,7 +30010,7 @@
     {
         "guid": 30153,
         "name_id": 1618,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1248,
         "unknown6": 0,
         "tint": 0,
@@ -30054,7 +30054,7 @@
     {
         "guid": 30154,
         "name_id": 8906,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 170,
         "unknown6": 0,
         "tint": 0,
@@ -30098,7 +30098,7 @@
     {
         "guid": 30155,
         "name_id": 4714,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2761,
         "unknown6": 0,
         "tint": 0,
@@ -30142,7 +30142,7 @@
     {
         "guid": 30156,
         "name_id": 202,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 171,
         "unknown6": 0,
         "tint": 0,
@@ -30186,7 +30186,7 @@
     {
         "guid": 30157,
         "name_id": 956,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 463,
         "unknown6": 0,
         "tint": 0,
@@ -30230,7 +30230,7 @@
     {
         "guid": 30158,
         "name_id": 1500,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1143,
         "unknown6": 0,
         "tint": 0,
@@ -30274,7 +30274,7 @@
     {
         "guid": 30159,
         "name_id": 202,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 676,
         "unknown6": 0,
         "tint": 0,
@@ -30318,7 +30318,7 @@
     {
         "guid": 30160,
         "name_id": 54604,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3836,
         "unknown6": 0,
         "tint": 0,
@@ -30362,7 +30362,7 @@
     {
         "guid": 30161,
         "name_id": 4820,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2854,
         "unknown6": 0,
         "tint": 0,
@@ -30406,7 +30406,7 @@
     {
         "guid": 30162,
         "name_id": 52788,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3112,
         "unknown6": 0,
         "tint": 0,
@@ -30450,7 +30450,7 @@
     {
         "guid": 30163,
         "name_id": 0,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 676,
         "unknown6": 0,
         "tint": 0,
@@ -30494,7 +30494,7 @@
     {
         "guid": 30164,
         "name_id": 8900,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 173,
         "unknown6": 0,
         "tint": 0,
@@ -30538,7 +30538,7 @@
     {
         "guid": 30165,
         "name_id": 912,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 434,
         "unknown6": 0,
         "tint": 0,
@@ -30582,7 +30582,7 @@
     {
         "guid": 30166,
         "name_id": 4763,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2805,
         "unknown6": 0,
         "tint": 0,
@@ -30626,7 +30626,7 @@
     {
         "guid": 30167,
         "name_id": 1767,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1376,
         "unknown6": 0,
         "tint": 0,
@@ -30670,7 +30670,7 @@
     {
         "guid": 30168,
         "name_id": 1741,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1344,
         "unknown6": 0,
         "tint": 0,
@@ -30714,7 +30714,7 @@
     {
         "guid": 30169,
         "name_id": 43706,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1886,
         "unknown6": 0,
         "tint": 0,
@@ -30758,7 +30758,7 @@
     {
         "guid": 30170,
         "name_id": 54415,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3686,
         "unknown6": 0,
         "tint": 0,
@@ -30802,7 +30802,7 @@
     {
         "guid": 30171,
         "name_id": 214,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 174,
         "unknown6": 0,
         "tint": 0,
@@ -30846,7 +30846,7 @@
     {
         "guid": 30172,
         "name_id": 52807,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3141,
         "unknown6": 0,
         "tint": 0,
@@ -30890,7 +30890,7 @@
     {
         "guid": 30173,
         "name_id": 52834,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3060,
         "unknown6": 0,
         "tint": 0,
@@ -30934,7 +30934,7 @@
     {
         "guid": 30174,
         "name_id": 52834,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 676,
         "unknown6": 0,
         "tint": 0,
@@ -30978,7 +30978,7 @@
     {
         "guid": 30175,
         "name_id": 52854,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3082,
         "unknown6": 0,
         "tint": 0,
@@ -31022,7 +31022,7 @@
     {
         "guid": 30176,
         "name_id": 33558,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1658,
         "unknown6": 0,
         "tint": 0,
@@ -31066,7 +31066,7 @@
     {
         "guid": 30177,
         "name_id": 1581,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1931,
         "unknown6": 0,
         "tint": 0,
@@ -31110,7 +31110,7 @@
     {
         "guid": 30178,
         "name_id": 32984,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1627,
         "unknown6": 0,
         "tint": 0,
@@ -31154,7 +31154,7 @@
     {
         "guid": 30179,
         "name_id": 8538,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 175,
         "unknown6": 0,
         "tint": 0,
@@ -31198,7 +31198,7 @@
     {
         "guid": 30180,
         "name_id": 32935,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1604,
         "unknown6": 0,
         "tint": 0,
@@ -31242,7 +31242,7 @@
     {
         "guid": 30181,
         "name_id": 44499,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1982,
         "unknown6": 0,
         "tint": 0,
@@ -31286,7 +31286,7 @@
     {
         "guid": 30182,
         "name_id": 2660,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2163,
         "unknown6": 0,
         "tint": 0,
@@ -31330,7 +31330,7 @@
     {
         "guid": 30183,
         "name_id": 44828,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2062,
         "unknown6": 0,
         "tint": 0,
@@ -31374,7 +31374,7 @@
     {
         "guid": 30184,
         "name_id": 2669,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2294,
         "unknown6": 0,
         "tint": 0,
@@ -31418,7 +31418,7 @@
     {
         "guid": 30185,
         "name_id": 53541,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3181,
         "unknown6": 0,
         "tint": 0,
@@ -31462,7 +31462,7 @@
     {
         "guid": 30186,
         "name_id": 43188,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1788,
         "unknown6": 0,
         "tint": 0,
@@ -31506,7 +31506,7 @@
     {
         "guid": 30187,
         "name_id": 53604,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3203,
         "unknown6": 0,
         "tint": 0,
@@ -31550,7 +31550,7 @@
     {
         "guid": 30188,
         "name_id": 2971,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2383,
         "unknown6": 0,
         "tint": 0,
@@ -31594,7 +31594,7 @@
     {
         "guid": 30189,
         "name_id": 230,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 176,
         "unknown6": 0,
         "tint": 0,
@@ -31638,7 +31638,7 @@
     {
         "guid": 30190,
         "name_id": 44874,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2104,
         "unknown6": 0,
         "tint": 0,
@@ -31682,7 +31682,7 @@
     {
         "guid": 30191,
         "name_id": 54426,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3696,
         "unknown6": 0,
         "tint": 0,
@@ -31726,7 +31726,7 @@
     {
         "guid": 30192,
         "name_id": 1386,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1106,
         "unknown6": 0,
         "tint": 0,
@@ -31770,7 +31770,7 @@
     {
         "guid": 30193,
         "name_id": 60675,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3785,
         "unknown6": 0,
         "tint": 0,
@@ -31814,7 +31814,7 @@
     {
         "guid": 30194,
         "name_id": 1751,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1435,
         "unknown6": 0,
         "tint": 0,
@@ -31858,7 +31858,7 @@
     {
         "guid": 30195,
         "name_id": 32939,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1600,
         "unknown6": 0,
         "tint": 0,
@@ -31902,7 +31902,7 @@
     {
         "guid": 30196,
         "name_id": 238,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 177,
         "unknown6": 0,
         "tint": 0,
@@ -31946,7 +31946,7 @@
     {
         "guid": 30197,
         "name_id": 44854,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1110,
         "unknown6": 0,
         "tint": 0,
@@ -31990,7 +31990,7 @@
     {
         "guid": 30198,
         "name_id": 4817,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2847,
         "unknown6": 0,
         "tint": 0,
@@ -32034,7 +32034,7 @@
     {
         "guid": 30199,
         "name_id": 53971,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3271,
         "unknown6": 0,
         "tint": 0,
@@ -32078,7 +32078,7 @@
     {
         "guid": 30200,
         "name_id": 1759,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1351,
         "unknown6": 0,
         "tint": 0,
@@ -32122,7 +32122,7 @@
     {
         "guid": 30201,
         "name_id": 32972,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1607,
         "unknown6": 0,
         "tint": 0,
@@ -32166,7 +32166,7 @@
     {
         "guid": 30202,
         "name_id": 8922,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 178,
         "unknown6": 0,
         "tint": 0,
@@ -32210,7 +32210,7 @@
     {
         "guid": 30203,
         "name_id": 312,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 181,
         "unknown6": 0,
         "tint": 0,
@@ -32254,7 +32254,7 @@
     {
         "guid": 30204,
         "name_id": 872,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 389,
         "unknown6": 0,
         "tint": 0,
@@ -32298,7 +32298,7 @@
     {
         "guid": 30205,
         "name_id": 812,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 441,
         "unknown6": 0,
         "tint": 0,
@@ -32342,7 +32342,7 @@
     {
         "guid": 30206,
         "name_id": 848,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 466,
         "unknown6": 0,
         "tint": 0,
@@ -32386,7 +32386,7 @@
     {
         "guid": 30207,
         "name_id": 1640,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1325,
         "unknown6": 0,
         "tint": 0,
@@ -32430,7 +32430,7 @@
     {
         "guid": 30208,
         "name_id": 1648,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 676,
         "unknown6": 0,
         "tint": 0,
@@ -32474,7 +32474,7 @@
     {
         "guid": 30209,
         "name_id": 4460,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2515,
         "unknown6": 0,
         "tint": 0,
@@ -32518,7 +32518,7 @@
     {
         "guid": 30210,
         "name_id": 4547,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2629,
         "unknown6": 0,
         "tint": 0,
@@ -32562,7 +32562,7 @@
     {
         "guid": 30211,
         "name_id": 52911,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3154,
         "unknown6": 0,
         "tint": 0,
@@ -32606,7 +32606,7 @@
     {
         "guid": 30212,
         "name_id": 60772,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3857,
         "unknown6": 0,
         "tint": 0,
@@ -32650,7 +32650,7 @@
     {
         "guid": 30213,
         "name_id": 44878,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2109,
         "unknown6": 0,
         "tint": 0,
@@ -32694,7 +32694,7 @@
     {
         "guid": 30214,
         "name_id": 2676,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3333,
         "unknown6": 0,
         "tint": 0,
@@ -32738,7 +32738,7 @@
     {
         "guid": 30215,
         "name_id": 4509,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2579,
         "unknown6": 0,
         "tint": 0,
@@ -32782,7 +32782,7 @@
     {
         "guid": 30216,
         "name_id": 4946,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3004,
         "unknown6": 0,
         "tint": 0,
@@ -32826,7 +32826,7 @@
     {
         "guid": 30217,
         "name_id": 4950,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3008,
         "unknown6": 0,
         "tint": 0,
@@ -32870,7 +32870,7 @@
     {
         "guid": 30218,
         "name_id": 4954,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3012,
         "unknown6": 0,
         "tint": 0,
@@ -32914,7 +32914,7 @@
     {
         "guid": 30219,
         "name_id": 1390,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1119,
         "unknown6": 0,
         "tint": 0,
@@ -32958,7 +32958,7 @@
     {
         "guid": 30220,
         "name_id": 52905,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3148,
         "unknown6": 0,
         "tint": 0,
@@ -33002,7 +33002,7 @@
     {
         "guid": 30221,
         "name_id": 1660,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1252,
         "unknown6": 0,
         "tint": 0,
@@ -33046,7 +33046,7 @@
     {
         "guid": 30222,
         "name_id": 254,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 183,
         "unknown6": 0,
         "tint": 0,
@@ -33090,7 +33090,7 @@
     {
         "guid": 30223,
         "name_id": 222,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 182,
         "unknown6": 0,
         "tint": 0,
@@ -33134,7 +33134,7 @@
     {
         "guid": 30224,
         "name_id": 4613,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2681,
         "unknown6": 0,
         "tint": 0,
@@ -33178,7 +33178,7 @@
     {
         "guid": 30225,
         "name_id": 1392,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1199,
         "unknown6": 0,
         "tint": 0,
@@ -33222,7 +33222,7 @@
     {
         "guid": 30226,
         "name_id": 4779,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2820,
         "unknown6": 0,
         "tint": 0,
@@ -33266,7 +33266,7 @@
     {
         "guid": 30227,
         "name_id": 4771,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2812,
         "unknown6": 0,
         "tint": 0,
@@ -33310,7 +33310,7 @@
     {
         "guid": 30228,
         "name_id": 4775,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2816,
         "unknown6": 0,
         "tint": 0,
@@ -33354,7 +33354,7 @@
     {
         "guid": 30229,
         "name_id": 4298,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2410,
         "unknown6": 0,
         "tint": 0,
@@ -33398,7 +33398,7 @@
     {
         "guid": 30230,
         "name_id": 884,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 489,
         "unknown6": 0,
         "tint": 0,
@@ -33442,7 +33442,7 @@
     {
         "guid": 30231,
         "name_id": 32980,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1614,
         "unknown6": 0,
         "tint": 0,
@@ -33486,7 +33486,7 @@
     {
         "guid": 30232,
         "name_id": 958,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 485,
         "unknown6": 0,
         "tint": 0,
@@ -33530,7 +33530,7 @@
     {
         "guid": 30233,
         "name_id": 960,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 504,
         "unknown6": 0,
         "tint": 0,
@@ -33574,7 +33574,7 @@
     {
         "guid": 30234,
         "name_id": 53545,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3186,
         "unknown6": 0,
         "tint": 0,
@@ -33618,7 +33618,7 @@
     {
         "guid": 30235,
         "name_id": 1394,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1146,
         "unknown6": 0,
         "tint": 0,
@@ -33662,7 +33662,7 @@
     {
         "guid": 40000,
         "name_id": 44504,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1987,
         "unknown6": 0,
         "tint": 0,
@@ -33706,7 +33706,7 @@
     {
         "guid": 40001,
         "name_id": 922,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 437,
         "unknown6": 0,
         "tint": 0,
@@ -33750,7 +33750,7 @@
     {
         "guid": 40002,
         "name_id": 1899,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1442,
         "unknown6": 0,
         "tint": 0,
@@ -33794,7 +33794,7 @@
     {
         "guid": 40003,
         "name_id": 44192,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1958,
         "unknown6": 0,
         "tint": 0,
@@ -33838,7 +33838,7 @@
     {
         "guid": 40004,
         "name_id": 44376,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1979,
         "unknown6": 0,
         "tint": 0,
@@ -33882,7 +33882,7 @@
     {
         "guid": 40005,
         "name_id": 2668,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2299,
         "unknown6": 0,
         "tint": 0,
@@ -33926,7 +33926,7 @@
     {
         "guid": 40006,
         "name_id": 4451,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2509,
         "unknown6": 0,
         "tint": 0,
@@ -33970,7 +33970,7 @@
     {
         "guid": 40007,
         "name_id": 2515,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 117,
         "unknown6": 0,
         "tint": 0,
@@ -34014,7 +34014,7 @@
     {
         "guid": 40008,
         "name_id": 1905,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1446,
         "unknown6": 0,
         "tint": 0,
@@ -34058,7 +34058,7 @@
     {
         "guid": 40009,
         "name_id": 43964,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1948,
         "unknown6": 0,
         "tint": 0,
@@ -34102,7 +34102,7 @@
     {
         "guid": 40010,
         "name_id": 44843,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2100,
         "unknown6": 0,
         "tint": 0,
@@ -34146,7 +34146,7 @@
     {
         "guid": 40011,
         "name_id": 44670,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2009,
         "unknown6": 0,
         "tint": 0,
@@ -34190,7 +34190,7 @@
     {
         "guid": 40012,
         "name_id": 2674,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 680,
         "unknown6": 0,
         "tint": 0,
@@ -34234,7 +34234,7 @@
     {
         "guid": 40013,
         "name_id": 2350,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2324,
         "unknown6": 0,
         "tint": 0,
@@ -34278,7 +34278,7 @@
     {
         "guid": 40014,
         "name_id": 4672,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2732,
         "unknown6": 0,
         "tint": 0,
@@ -34322,7 +34322,7 @@
     {
         "guid": 40015,
         "name_id": 140,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 118,
         "unknown6": 0,
         "tint": 0,
@@ -34366,7 +34366,7 @@
     {
         "guid": 40016,
         "name_id": 148,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 119,
         "unknown6": 0,
         "tint": 0,
@@ -34410,7 +34410,7 @@
     {
         "guid": 40017,
         "name_id": 1575,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1324,
         "unknown6": 0,
         "tint": 0,
@@ -34454,7 +34454,7 @@
     {
         "guid": 40018,
         "name_id": 1881,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1407,
         "unknown6": 0,
         "tint": 0,
@@ -34498,7 +34498,7 @@
     {
         "guid": 40019,
         "name_id": 1614,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1245,
         "unknown6": 0,
         "tint": 0,
@@ -34542,7 +34542,7 @@
     {
         "guid": 40020,
         "name_id": 2951,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2389,
         "unknown6": 0,
         "tint": 0,
@@ -34586,7 +34586,7 @@
     {
         "guid": 40021,
         "name_id": 54203,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3764,
         "unknown6": 0,
         "tint": 0,
@@ -34630,7 +34630,7 @@
     {
         "guid": 40022,
         "name_id": 4553,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2635,
         "unknown6": 0,
         "tint": 0,
@@ -34674,7 +34674,7 @@
     {
         "guid": 40023,
         "name_id": 4906,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2937,
         "unknown6": 0,
         "tint": 0,
@@ -34718,7 +34718,7 @@
     {
         "guid": 40024,
         "name_id": 54256,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3635,
         "unknown6": 0,
         "tint": 0,
@@ -34762,7 +34762,7 @@
     {
         "guid": 40025,
         "name_id": 4704,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2752,
         "unknown6": 0,
         "tint": 0,
@@ -34806,7 +34806,7 @@
     {
         "guid": 40026,
         "name_id": 60671,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3782,
         "unknown6": 0,
         "tint": 0,
@@ -34850,7 +34850,7 @@
     {
         "guid": 40027,
         "name_id": 156,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 120,
         "unknown6": 0,
         "tint": 0,
@@ -34894,7 +34894,7 @@
     {
         "guid": 40028,
         "name_id": 67,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 123,
         "unknown6": 0,
         "tint": 0,
@@ -34938,7 +34938,7 @@
     {
         "guid": 40029,
         "name_id": 365,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 122,
         "unknown6": 0,
         "tint": 0,
@@ -34982,7 +34982,7 @@
     {
         "guid": 40030,
         "name_id": 8880,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 121,
         "unknown6": 0,
         "tint": 0,
@@ -35026,7 +35026,7 @@
     {
         "guid": 40031,
         "name_id": 916,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 433,
         "unknown6": 0,
         "tint": 0,
@@ -35070,7 +35070,7 @@
     {
         "guid": 40032,
         "name_id": 844,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 459,
         "unknown6": 0,
         "tint": 0,
@@ -35114,7 +35114,7 @@
     {
         "guid": 40033,
         "name_id": 1567,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 680,
         "unknown6": 0,
         "tint": 0,
@@ -35158,7 +35158,7 @@
     {
         "guid": 40034,
         "name_id": 32941,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1599,
         "unknown6": 0,
         "tint": 0,
@@ -35202,7 +35202,7 @@
     {
         "guid": 40035,
         "name_id": 8511,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 124,
         "unknown6": 0,
         "tint": 0,
@@ -35246,7 +35246,7 @@
     {
         "guid": 40036,
         "name_id": 4587,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2653,
         "unknown6": 0,
         "tint": 0,
@@ -35290,7 +35290,7 @@
     {
         "guid": 40037,
         "name_id": 2342,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2329,
         "unknown6": 0,
         "tint": 0,
@@ -35334,7 +35334,7 @@
     {
         "guid": 40038,
         "name_id": 52064,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2972,
         "unknown6": 0,
         "tint": 0,
@@ -35378,7 +35378,7 @@
     {
         "guid": 40039,
         "name_id": 822,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 443,
         "unknown6": 0,
         "tint": 0,
@@ -35422,7 +35422,7 @@
     {
         "guid": 40040,
         "name_id": 20053,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1470,
         "unknown6": 0,
         "tint": 0,
@@ -35466,7 +35466,7 @@
     {
         "guid": 40041,
         "name_id": 14166,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 447,
         "unknown6": 0,
         "tint": 0,
@@ -35510,7 +35510,7 @@
     {
         "guid": 40042,
         "name_id": 2508,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 135,
         "unknown6": 0,
         "tint": 0,
@@ -35554,7 +35554,7 @@
     {
         "guid": 40043,
         "name_id": 8520,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 129,
         "unknown6": 0,
         "tint": 0,
@@ -35598,7 +35598,7 @@
     {
         "guid": 40044,
         "name_id": 8522,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 130,
         "unknown6": 0,
         "tint": 0,
@@ -35642,7 +35642,7 @@
     {
         "guid": 40045,
         "name_id": 8910,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 131,
         "unknown6": 0,
         "tint": 0,
@@ -35686,7 +35686,7 @@
     {
         "guid": 40046,
         "name_id": 8920,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 132,
         "unknown6": 0,
         "tint": 0,
@@ -35730,7 +35730,7 @@
     {
         "guid": 40047,
         "name_id": 8928,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 133,
         "unknown6": 0,
         "tint": 0,
@@ -35774,7 +35774,7 @@
     {
         "guid": 40048,
         "name_id": 8936,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 134,
         "unknown6": 0,
         "tint": 0,
@@ -35818,7 +35818,7 @@
     {
         "guid": 40049,
         "name_id": 164,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 125,
         "unknown6": 0,
         "tint": 0,
@@ -35862,7 +35862,7 @@
     {
         "guid": 40050,
         "name_id": 186,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 127,
         "unknown6": 0,
         "tint": 0,
@@ -35906,7 +35906,7 @@
     {
         "guid": 40051,
         "name_id": 196,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 128,
         "unknown6": 0,
         "tint": 0,
@@ -35950,7 +35950,7 @@
     {
         "guid": 40052,
         "name_id": 172,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 126,
         "unknown6": 0,
         "tint": 0,
@@ -35994,7 +35994,7 @@
     {
         "guid": 40053,
         "name_id": 0,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 379,
         "unknown6": 0,
         "tint": 0,
@@ -36038,7 +36038,7 @@
     {
         "guid": 40054,
         "name_id": 1180,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 378,
         "unknown6": 0,
         "tint": 0,
@@ -36082,7 +36082,7 @@
     {
         "guid": 40055,
         "name_id": 838,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 455,
         "unknown6": 0,
         "tint": 0,
@@ -36126,7 +36126,7 @@
     {
         "guid": 40056,
         "name_id": 868,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 477,
         "unknown6": 0,
         "tint": 0,
@@ -36170,7 +36170,7 @@
     {
         "guid": 40057,
         "name_id": 944,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 469,
         "unknown6": 0,
         "tint": 0,
@@ -36214,7 +36214,7 @@
     {
         "guid": 40058,
         "name_id": 1335,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1122,
         "unknown6": 0,
         "tint": 0,
@@ -36258,7 +36258,7 @@
     {
         "guid": 40059,
         "name_id": 1337,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1126,
         "unknown6": 0,
         "tint": 0,
@@ -36302,7 +36302,7 @@
     {
         "guid": 40060,
         "name_id": 1339,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1130,
         "unknown6": 0,
         "tint": 0,
@@ -36346,7 +36346,7 @@
     {
         "guid": 40061,
         "name_id": 1341,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1134,
         "unknown6": 0,
         "tint": 0,
@@ -36390,7 +36390,7 @@
     {
         "guid": 40062,
         "name_id": 20315,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1485,
         "unknown6": 0,
         "tint": 0,
@@ -36434,7 +36434,7 @@
     {
         "guid": 40063,
         "name_id": 32978,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1609,
         "unknown6": 0,
         "tint": 0,
@@ -36478,7 +36478,7 @@
     {
         "guid": 40064,
         "name_id": 43059,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1744,
         "unknown6": 0,
         "tint": 0,
@@ -36522,7 +36522,7 @@
     {
         "guid": 40065,
         "name_id": 43063,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1748,
         "unknown6": 0,
         "tint": 0,
@@ -36566,7 +36566,7 @@
     {
         "guid": 40066,
         "name_id": 2682,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 680,
         "unknown6": 0,
         "tint": 0,
@@ -36610,7 +36610,7 @@
     {
         "guid": 40067,
         "name_id": 43688,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1865,
         "unknown6": 0,
         "tint": 0,
@@ -36654,7 +36654,7 @@
     {
         "guid": 40068,
         "name_id": 43712,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1889,
         "unknown6": 0,
         "tint": 0,
@@ -36698,7 +36698,7 @@
     {
         "guid": 40069,
         "name_id": 44753,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2015,
         "unknown6": 0,
         "tint": 0,
@@ -36742,7 +36742,7 @@
     {
         "guid": 40070,
         "name_id": 43684,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1861,
         "unknown6": 0,
         "tint": 0,
@@ -36786,7 +36786,7 @@
     {
         "guid": 40071,
         "name_id": 44884,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2116,
         "unknown6": 0,
         "tint": 0,
@@ -36830,7 +36830,7 @@
     {
         "guid": 40072,
         "name_id": 2710,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 680,
         "unknown6": 0,
         "tint": 0,
@@ -36874,7 +36874,7 @@
     {
         "guid": 40073,
         "name_id": 2706,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 680,
         "unknown6": 0,
         "tint": 0,
@@ -36918,7 +36918,7 @@
     {
         "guid": 40074,
         "name_id": 1468,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1077,
         "unknown6": 0,
         "tint": 0,
@@ -36962,7 +36962,7 @@
     {
         "guid": 40075,
         "name_id": 1343,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1138,
         "unknown6": 0,
         "tint": 0,
@@ -37006,7 +37006,7 @@
     {
         "guid": 40076,
         "name_id": 54533,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3801,
         "unknown6": 0,
         "tint": 0,
@@ -37050,7 +37050,7 @@
     {
         "guid": 40077,
         "name_id": 33105,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1649,
         "unknown6": 0,
         "tint": 0,
@@ -37094,7 +37094,7 @@
     {
         "guid": 40078,
         "name_id": 33109,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1653,
         "unknown6": 0,
         "tint": 0,
@@ -37138,7 +37138,7 @@
     {
         "guid": 40079,
         "name_id": 33887,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1670,
         "unknown6": 0,
         "tint": 0,
@@ -37182,7 +37182,7 @@
     {
         "guid": 40080,
         "name_id": 43692,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1869,
         "unknown6": 0,
         "tint": 0,
@@ -37226,7 +37226,7 @@
     {
         "guid": 40081,
         "name_id": 43732,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1909,
         "unknown6": 0,
         "tint": 0,
@@ -37270,7 +37270,7 @@
     {
         "guid": 40082,
         "name_id": 43728,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1905,
         "unknown6": 0,
         "tint": 0,
@@ -37314,7 +37314,7 @@
     {
         "guid": 40083,
         "name_id": 43716,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1893,
         "unknown6": 0,
         "tint": 0,
@@ -37358,7 +37358,7 @@
     {
         "guid": 40084,
         "name_id": 43680,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1857,
         "unknown6": 0,
         "tint": 0,
@@ -37402,7 +37402,7 @@
     {
         "guid": 40085,
         "name_id": 43720,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1897,
         "unknown6": 0,
         "tint": 0,
@@ -37446,7 +37446,7 @@
     {
         "guid": 40086,
         "name_id": 43724,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1901,
         "unknown6": 0,
         "tint": 0,
@@ -37490,7 +37490,7 @@
     {
         "guid": 40087,
         "name_id": 54086,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3339,
         "unknown6": 0,
         "tint": 0,
@@ -37534,7 +37534,7 @@
     {
         "guid": 40088,
         "name_id": 60182,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3723,
         "unknown6": 0,
         "tint": 0,
@@ -37578,7 +37578,7 @@
     {
         "guid": 40089,
         "name_id": 830,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 451,
         "unknown6": 0,
         "tint": 0,
@@ -37622,7 +37622,7 @@
     {
         "guid": 40090,
         "name_id": 1561,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2837,
         "unknown6": 0,
         "tint": 0,
@@ -37666,7 +37666,7 @@
     {
         "guid": 40091,
         "name_id": 4385,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2467,
         "unknown6": 0,
         "tint": 0,
@@ -37710,7 +37710,7 @@
     {
         "guid": 40092,
         "name_id": 54515,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3769,
         "unknown6": 0,
         "tint": 0,
@@ -37754,7 +37754,7 @@
     {
         "guid": 40093,
         "name_id": 54544,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3810,
         "unknown6": 0,
         "tint": 0,
@@ -37798,7 +37798,7 @@
     {
         "guid": 40094,
         "name_id": 4481,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2570,
         "unknown6": 0,
         "tint": 0,
@@ -37842,7 +37842,7 @@
     {
         "guid": 40095,
         "name_id": 52801,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3105,
         "unknown6": 0,
         "tint": 0,
@@ -37886,7 +37886,7 @@
     {
         "guid": 40096,
         "name_id": 20323,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1489,
         "unknown6": 0,
         "tint": 0,
@@ -37930,7 +37930,7 @@
     {
         "guid": 40097,
         "name_id": 2384,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2349,
         "unknown6": 0,
         "tint": 0,
@@ -37974,7 +37974,7 @@
     {
         "guid": 40098,
         "name_id": 4308,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2412,
         "unknown6": 0,
         "tint": 0,
@@ -38018,7 +38018,7 @@
     {
         "guid": 40099,
         "name_id": 53726,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3243,
         "unknown6": 0,
         "tint": 0,
@@ -38062,7 +38062,7 @@
     {
         "guid": 40100,
         "name_id": 2372,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2345,
         "unknown6": 0,
         "tint": 0,
@@ -38106,7 +38106,7 @@
     {
         "guid": 40101,
         "name_id": 1212,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 680,
         "unknown6": 0,
         "tint": 0,
@@ -38150,7 +38150,7 @@
     {
         "guid": 40102,
         "name_id": 2945,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2379,
         "unknown6": 0,
         "tint": 0,
@@ -38194,7 +38194,7 @@
     {
         "guid": 40103,
         "name_id": 4393,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2486,
         "unknown6": 0,
         "tint": 0,
@@ -38238,7 +38238,7 @@
     {
         "guid": 40104,
         "name_id": 4916,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2946,
         "unknown6": 0,
         "tint": 0,
@@ -38282,7 +38282,7 @@
     {
         "guid": 40105,
         "name_id": 4912,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2942,
         "unknown6": 0,
         "tint": 0,
@@ -38326,7 +38326,7 @@
     {
         "guid": 40106,
         "name_id": 53547,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3188,
         "unknown6": 0,
         "tint": 0,
@@ -38370,7 +38370,7 @@
     {
         "guid": 40107,
         "name_id": 53967,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3269,
         "unknown6": 0,
         "tint": 0,
@@ -38414,7 +38414,7 @@
     {
         "guid": 40108,
         "name_id": 54270,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3643,
         "unknown6": 0,
         "tint": 0,
@@ -38458,7 +38458,7 @@
     {
         "guid": 40109,
         "name_id": 54276,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3647,
         "unknown6": 0,
         "tint": 0,
@@ -38502,7 +38502,7 @@
     {
         "guid": 40110,
         "name_id": 54282,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3652,
         "unknown6": 0,
         "tint": 0,
@@ -38546,7 +38546,7 @@
     {
         "guid": 40111,
         "name_id": 54412,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3682,
         "unknown6": 0,
         "tint": 0,
@@ -38590,7 +38590,7 @@
     {
         "guid": 40112,
         "name_id": 54555,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3819,
         "unknown6": 0,
         "tint": 0,
@@ -38634,7 +38634,7 @@
     {
         "guid": 40113,
         "name_id": 54580,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3825,
         "unknown6": 0,
         "tint": 0,
@@ -38678,7 +38678,7 @@
     {
         "guid": 40114,
         "name_id": 4920,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2950,
         "unknown6": 0,
         "tint": 0,
@@ -38722,7 +38722,7 @@
     {
         "guid": 40115,
         "name_id": 4279,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2398,
         "unknown6": 0,
         "tint": 0,
@@ -38766,7 +38766,7 @@
     {
         "guid": 40116,
         "name_id": 8890,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 136,
         "unknown6": 0,
         "tint": 0,
@@ -38810,7 +38810,7 @@
     {
         "guid": 40117,
         "name_id": 20303,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1505,
         "unknown6": 0,
         "tint": 0,
@@ -38854,7 +38854,7 @@
     {
         "guid": 40118,
         "name_id": 44758,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2031,
         "unknown6": 0,
         "tint": 0,
@@ -38898,7 +38898,7 @@
     {
         "guid": 40119,
         "name_id": 14174,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 492,
         "unknown6": 0,
         "tint": 0,
@@ -38942,7 +38942,7 @@
     {
         "guid": 40120,
         "name_id": 53651,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3218,
         "unknown6": 0,
         "tint": 0,
@@ -38986,7 +38986,7 @@
     {
         "guid": 40121,
         "name_id": 1188,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 380,
         "unknown6": 0,
         "tint": 0,
@@ -39030,7 +39030,7 @@
     {
         "guid": 40122,
         "name_id": 1913,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1449,
         "unknown6": 0,
         "tint": 0,
@@ -39074,7 +39074,7 @@
     {
         "guid": 40123,
         "name_id": 1204,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 381,
         "unknown6": 0,
         "tint": 0,
@@ -39118,7 +39118,7 @@
     {
         "guid": 40124,
         "name_id": 1305,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1081,
         "unknown6": 0,
         "tint": 0,
@@ -39162,7 +39162,7 @@
     {
         "guid": 40125,
         "name_id": 32930,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1081,
         "unknown6": 0,
         "tint": 0,
@@ -39206,7 +39206,7 @@
     {
         "guid": 40126,
         "name_id": 54471,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3715,
         "unknown6": 0,
         "tint": 0,
@@ -39250,7 +39250,7 @@
     {
         "guid": 40127,
         "name_id": 54496,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3749,
         "unknown6": 0,
         "tint": 0,
@@ -39294,7 +39294,7 @@
     {
         "guid": 40128,
         "name_id": 4748,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2788,
         "unknown6": 0,
         "tint": 0,
@@ -39338,7 +39338,7 @@
     {
         "guid": 40129,
         "name_id": 4744,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2784,
         "unknown6": 0,
         "tint": 0,
@@ -39382,7 +39382,7 @@
     {
         "guid": 40130,
         "name_id": 2686,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2853,
         "unknown6": 0,
         "tint": 0,
@@ -39426,7 +39426,7 @@
     {
         "guid": 40131,
         "name_id": 52795,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3115,
         "unknown6": 0,
         "tint": 0,
@@ -39470,7 +39470,7 @@
     {
         "guid": 40132,
         "name_id": 4927,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1877,
         "unknown6": 0,
         "tint": 0,
@@ -39514,7 +39514,7 @@
     {
         "guid": 40133,
         "name_id": 43704,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1881,
         "unknown6": 0,
         "tint": 0,
@@ -39558,7 +39558,7 @@
     {
         "guid": 40134,
         "name_id": 54482,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3707,
         "unknown6": 0,
         "tint": 0,
@@ -39602,7 +39602,7 @@
     {
         "guid": 40135,
         "name_id": 53718,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3235,
         "unknown6": 0,
         "tint": 0,
@@ -39646,7 +39646,7 @@
     {
         "guid": 40136,
         "name_id": 53714,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3231,
         "unknown6": 0,
         "tint": 0,
@@ -39690,7 +39690,7 @@
     {
         "guid": 40137,
         "name_id": 53710,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3227,
         "unknown6": 0,
         "tint": 0,
@@ -39734,7 +39734,7 @@
     {
         "guid": 40138,
         "name_id": 53722,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3239,
         "unknown6": 0,
         "tint": 0,
@@ -39778,7 +39778,7 @@
     {
         "guid": 40139,
         "name_id": 180,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 137,
         "unknown6": 0,
         "tint": 0,
@@ -39822,7 +39822,7 @@
     {
         "guid": 40140,
         "name_id": 1196,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 382,
         "unknown6": 0,
         "tint": 0,
@@ -39866,7 +39866,7 @@
     {
         "guid": 40141,
         "name_id": 2698,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2592,
         "unknown6": 0,
         "tint": 0,
@@ -39910,7 +39910,7 @@
     {
         "guid": 40142,
         "name_id": 2702,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 680,
         "unknown6": 0,
         "tint": 0,
@@ -39954,7 +39954,7 @@
     {
         "guid": 40143,
         "name_id": 54250,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3630,
         "unknown6": 0,
         "tint": 0,
@@ -39998,7 +39998,7 @@
     {
         "guid": 40144,
         "name_id": 54417,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3688,
         "unknown6": 0,
         "tint": 0,
@@ -40042,7 +40042,7 @@
     {
         "guid": 40145,
         "name_id": 2694,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2742,
         "unknown6": 0,
         "tint": 0,
@@ -40086,7 +40086,7 @@
     {
         "guid": 40146,
         "name_id": 4304,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2424,
         "unknown6": 0,
         "tint": 0,
@@ -40130,7 +40130,7 @@
     {
         "guid": 40147,
         "name_id": 2665,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2165,
         "unknown6": 0,
         "tint": 0,
@@ -40174,7 +40174,7 @@
     {
         "guid": 40148,
         "name_id": 4684,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2738,
         "unknown6": 0,
         "tint": 0,
@@ -40218,7 +40218,7 @@
     {
         "guid": 40149,
         "name_id": 1470,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1093,
         "unknown6": 0,
         "tint": 0,
@@ -40262,7 +40262,7 @@
     {
         "guid": 40150,
         "name_id": 1346,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1085,
         "unknown6": 0,
         "tint": 0,
@@ -40306,7 +40306,7 @@
     {
         "guid": 40151,
         "name_id": 1348,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1089,
         "unknown6": 0,
         "tint": 0,
@@ -40350,7 +40350,7 @@
     {
         "guid": 40152,
         "name_id": 1579,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1239,
         "unknown6": 0,
         "tint": 0,
@@ -40394,7 +40394,7 @@
     {
         "guid": 40153,
         "name_id": 4626,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2691,
         "unknown6": 0,
         "tint": 0,
@@ -40438,7 +40438,7 @@
     {
         "guid": 40154,
         "name_id": 54601,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3834,
         "unknown6": 0,
         "tint": 0,
@@ -40482,7 +40482,7 @@
     {
         "guid": 40155,
         "name_id": 60290,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3739,
         "unknown6": 0,
         "tint": 0,
@@ -40526,7 +40526,7 @@
     {
         "guid": 40156,
         "name_id": 896,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 499,
         "unknown6": 0,
         "tint": 0,
@@ -40570,7 +40570,7 @@
     {
         "guid": 40157,
         "name_id": 43696,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1873,
         "unknown6": 0,
         "tint": 0,
@@ -40614,7 +40614,7 @@
     {
         "guid": 40158,
         "name_id": 0,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 680,
         "unknown6": 0,
         "tint": 0,
@@ -40658,7 +40658,7 @@
     {
         "guid": 40159,
         "name_id": 858,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 472,
         "unknown6": 0,
         "tint": 0,
@@ -40702,7 +40702,7 @@
     {
         "guid": 40160,
         "name_id": 304,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 138,
         "unknown6": 0,
         "tint": 0,
@@ -40746,7 +40746,7 @@
     {
         "guid": 40161,
         "name_id": 1575,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1320,
         "unknown6": 0,
         "tint": 0,
@@ -40790,7 +40790,7 @@
     {
         "guid": 40162,
         "name_id": 304,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3840,
         "unknown6": 0,
         "tint": 0,
@@ -40834,7 +40834,7 @@
     {
         "guid": 40163,
         "name_id": 304,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 680,
         "unknown6": 0,
         "tint": 0,
@@ -40878,7 +40878,7 @@
     {
         "guid": 40164,
         "name_id": 310,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 139,
         "unknown6": 0,
         "tint": 0,
@@ -40922,7 +40922,7 @@
     {
         "guid": 40165,
         "name_id": 876,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 383,
         "unknown6": 0,
         "tint": 0,
@@ -40966,7 +40966,7 @@
     {
         "guid": 40166,
         "name_id": 852,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 465,
         "unknown6": 0,
         "tint": 0,
@@ -41010,7 +41010,7 @@
     {
         "guid": 40167,
         "name_id": 1350,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1198,
         "unknown6": 0,
         "tint": 0,
@@ -41054,7 +41054,7 @@
     {
         "guid": 40168,
         "name_id": 1652,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 680,
         "unknown6": 0,
         "tint": 0,
@@ -41098,7 +41098,7 @@
     {
         "guid": 40169,
         "name_id": 1664,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1251,
         "unknown6": 0,
         "tint": 0,
@@ -41142,7 +41142,7 @@
     {
         "guid": 40170,
         "name_id": 1850,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1382,
         "unknown6": 0,
         "tint": 0,
@@ -41186,7 +41186,7 @@
     {
         "guid": 40171,
         "name_id": 43187,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1790,
         "unknown6": 0,
         "tint": 0,
@@ -41230,7 +41230,7 @@
     {
         "guid": 40172,
         "name_id": 1352,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1097,
         "unknown6": 0,
         "tint": 0,
@@ -41274,7 +41274,7 @@
     {
         "guid": 40173,
         "name_id": 54477,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3711,
         "unknown6": 0,
         "tint": 0,
@@ -41318,7 +41318,7 @@
     {
         "guid": 40174,
         "name_id": 52887,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3814,
         "unknown6": 0,
         "tint": 0,
@@ -41362,7 +41362,7 @@
     {
         "guid": 40175,
         "name_id": 200,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 140,
         "unknown6": 0,
         "tint": 0,
@@ -41406,7 +41406,7 @@
     {
         "guid": 40176,
         "name_id": 1622,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1247,
         "unknown6": 0,
         "tint": 0,
@@ -41450,7 +41450,7 @@
     {
         "guid": 40177,
         "name_id": 8904,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 141,
         "unknown6": 0,
         "tint": 0,
@@ -41494,7 +41494,7 @@
     {
         "guid": 40178,
         "name_id": 44880,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2111,
         "unknown6": 0,
         "tint": 0,
@@ -41538,7 +41538,7 @@
     {
         "guid": 40179,
         "name_id": 2678,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3335,
         "unknown6": 0,
         "tint": 0,
@@ -41582,7 +41582,7 @@
     {
         "guid": 40180,
         "name_id": 4716,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2763,
         "unknown6": 0,
         "tint": 0,
@@ -41626,7 +41626,7 @@
     {
         "guid": 40181,
         "name_id": 206,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 142,
         "unknown6": 0,
         "tint": 0,
@@ -41670,7 +41670,7 @@
     {
         "guid": 40182,
         "name_id": 54606,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3838,
         "unknown6": 0,
         "tint": 0,
@@ -41714,7 +41714,7 @@
     {
         "guid": 40183,
         "name_id": 206,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 680,
         "unknown6": 0,
         "tint": 0,
@@ -41758,7 +41758,7 @@
     {
         "guid": 40184,
         "name_id": 1472,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1101,
         "unknown6": 0,
         "tint": 0,
@@ -41802,7 +41802,7 @@
     {
         "guid": 40185,
         "name_id": 1472,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3842,
         "unknown6": 0,
         "tint": 0,
@@ -41846,7 +41846,7 @@
     {
         "guid": 40186,
         "name_id": 1472,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 680,
         "unknown6": 0,
         "tint": 0,
@@ -41890,7 +41890,7 @@
     {
         "guid": 40187,
         "name_id": 4822,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2856,
         "unknown6": 0,
         "tint": 0,
@@ -41934,7 +41934,7 @@
     {
         "guid": 40188,
         "name_id": 52789,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3111,
         "unknown6": 0,
         "tint": 0,
@@ -41978,7 +41978,7 @@
     {
         "guid": 40189,
         "name_id": 360,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 143,
         "unknown6": 0,
         "tint": 0,
@@ -42022,7 +42022,7 @@
     {
         "guid": 40190,
         "name_id": 880,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 482,
         "unknown6": 0,
         "tint": 0,
@@ -42066,7 +42066,7 @@
     {
         "guid": 40191,
         "name_id": 816,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 440,
         "unknown6": 0,
         "tint": 0,
@@ -42110,7 +42110,7 @@
     {
         "guid": 40192,
         "name_id": 1354,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1103,
         "unknown6": 0,
         "tint": 0,
@@ -42154,7 +42154,7 @@
     {
         "guid": 40193,
         "name_id": 1840,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1379,
         "unknown6": 0,
         "tint": 0,
@@ -42198,7 +42198,7 @@
     {
         "guid": 40194,
         "name_id": 20307,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1481,
         "unknown6": 0,
         "tint": 0,
@@ -42242,7 +42242,7 @@
     {
         "guid": 40195,
         "name_id": 8886,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 144,
         "unknown6": 0,
         "tint": 0,
@@ -42286,7 +42286,7 @@
     {
         "guid": 40196,
         "name_id": 932,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 496,
         "unknown6": 0,
         "tint": 0,
@@ -42330,7 +42330,7 @@
     {
         "guid": 40197,
         "name_id": 212,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 145,
         "unknown6": 0,
         "tint": 0,
@@ -42374,7 +42374,7 @@
     {
         "guid": 40198,
         "name_id": 1474,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1112,
         "unknown6": 0,
         "tint": 0,
@@ -42418,7 +42418,7 @@
     {
         "guid": 40199,
         "name_id": 0,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 680,
         "unknown6": 0,
         "tint": 0,
@@ -42462,7 +42462,7 @@
     {
         "guid": 40200,
         "name_id": 4549,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2631,
         "unknown6": 0,
         "tint": 0,
@@ -42506,7 +42506,7 @@
     {
         "guid": 40201,
         "name_id": 8898,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 146,
         "unknown6": 0,
         "tint": 0,
@@ -42550,7 +42550,7 @@
     {
         "guid": 40202,
         "name_id": 4765,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2807,
         "unknown6": 0,
         "tint": 0,
@@ -42594,7 +42594,7 @@
     {
         "guid": 40203,
         "name_id": 1771,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1375,
         "unknown6": 0,
         "tint": 0,
@@ -42638,7 +42638,7 @@
     {
         "guid": 40204,
         "name_id": 1745,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1343,
         "unknown6": 0,
         "tint": 0,
@@ -42682,7 +42682,7 @@
     {
         "guid": 40205,
         "name_id": 43708,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1885,
         "unknown6": 0,
         "tint": 0,
@@ -42726,7 +42726,7 @@
     {
         "guid": 40206,
         "name_id": 218,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 147,
         "unknown6": 0,
         "tint": 0,
@@ -42770,7 +42770,7 @@
     {
         "guid": 40207,
         "name_id": 52808,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3140,
         "unknown6": 0,
         "tint": 0,
@@ -42814,7 +42814,7 @@
     {
         "guid": 40208,
         "name_id": 1925,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1453,
         "unknown6": 0,
         "tint": 0,
@@ -42858,7 +42858,7 @@
     {
         "guid": 40209,
         "name_id": 52856,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3084,
         "unknown6": 0,
         "tint": 0,
@@ -42902,7 +42902,7 @@
     {
         "guid": 40210,
         "name_id": 52836,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3062,
         "unknown6": 0,
         "tint": 0,
@@ -42946,7 +42946,7 @@
     {
         "guid": 40211,
         "name_id": 52836,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 680,
         "unknown6": 0,
         "tint": 0,
@@ -42990,7 +42990,7 @@
     {
         "guid": 40212,
         "name_id": 33785,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1666,
         "unknown6": 0,
         "tint": 0,
@@ -43034,7 +43034,7 @@
     {
         "guid": 40213,
         "name_id": 33560,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1660,
         "unknown6": 0,
         "tint": 0,
@@ -43078,7 +43078,7 @@
     {
         "guid": 40214,
         "name_id": 32934,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1596,
         "unknown6": 0,
         "tint": 0,
@@ -43122,7 +43122,7 @@
     {
         "guid": 40215,
         "name_id": 1585,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1930,
         "unknown6": 0,
         "tint": 0,
@@ -43166,7 +43166,7 @@
     {
         "guid": 40216,
         "name_id": 32986,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1626,
         "unknown6": 0,
         "tint": 0,
@@ -43210,7 +43210,7 @@
     {
         "guid": 40217,
         "name_id": 60773,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3856,
         "unknown6": 0,
         "tint": 0,
@@ -43254,7 +43254,7 @@
     {
         "guid": 40218,
         "name_id": 8536,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 148,
         "unknown6": 0,
         "tint": 0,
@@ -43298,7 +43298,7 @@
     {
         "guid": 40219,
         "name_id": 32937,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1603,
         "unknown6": 0,
         "tint": 0,
@@ -43342,7 +43342,7 @@
     {
         "guid": 40220,
         "name_id": 44501,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1984,
         "unknown6": 0,
         "tint": 0,
@@ -43386,7 +43386,7 @@
     {
         "guid": 40221,
         "name_id": 2659,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2162,
         "unknown6": 0,
         "tint": 0,
@@ -43430,7 +43430,7 @@
     {
         "guid": 40222,
         "name_id": 2671,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2296,
         "unknown6": 0,
         "tint": 0,
@@ -43474,7 +43474,7 @@
     {
         "guid": 40223,
         "name_id": 44830,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2064,
         "unknown6": 0,
         "tint": 0,
@@ -43518,7 +43518,7 @@
     {
         "guid": 40224,
         "name_id": 53543,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3183,
         "unknown6": 0,
         "tint": 0,
@@ -43562,7 +43562,7 @@
     {
         "guid": 40225,
         "name_id": 52913,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3156,
         "unknown6": 0,
         "tint": 0,
@@ -43606,7 +43606,7 @@
     {
         "guid": 40226,
         "name_id": 53606,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3205,
         "unknown6": 0,
         "tint": 0,
@@ -43650,7 +43650,7 @@
     {
         "guid": 40227,
         "name_id": 2975,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2385,
         "unknown6": 0,
         "tint": 0,
@@ -43694,7 +43694,7 @@
     {
         "guid": 40228,
         "name_id": 234,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 149,
         "unknown6": 0,
         "tint": 0,
@@ -43738,7 +43738,7 @@
     {
         "guid": 40229,
         "name_id": 43512,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1843,
         "unknown6": 0,
         "tint": 0,
@@ -43782,7 +43782,7 @@
     {
         "guid": 40230,
         "name_id": 44876,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2106,
         "unknown6": 0,
         "tint": 0,
@@ -43826,7 +43826,7 @@
     {
         "guid": 40231,
         "name_id": 54428,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3698,
         "unknown6": 0,
         "tint": 0,
@@ -43870,7 +43870,7 @@
     {
         "guid": 40232,
         "name_id": 2364,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2335,
         "unknown6": 0,
         "tint": 0,
@@ -43914,7 +43914,7 @@
     {
         "guid": 40233,
         "name_id": 1356,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1105,
         "unknown6": 0,
         "tint": 0,
@@ -43958,7 +43958,7 @@
     {
         "guid": 40234,
         "name_id": 60677,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3787,
         "unknown6": 0,
         "tint": 0,
@@ -44002,7 +44002,7 @@
     {
         "guid": 40235,
         "name_id": 1755,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1434,
         "unknown6": 0,
         "tint": 0,
@@ -44046,7 +44046,7 @@
     {
         "guid": 40236,
         "name_id": 4594,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2658,
         "unknown6": 0,
         "tint": 0,
@@ -44090,7 +44090,7 @@
     {
         "guid": 40237,
         "name_id": 242,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 150,
         "unknown6": 0,
         "tint": 0,
@@ -44134,7 +44134,7 @@
     {
         "guid": 40238,
         "name_id": 20056,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1473,
         "unknown6": 0,
         "tint": 0,
@@ -44178,7 +44178,7 @@
     {
         "guid": 40239,
         "name_id": 44853,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1109,
         "unknown6": 0,
         "tint": 0,
@@ -44222,7 +44222,7 @@
     {
         "guid": 40240,
         "name_id": 4819,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2849,
         "unknown6": 0,
         "tint": 0,
@@ -44266,7 +44266,7 @@
     {
         "guid": 40241,
         "name_id": 53973,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3273,
         "unknown6": 0,
         "tint": 0,
@@ -44310,7 +44310,7 @@
     {
         "guid": 40242,
         "name_id": 1763,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1350,
         "unknown6": 0,
         "tint": 0,
@@ -44354,7 +44354,7 @@
     {
         "guid": 40243,
         "name_id": 32974,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1606,
         "unknown6": 0,
         "tint": 0,
@@ -44398,7 +44398,7 @@
     {
         "guid": 40244,
         "name_id": 250,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 151,
         "unknown6": 0,
         "tint": 0,
@@ -44442,7 +44442,7 @@
     {
         "guid": 40245,
         "name_id": 1656,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1928,
         "unknown6": 0,
         "tint": 0,
@@ -44486,7 +44486,7 @@
     {
         "guid": 40246,
         "name_id": 4948,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3006,
         "unknown6": 0,
         "tint": 0,
@@ -44530,7 +44530,7 @@
     {
         "guid": 40247,
         "name_id": 4952,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3010,
         "unknown6": 0,
         "tint": 0,
@@ -44574,7 +44574,7 @@
     {
         "guid": 40248,
         "name_id": 4956,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3014,
         "unknown6": 0,
         "tint": 0,
@@ -44618,7 +44618,7 @@
     {
         "guid": 40249,
         "name_id": 1360,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1114,
         "unknown6": 0,
         "tint": 0,
@@ -44662,7 +44662,7 @@
     {
         "guid": 40250,
         "name_id": 4620,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2687,
         "unknown6": 0,
         "tint": 0,
@@ -44706,7 +44706,7 @@
     {
         "guid": 40251,
         "name_id": 60197,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3718,
         "unknown6": 0,
         "tint": 0,
@@ -44750,7 +44750,7 @@
     {
         "guid": 40252,
         "name_id": 1362,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1118,
         "unknown6": 0,
         "tint": 0,
@@ -44794,7 +44794,7 @@
     {
         "guid": 40253,
         "name_id": 52907,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3150,
         "unknown6": 0,
         "tint": 0,
@@ -44838,7 +44838,7 @@
     {
         "guid": 40254,
         "name_id": 1775,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1347,
         "unknown6": 0,
         "tint": 0,
@@ -44882,7 +44882,7 @@
     {
         "guid": 40255,
         "name_id": 226,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 152,
         "unknown6": 0,
         "tint": 0,
@@ -44926,7 +44926,7 @@
     {
         "guid": 40256,
         "name_id": 258,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 153,
         "unknown6": 0,
         "tint": 0,
@@ -44970,7 +44970,7 @@
     {
         "guid": 40257,
         "name_id": 4615,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2683,
         "unknown6": 0,
         "tint": 0,
@@ -45014,7 +45014,7 @@
     {
         "guid": 40258,
         "name_id": 4300,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2409,
         "unknown6": 0,
         "tint": 0,
@@ -45058,7 +45058,7 @@
     {
         "guid": 40259,
         "name_id": 4781,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2822,
         "unknown6": 0,
         "tint": 0,
@@ -45102,7 +45102,7 @@
     {
         "guid": 40260,
         "name_id": 4777,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2818,
         "unknown6": 0,
         "tint": 0,
@@ -45146,7 +45146,7 @@
     {
         "guid": 40261,
         "name_id": 4773,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2814,
         "unknown6": 0,
         "tint": 0,
@@ -45190,7 +45190,7 @@
     {
         "guid": 40262,
         "name_id": 888,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 488,
         "unknown6": 0,
         "tint": 0,
@@ -45234,7 +45234,7 @@
     {
         "guid": 40263,
         "name_id": 32982,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1613,
         "unknown6": 0,
         "tint": 0,
@@ -45278,7 +45278,7 @@
     {
         "guid": 40264,
         "name_id": 948,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 503,
         "unknown6": 0,
         "tint": 0,
@@ -45322,7 +45322,7 @@
     {
         "guid": 40265,
         "name_id": 946,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 484,
         "unknown6": 0,
         "tint": 0,
@@ -45366,7 +45366,7 @@
     {
         "guid": 40266,
         "name_id": 950,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 462,
         "unknown6": 0,
         "tint": 0,
@@ -45410,7 +45410,7 @@
     {
         "guid": 40267,
         "name_id": 44892,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2126,
         "unknown6": 0,
         "tint": 0,
@@ -45454,7 +45454,7 @@
     {
         "guid": 40268,
         "name_id": 4511,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2581,
         "unknown6": 0,
         "tint": 0,
@@ -45498,7 +45498,7 @@
     {
         "guid": 40269,
         "name_id": 1589,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1240,
         "unknown6": 0,
         "tint": 0,
@@ -45542,7 +45542,7 @@
     {
         "guid": 40270,
         "name_id": 44318,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1973,
         "unknown6": 0,
         "tint": 0,
@@ -45586,7 +45586,7 @@
     {
         "guid": 40271,
         "name_id": 44316,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1971,
         "unknown6": 0,
         "tint": 0,
@@ -45630,7 +45630,7 @@
     {
         "guid": 40272,
         "name_id": 1476,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1142,
         "unknown6": 0,
         "tint": 0,
@@ -45674,7 +45674,7 @@
     {
         "guid": 40273,
         "name_id": 1364,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1145,
         "unknown6": 0,
         "tint": 0,
@@ -45718,7 +45718,7 @@
     {
         "guid": 40274,
         "name_id": 4454,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2512,
         "unknown6": 0,
         "tint": 0,
@@ -45762,7 +45762,7 @@
     {
         "guid": 40275,
         "name_id": 4462,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2517,
         "unknown6": 0,
         "tint": 0,
@@ -45806,7 +45806,7 @@
     {
         "guid": 50000,
         "name_id": 2526,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 419,
         "unknown6": 0,
         "tint": 0,
@@ -45850,7 +45850,7 @@
     {
         "guid": 50001,
         "name_id": 1258,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 410,
         "unknown6": 0,
         "tint": 0,
@@ -45894,7 +45894,7 @@
     {
         "guid": 50002,
         "name_id": 54524,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 410,
         "unknown6": 0,
         "tint": 0,
@@ -45938,7 +45938,7 @@
     {
         "guid": 50003,
         "name_id": 1524,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 396,
         "unknown6": 0,
         "tint": 0,
@@ -45982,7 +45982,7 @@
     {
         "guid": 50004,
         "name_id": 1253,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 409,
         "unknown6": 0,
         "tint": 0,
@@ -46026,7 +46026,7 @@
     {
         "guid": 50005,
         "name_id": 1254,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 412,
         "unknown6": 0,
         "tint": 0,
@@ -46070,7 +46070,7 @@
     {
         "guid": 50006,
         "name_id": 54484,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3745,
         "unknown6": 0,
         "tint": 0,
@@ -46114,7 +46114,7 @@
     {
         "guid": 50007,
         "name_id": 1255,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 413,
         "unknown6": 0,
         "tint": 0,
@@ -46158,7 +46158,7 @@
     {
         "guid": 50008,
         "name_id": 1256,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 414,
         "unknown6": 0,
         "tint": 0,
@@ -46202,7 +46202,7 @@
     {
         "guid": 50009,
         "name_id": 1257,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 416,
         "unknown6": 0,
         "tint": 0,
@@ -46246,7 +46246,7 @@
     {
         "guid": 50010,
         "name_id": 44509,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1996,
         "unknown6": 0,
         "tint": 0,
@@ -46290,7 +46290,7 @@
     {
         "guid": 50011,
         "name_id": 54597,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 419,
         "unknown6": 0,
         "tint": 0,
@@ -46334,7 +46334,7 @@
     {
         "guid": 50012,
         "name_id": 2652,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2142,
         "unknown6": 0,
         "tint": 0,
@@ -46378,7 +46378,7 @@
     {
         "guid": 50013,
         "name_id": 44851,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 411,
         "unknown6": 0,
         "tint": 0,
@@ -46422,7 +46422,7 @@
     {
         "guid": 50014,
         "name_id": 1931,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 417,
         "unknown6": 0,
         "tint": 0,
@@ -46466,7 +46466,7 @@
     {
         "guid": 50015,
         "name_id": 1259,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 415,
         "unknown6": 0,
         "tint": 0,
@@ -46510,7 +46510,7 @@
     {
         "guid": 50016,
         "name_id": 53018,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 409,
         "unknown6": 0,
         "tint": 0,
@@ -46554,7 +46554,7 @@
     {
         "guid": 50017,
         "name_id": 54492,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3745,
         "unknown6": 0,
         "tint": 0,
@@ -46598,7 +46598,7 @@
     {
         "guid": 50018,
         "name_id": 53017,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 416,
         "unknown6": 0,
         "tint": 0,
@@ -46642,7 +46642,7 @@
     {
         "guid": 50019,
         "name_id": 44197,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 418,
         "unknown6": 0,
         "tint": 0,
@@ -46686,7 +46686,7 @@
     {
         "guid": 60000,
         "name_id": 2527,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 398,
         "unknown6": 0,
         "tint": 20,
@@ -46730,7 +46730,7 @@
     {
         "guid": 60001,
         "name_id": 2528,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 399,
         "unknown6": 0,
         "tint": 21,
@@ -46774,7 +46774,7 @@
     {
         "guid": 60002,
         "name_id": 2529,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 408,
         "unknown6": 0,
         "tint": 22,
@@ -46818,7 +46818,7 @@
     {
         "guid": 60003,
         "name_id": 2530,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 401,
         "unknown6": 0,
         "tint": 23,
@@ -46862,7 +46862,7 @@
     {
         "guid": 60004,
         "name_id": 2531,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 404,
         "unknown6": 0,
         "tint": 24,
@@ -46906,7 +46906,7 @@
     {
         "guid": 60005,
         "name_id": 2532,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 403,
         "unknown6": 0,
         "tint": 25,
@@ -46950,7 +46950,7 @@
     {
         "guid": 60006,
         "name_id": 2533,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 405,
         "unknown6": 0,
         "tint": 26,
@@ -46994,7 +46994,7 @@
     {
         "guid": 60007,
         "name_id": 2534,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 406,
         "unknown6": 0,
         "tint": 27,
@@ -47038,7 +47038,7 @@
     {
         "guid": 60008,
         "name_id": 2535,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 402,
         "unknown6": 0,
         "tint": 28,
@@ -47082,7 +47082,7 @@
     {
         "guid": 60009,
         "name_id": 2536,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 400,
         "unknown6": 0,
         "tint": 29,
@@ -47126,7 +47126,7 @@
     {
         "guid": 60010,
         "name_id": 2537,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 407,
         "unknown6": 0,
         "tint": 30,
@@ -47170,7 +47170,7 @@
     {
         "guid": 60011,
         "name_id": 2538,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 397,
         "unknown6": 0,
         "tint": 31,
@@ -47214,7 +47214,7 @@
     {
         "guid": 60012,
         "name_id": 51152,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2772,
         "unknown6": 0,
         "tint": 47,
@@ -47258,7 +47258,7 @@
     {
         "guid": 70000,
         "name_id": 4975,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3044,
         "unknown6": 0,
         "tint": 0,
@@ -47302,7 +47302,7 @@
     {
         "guid": 70001,
         "name_id": 8764,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 219,
         "unknown6": 0,
         "tint": 0,
@@ -47346,7 +47346,7 @@
     {
         "guid": 70002,
         "name_id": 4806,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2838,
         "unknown6": 0,
         "tint": 0,
@@ -47390,7 +47390,7 @@
     {
         "guid": 70003,
         "name_id": 33110,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1656,
         "unknown6": 0,
         "tint": 0,
@@ -47434,7 +47434,7 @@
     {
         "guid": 70004,
         "name_id": 52792,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3118,
         "unknown6": 0,
         "tint": 0,
@@ -47478,7 +47478,7 @@
     {
         "guid": 70005,
         "name_id": 8761,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 220,
         "unknown6": 0,
         "tint": 0,
@@ -47522,7 +47522,7 @@
     {
         "guid": 70006,
         "name_id": 4907,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2938,
         "unknown6": 0,
         "tint": 0,
@@ -47566,7 +47566,7 @@
     {
         "guid": 70007,
         "name_id": 60286,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3735,
         "unknown6": 0,
         "tint": 0,
@@ -47610,7 +47610,7 @@
     {
         "guid": 70008,
         "name_id": 52786,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3133,
         "unknown6": 0,
         "tint": 0,
@@ -47654,7 +47654,7 @@
     {
         "guid": 70009,
         "name_id": 4823,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2862,
         "unknown6": 0,
         "tint": 0,
@@ -47698,7 +47698,7 @@
     {
         "guid": 70010,
         "name_id": 306,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 221,
         "unknown6": 0,
         "tint": 0,
@@ -47742,7 +47742,7 @@
     {
         "guid": 70011,
         "name_id": 8768,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 222,
         "unknown6": 0,
         "tint": 0,
@@ -47786,7 +47786,7 @@
     {
         "guid": 70012,
         "name_id": 19895,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1459,
         "unknown6": 0,
         "tint": 0,
@@ -47830,7 +47830,7 @@
     {
         "guid": 70013,
         "name_id": 51036,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 425,
         "unknown6": 0,
         "tint": 0,
@@ -47874,7 +47874,7 @@
     {
         "guid": 70015,
         "name_id": 8762,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 223,
         "unknown6": 0,
         "tint": 0,
@@ -47918,7 +47918,7 @@
     {
         "guid": 70016,
         "name_id": 51037,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 425,
         "unknown6": 0,
         "tint": 0,
@@ -47962,7 +47962,7 @@
     {
         "guid": 70017,
         "name_id": 14786,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 508,
         "unknown6": 0,
         "tint": 0,
@@ -48006,7 +48006,7 @@
     {
         "guid": 70018,
         "name_id": 53615,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3207,
         "unknown6": 0,
         "tint": 0,
@@ -48050,7 +48050,7 @@
     {
         "guid": 70019,
         "name_id": 14788,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 509,
         "unknown6": 0,
         "tint": 0,
@@ -48094,7 +48094,7 @@
     {
         "guid": 70020,
         "name_id": 4976,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3045,
         "unknown6": 0,
         "tint": 0,
@@ -48138,7 +48138,7 @@
     {
         "guid": 70021,
         "name_id": 8763,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 224,
         "unknown6": 0,
         "tint": 0,
@@ -48182,7 +48182,7 @@
     {
         "guid": 70022,
         "name_id": 54592,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3829,
         "unknown6": 0,
         "tint": 0,
@@ -48226,7 +48226,7 @@
     {
         "guid": 70023,
         "name_id": 54521,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3791,
         "unknown6": 0,
         "tint": 0,
@@ -48270,7 +48270,7 @@
     {
         "guid": 70024,
         "name_id": 4718,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2764,
         "unknown6": 0,
         "tint": 0,
@@ -48314,7 +48314,7 @@
     {
         "guid": 70025,
         "name_id": 8766,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 225,
         "unknown6": 0,
         "tint": 0,
@@ -48358,7 +48358,7 @@
     {
         "guid": 70026,
         "name_id": 2440,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 226,
         "unknown6": 0,
         "tint": 0,
@@ -48402,7 +48402,7 @@
     {
         "guid": 70027,
         "name_id": 54602,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3835,
         "unknown6": 0,
         "tint": 0,
@@ -48446,7 +48446,7 @@
     {
         "guid": 70028,
         "name_id": 54593,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3828,
         "unknown6": 0,
         "tint": 0,
@@ -48490,7 +48490,7 @@
     {
         "guid": 70029,
         "name_id": 53620,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3212,
         "unknown6": 0,
         "tint": 0,
@@ -48534,7 +48534,7 @@
     {
         "guid": 70030,
         "name_id": 2650,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2136,
         "unknown6": 0,
         "tint": 0,
@@ -48578,7 +48578,7 @@
     {
         "guid": 70031,
         "name_id": 53616,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3208,
         "unknown6": 0,
         "tint": 0,
@@ -48622,7 +48622,7 @@
     {
         "guid": 70032,
         "name_id": 8769,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 227,
         "unknown6": 0,
         "tint": 0,
@@ -48666,7 +48666,7 @@
     {
         "guid": 70033,
         "name_id": 44507,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1993,
         "unknown6": 0,
         "tint": 0,
@@ -48710,7 +48710,7 @@
     {
         "guid": 70034,
         "name_id": 44850,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 510,
         "unknown6": 0,
         "tint": 0,
@@ -48754,7 +48754,7 @@
     {
         "guid": 70035,
         "name_id": 53621,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3213,
         "unknown6": 0,
         "tint": 0,
@@ -48798,7 +48798,7 @@
     {
         "guid": 70036,
         "name_id": 2444,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 228,
         "unknown6": 0,
         "tint": 0,
@@ -48842,7 +48842,7 @@
     {
         "guid": 70037,
         "name_id": 8767,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 229,
         "unknown6": 0,
         "tint": 0,
@@ -48886,7 +48886,7 @@
     {
         "guid": 70038,
         "name_id": 974,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 511,
         "unknown6": 0,
         "tint": 0,
@@ -48930,7 +48930,7 @@
     {
         "guid": 70039,
         "name_id": 60157,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 511,
         "unknown6": 0,
         "tint": 0,
@@ -48974,7 +48974,7 @@
     {
         "guid": 70040,
         "name_id": 8770,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 230,
         "unknown6": 0,
         "tint": 0,
@@ -49018,7 +49018,7 @@
     {
         "guid": 70041,
         "name_id": 8771,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 231,
         "unknown6": 0,
         "tint": 0,
@@ -49062,7 +49062,7 @@
     {
         "guid": 70042,
         "name_id": 308,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 232,
         "unknown6": 0,
         "tint": 0,
@@ -49106,7 +49106,7 @@
     {
         "guid": 70043,
         "name_id": 8772,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 233,
         "unknown6": 0,
         "tint": 0,
@@ -49150,7 +49150,7 @@
     {
         "guid": 70044,
         "name_id": 51038,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 425,
         "unknown6": 0,
         "tint": 0,
@@ -49194,7 +49194,7 @@
     {
         "guid": 70045,
         "name_id": 8773,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 234,
         "unknown6": 0,
         "tint": 0,
@@ -49238,7 +49238,7 @@
     {
         "guid": 70046,
         "name_id": 53617,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3209,
         "unknown6": 0,
         "tint": 0,
@@ -49282,7 +49282,7 @@
     {
         "guid": 70047,
         "name_id": 976,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 512,
         "unknown6": 0,
         "tint": 0,
@@ -49326,7 +49326,7 @@
     {
         "guid": 70048,
         "name_id": 60678,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3788,
         "unknown6": 0,
         "tint": 0,
@@ -49370,7 +49370,7 @@
     {
         "guid": 70049,
         "name_id": 19637,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1436,
         "unknown6": 0,
         "tint": 0,
@@ -49414,7 +49414,7 @@
     {
         "guid": 70050,
         "name_id": 43190,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1792,
         "unknown6": 0,
         "tint": 0,
@@ -49458,7 +49458,7 @@
     {
         "guid": 70051,
         "name_id": 14792,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 513,
         "unknown6": 0,
         "tint": 0,
@@ -49502,7 +49502,7 @@
     {
         "guid": 70052,
         "name_id": 8774,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 235,
         "unknown6": 0,
         "tint": 0,
@@ -49546,7 +49546,7 @@
     {
         "guid": 70053,
         "name_id": 978,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 514,
         "unknown6": 0,
         "tint": 0,
@@ -49590,7 +49590,7 @@
     {
         "guid": 70054,
         "name_id": 60198,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3721,
         "unknown6": 0,
         "tint": 0,
@@ -49634,7 +49634,7 @@
     {
         "guid": 70055,
         "name_id": 980,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 515,
         "unknown6": 0,
         "tint": 0,
@@ -49678,7 +49678,7 @@
     {
         "guid": 70056,
         "name_id": 4824,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2863,
         "unknown6": 0,
         "tint": 0,
@@ -49722,7 +49722,7 @@
     {
         "guid": 70057,
         "name_id": 8775,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 236,
         "unknown6": 0,
         "tint": 0,
@@ -49766,7 +49766,7 @@
     {
         "guid": 70058,
         "name_id": 982,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 516,
         "unknown6": 0,
         "tint": 0,
@@ -49810,7 +49810,7 @@
     {
         "guid": 70059,
         "name_id": 14794,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 517,
         "unknown6": 0,
         "tint": 0,
@@ -49854,7 +49854,7 @@
     {
         "guid": 70060,
         "name_id": 8777,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 237,
         "unknown6": 0,
         "tint": 0,
@@ -49898,7 +49898,7 @@
     {
         "guid": 70062,
         "name_id": 1797,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3169,
         "unknown6": 0,
         "tint": 0,
@@ -49942,7 +49942,7 @@
     {
         "guid": 70063,
         "name_id": 53619,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3211,
         "unknown6": 0,
         "tint": 0,
@@ -49986,7 +49986,7 @@
     {
         "guid": 70064,
         "name_id": 986,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1148,
         "unknown6": 0,
         "tint": 0,
@@ -50030,7 +50030,7 @@
     {
         "guid": 80010,
         "name_id": 306,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 221,
         "unknown6": 0,
         "tint": 0,
@@ -50074,7 +50074,7 @@
     {
         "guid": 80011,
         "name_id": 8768,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 222,
         "unknown6": 0,
         "tint": 0,
@@ -50118,7 +50118,7 @@
     {
         "guid": 80013,
         "name_id": 51036,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 425,
         "unknown6": 0,
         "tint": 0,
@@ -50162,7 +50162,7 @@
     {
         "guid": 80014,
         "name_id": 19893,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1459,
         "unknown6": 0,
         "tint": 0,
@@ -50206,7 +50206,7 @@
     {
         "guid": 80015,
         "name_id": 8762,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 223,
         "unknown6": 0,
         "tint": 0,
@@ -50250,7 +50250,7 @@
     {
         "guid": 80016,
         "name_id": 51037,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 425,
         "unknown6": 0,
         "tint": 0,
@@ -50294,7 +50294,7 @@
     {
         "guid": 80017,
         "name_id": 14786,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 508,
         "unknown6": 0,
         "tint": 0,
@@ -50338,7 +50338,7 @@
     {
         "guid": 80018,
         "name_id": 53615,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3207,
         "unknown6": 0,
         "tint": 0,
@@ -50382,7 +50382,7 @@
     {
         "guid": 80019,
         "name_id": 14788,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 509,
         "unknown6": 0,
         "tint": 0,
@@ -50426,7 +50426,7 @@
     {
         "guid": 80020,
         "name_id": 4976,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3045,
         "unknown6": 0,
         "tint": 0,
@@ -50470,7 +50470,7 @@
     {
         "guid": 80021,
         "name_id": 8763,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 224,
         "unknown6": 0,
         "tint": 0,
@@ -50514,7 +50514,7 @@
     {
         "guid": 80022,
         "name_id": 54592,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3829,
         "unknown6": 0,
         "tint": 0,
@@ -50558,7 +50558,7 @@
     {
         "guid": 80023,
         "name_id": 54521,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3791,
         "unknown6": 0,
         "tint": 0,
@@ -50602,7 +50602,7 @@
     {
         "guid": 80024,
         "name_id": 4718,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2764,
         "unknown6": 0,
         "tint": 0,
@@ -50646,7 +50646,7 @@
     {
         "guid": 80025,
         "name_id": 8766,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 225,
         "unknown6": 0,
         "tint": 0,
@@ -50690,7 +50690,7 @@
     {
         "guid": 80026,
         "name_id": 2440,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 226,
         "unknown6": 0,
         "tint": 0,
@@ -50734,7 +50734,7 @@
     {
         "guid": 80027,
         "name_id": 54602,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3835,
         "unknown6": 0,
         "tint": 0,
@@ -50778,7 +50778,7 @@
     {
         "guid": 80028,
         "name_id": 54593,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3828,
         "unknown6": 0,
         "tint": 0,
@@ -50822,7 +50822,7 @@
     {
         "guid": 80029,
         "name_id": 53620,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3212,
         "unknown6": 0,
         "tint": 0,
@@ -50866,7 +50866,7 @@
     {
         "guid": 80030,
         "name_id": 2650,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2136,
         "unknown6": 0,
         "tint": 0,
@@ -50910,7 +50910,7 @@
     {
         "guid": 80031,
         "name_id": 53616,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3208,
         "unknown6": 0,
         "tint": 0,
@@ -50954,7 +50954,7 @@
     {
         "guid": 80032,
         "name_id": 8769,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 227,
         "unknown6": 0,
         "tint": 0,
@@ -50998,7 +50998,7 @@
     {
         "guid": 80033,
         "name_id": 44507,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1993,
         "unknown6": 0,
         "tint": 0,
@@ -51042,7 +51042,7 @@
     {
         "guid": 80034,
         "name_id": 44850,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 510,
         "unknown6": 0,
         "tint": 0,
@@ -51086,7 +51086,7 @@
     {
         "guid": 80035,
         "name_id": 53621,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3213,
         "unknown6": 0,
         "tint": 0,
@@ -51130,7 +51130,7 @@
     {
         "guid": 80036,
         "name_id": 2444,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 228,
         "unknown6": 0,
         "tint": 0,
@@ -51174,7 +51174,7 @@
     {
         "guid": 80037,
         "name_id": 8767,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 229,
         "unknown6": 0,
         "tint": 0,
@@ -51218,7 +51218,7 @@
     {
         "guid": 80038,
         "name_id": 974,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 511,
         "unknown6": 0,
         "tint": 0,
@@ -51262,7 +51262,7 @@
     {
         "guid": 80039,
         "name_id": 60157,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 511,
         "unknown6": 0,
         "tint": 0,
@@ -51306,7 +51306,7 @@
     {
         "guid": 80040,
         "name_id": 8770,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 230,
         "unknown6": 0,
         "tint": 0,
@@ -51350,7 +51350,7 @@
     {
         "guid": 80041,
         "name_id": 8771,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 231,
         "unknown6": 0,
         "tint": 0,
@@ -51394,7 +51394,7 @@
     {
         "guid": 80042,
         "name_id": 308,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 232,
         "unknown6": 0,
         "tint": 0,
@@ -51438,7 +51438,7 @@
     {
         "guid": 80043,
         "name_id": 8772,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 233,
         "unknown6": 0,
         "tint": 0,
@@ -51482,7 +51482,7 @@
     {
         "guid": 80044,
         "name_id": 51038,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 425,
         "unknown6": 0,
         "tint": 0,
@@ -51526,7 +51526,7 @@
     {
         "guid": 80045,
         "name_id": 8773,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 234,
         "unknown6": 0,
         "tint": 0,
@@ -51570,7 +51570,7 @@
     {
         "guid": 80046,
         "name_id": 53617,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3209,
         "unknown6": 0,
         "tint": 0,
@@ -51614,7 +51614,7 @@
     {
         "guid": 80047,
         "name_id": 976,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 512,
         "unknown6": 0,
         "tint": 0,
@@ -51658,7 +51658,7 @@
     {
         "guid": 80048,
         "name_id": 60678,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3788,
         "unknown6": 0,
         "tint": 0,
@@ -51702,7 +51702,7 @@
     {
         "guid": 80049,
         "name_id": 19637,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1436,
         "unknown6": 0,
         "tint": 0,
@@ -51746,7 +51746,7 @@
     {
         "guid": 80050,
         "name_id": 43190,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1792,
         "unknown6": 0,
         "tint": 0,
@@ -51790,7 +51790,7 @@
     {
         "guid": 80051,
         "name_id": 14792,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 513,
         "unknown6": 0,
         "tint": 0,
@@ -51834,7 +51834,7 @@
     {
         "guid": 80052,
         "name_id": 8774,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 235,
         "unknown6": 0,
         "tint": 0,
@@ -51878,7 +51878,7 @@
     {
         "guid": 80053,
         "name_id": 978,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 514,
         "unknown6": 0,
         "tint": 0,
@@ -51922,7 +51922,7 @@
     {
         "guid": 80054,
         "name_id": 60198,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3721,
         "unknown6": 0,
         "tint": 0,
@@ -51966,7 +51966,7 @@
     {
         "guid": 80055,
         "name_id": 980,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 515,
         "unknown6": 0,
         "tint": 0,
@@ -52010,7 +52010,7 @@
     {
         "guid": 80056,
         "name_id": 4824,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2863,
         "unknown6": 0,
         "tint": 0,
@@ -52054,7 +52054,7 @@
     {
         "guid": 80057,
         "name_id": 8775,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 236,
         "unknown6": 0,
         "tint": 0,
@@ -52098,7 +52098,7 @@
     {
         "guid": 80058,
         "name_id": 982,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 516,
         "unknown6": 0,
         "tint": 0,
@@ -52142,7 +52142,7 @@
     {
         "guid": 80059,
         "name_id": 14794,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 517,
         "unknown6": 0,
         "tint": 0,
@@ -52186,7 +52186,7 @@
     {
         "guid": 80061,
         "name_id": 8776,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 237,
         "unknown6": 0,
         "tint": 0,
@@ -52230,7 +52230,7 @@
     {
         "guid": 80062,
         "name_id": 1797,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3169,
         "unknown6": 0,
         "tint": 0,
@@ -52274,7 +52274,7 @@
     {
         "guid": 80063,
         "name_id": 53619,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3211,
         "unknown6": 0,
         "tint": 0,
@@ -52318,7 +52318,7 @@
     {
         "guid": 80064,
         "name_id": 986,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1148,
         "unknown6": 0,
         "tint": 0,
@@ -52362,7 +52362,7 @@
     {
         "guid": 90000,
         "name_id": 2526,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 419,
         "unknown6": 0,
         "tint": 0,
@@ -52406,7 +52406,7 @@
     {
         "guid": 90001,
         "name_id": 1258,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 410,
         "unknown6": 0,
         "tint": 0,
@@ -52450,7 +52450,7 @@
     {
         "guid": 90002,
         "name_id": 54524,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 410,
         "unknown6": 0,
         "tint": 0,
@@ -52494,7 +52494,7 @@
     {
         "guid": 90003,
         "name_id": 1524,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 396,
         "unknown6": 0,
         "tint": 0,
@@ -52538,7 +52538,7 @@
     {
         "guid": 90004,
         "name_id": 1253,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 409,
         "unknown6": 0,
         "tint": 0,
@@ -52582,7 +52582,7 @@
     {
         "guid": 90005,
         "name_id": 1254,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 412,
         "unknown6": 0,
         "tint": 0,
@@ -52626,7 +52626,7 @@
     {
         "guid": 90006,
         "name_id": 54484,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3745,
         "unknown6": 0,
         "tint": 0,
@@ -52670,7 +52670,7 @@
     {
         "guid": 90007,
         "name_id": 1255,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 413,
         "unknown6": 0,
         "tint": 0,
@@ -52714,7 +52714,7 @@
     {
         "guid": 90008,
         "name_id": 1256,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 414,
         "unknown6": 0,
         "tint": 0,
@@ -52758,7 +52758,7 @@
     {
         "guid": 90009,
         "name_id": 1257,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 416,
         "unknown6": 0,
         "tint": 0,
@@ -52802,7 +52802,7 @@
     {
         "guid": 90010,
         "name_id": 44509,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1996,
         "unknown6": 0,
         "tint": 0,
@@ -52846,7 +52846,7 @@
     {
         "guid": 90011,
         "name_id": 54597,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 419,
         "unknown6": 0,
         "tint": 0,
@@ -52890,7 +52890,7 @@
     {
         "guid": 90012,
         "name_id": 2652,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2142,
         "unknown6": 0,
         "tint": 0,
@@ -52934,7 +52934,7 @@
     {
         "guid": 90013,
         "name_id": 44851,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 411,
         "unknown6": 0,
         "tint": 0,
@@ -52978,7 +52978,7 @@
     {
         "guid": 90014,
         "name_id": 1931,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 417,
         "unknown6": 0,
         "tint": 0,
@@ -53022,7 +53022,7 @@
     {
         "guid": 90015,
         "name_id": 1259,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 415,
         "unknown6": 0,
         "tint": 0,
@@ -53066,7 +53066,7 @@
     {
         "guid": 90016,
         "name_id": 53018,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 409,
         "unknown6": 0,
         "tint": 0,
@@ -53110,7 +53110,7 @@
     {
         "guid": 90017,
         "name_id": 54492,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3745,
         "unknown6": 0,
         "tint": 0,
@@ -53154,7 +53154,7 @@
     {
         "guid": 90018,
         "name_id": 53017,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 416,
         "unknown6": 0,
         "tint": 0,
@@ -53198,7 +53198,7 @@
     {
         "guid": 90019,
         "name_id": 44197,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 418,
         "unknown6": 0,
         "tint": 0,
@@ -53242,7 +53242,7 @@
     {
         "guid": 100000,
         "name_id": 2527,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 398,
         "unknown6": 0,
         "tint": 20,
@@ -53286,7 +53286,7 @@
     {
         "guid": 100001,
         "name_id": 2528,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 399,
         "unknown6": 0,
         "tint": 21,
@@ -53330,7 +53330,7 @@
     {
         "guid": 100002,
         "name_id": 2529,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 408,
         "unknown6": 0,
         "tint": 22,
@@ -53374,7 +53374,7 @@
     {
         "guid": 100003,
         "name_id": 2530,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 401,
         "unknown6": 0,
         "tint": 23,
@@ -53418,7 +53418,7 @@
     {
         "guid": 100004,
         "name_id": 2531,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 404,
         "unknown6": 0,
         "tint": 24,
@@ -53462,7 +53462,7 @@
     {
         "guid": 100005,
         "name_id": 2532,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 403,
         "unknown6": 0,
         "tint": 25,
@@ -53506,7 +53506,7 @@
     {
         "guid": 100006,
         "name_id": 2533,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 405,
         "unknown6": 0,
         "tint": 26,
@@ -53550,7 +53550,7 @@
     {
         "guid": 100007,
         "name_id": 2534,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 406,
         "unknown6": 0,
         "tint": 27,
@@ -53594,7 +53594,7 @@
     {
         "guid": 100008,
         "name_id": 2535,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 402,
         "unknown6": 0,
         "tint": 28,
@@ -53638,7 +53638,7 @@
     {
         "guid": 100009,
         "name_id": 2536,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 400,
         "unknown6": 0,
         "tint": 29,
@@ -53682,7 +53682,7 @@
     {
         "guid": 100010,
         "name_id": 2537,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 407,
         "unknown6": 0,
         "tint": 30,
@@ -53726,7 +53726,7 @@
     {
         "guid": 100011,
         "name_id": 2538,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 397,
         "unknown6": 0,
         "tint": 31,
@@ -53770,7 +53770,7 @@
     {
         "guid": 100012,
         "name_id": 51152,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2772,
         "unknown6": 0,
         "tint": 47,
@@ -53814,7 +53814,7 @@
     {
         "guid": 110000,
         "name_id": 4612,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2680,
         "unknown6": 0,
         "tint": 0,
@@ -53858,7 +53858,7 @@
     {
         "guid": 110001,
         "name_id": 14784,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 506,
         "unknown6": 0,
         "tint": 0,
@@ -53902,7 +53902,7 @@
     {
         "guid": 110002,
         "name_id": 4543,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2654,
         "unknown6": 0,
         "tint": 0,
@@ -53946,7 +53946,7 @@
     {
         "guid": 110003,
         "name_id": 314,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 213,
         "unknown6": 0,
         "tint": 0,
@@ -53990,7 +53990,7 @@
     {
         "guid": 110004,
         "name_id": 0,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 681,
         "unknown6": 0,
         "tint": 0,
@@ -54034,7 +54034,7 @@
     {
         "guid": 110005,
         "name_id": 14782,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 507,
         "unknown6": 0,
         "tint": 0,
@@ -54078,7 +54078,7 @@
     {
         "guid": 110006,
         "name_id": 52060,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2976,
         "unknown6": 0,
         "tint": 0,
@@ -54122,7 +54122,7 @@
     {
         "guid": 110007,
         "name_id": 2561,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 214,
         "unknown6": 0,
         "tint": 0,
@@ -54166,7 +54166,7 @@
     {
         "guid": 110008,
         "name_id": 8789,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 215,
         "unknown6": 0,
         "tint": 0,
@@ -54210,7 +54210,7 @@
     {
         "guid": 110009,
         "name_id": 52857,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3085,
         "unknown6": 0,
         "tint": 0,
@@ -54254,7 +54254,7 @@
     {
         "guid": 110010,
         "name_id": 4320,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2448,
         "unknown6": 0,
         "tint": 0,
@@ -54298,7 +54298,7 @@
     {
         "guid": 110011,
         "name_id": 4778,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2819,
         "unknown6": 0,
         "tint": 0,
@@ -54342,7 +54342,7 @@
     {
         "guid": 110012,
         "name_id": 4774,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2815,
         "unknown6": 0,
         "tint": 0,
@@ -54386,7 +54386,7 @@
     {
         "guid": 110013,
         "name_id": 4455,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2513,
         "unknown6": 0,
         "tint": 0,
@@ -54430,7 +54430,7 @@
     {
         "guid": 110014,
         "name_id": 33888,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1674,
         "unknown6": 0,
         "tint": 0,
@@ -54474,7 +54474,7 @@
     {
         "guid": 110015,
         "name_id": 32965,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1624,
         "unknown6": 0,
         "tint": 0,
@@ -54518,7 +54518,7 @@
     {
         "guid": 110016,
         "name_id": 4610,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2678,
         "unknown6": 0,
         "tint": 0,
@@ -54562,7 +54562,7 @@
     {
         "guid": 110017,
         "name_id": 4611,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2679,
         "unknown6": 0,
         "tint": 0,
@@ -54606,7 +54606,7 @@
     {
         "guid": 110018,
         "name_id": 4768,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2809,
         "unknown6": 0,
         "tint": 0,
@@ -54650,7 +54650,7 @@
     {
         "guid": 110019,
         "name_id": 4857,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2882,
         "unknown6": 0,
         "tint": 0,
@@ -54694,7 +54694,7 @@
     {
         "guid": 110020,
         "name_id": 54518,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3771,
         "unknown6": 0,
         "tint": 0,
@@ -54738,7 +54738,7 @@
     {
         "guid": 110021,
         "name_id": 4769,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2810,
         "unknown6": 0,
         "tint": 0,
@@ -54782,7 +54782,7 @@
     {
         "guid": 110022,
         "name_id": 0,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 681,
         "unknown6": 0,
         "tint": 0,
@@ -54826,7 +54826,7 @@
     {
         "guid": 110023,
         "name_id": 54520,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3790,
         "unknown6": 0,
         "tint": 0,
@@ -54870,7 +54870,7 @@
     {
         "guid": 110024,
         "name_id": 8790,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 216,
         "unknown6": 0,
         "tint": 0,
@@ -54914,7 +54914,7 @@
     {
         "guid": 110025,
         "name_id": 43859,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1935,
         "unknown6": 0,
         "tint": 0,
@@ -54958,7 +54958,7 @@
     {
         "guid": 110026,
         "name_id": 8794,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 217,
         "unknown6": 0,
         "tint": 0,
@@ -55002,7 +55002,7 @@
     {
         "guid": 110027,
         "name_id": 54594,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3827,
         "unknown6": 0,
         "tint": 0,
@@ -55046,7 +55046,7 @@
     {
         "guid": 110028,
         "name_id": 0,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 681,
         "unknown6": 0,
         "tint": 0,
@@ -55090,7 +55090,7 @@
     {
         "guid": 110029,
         "name_id": 2424,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 218,
         "unknown6": 0,
         "tint": 0,
@@ -55134,7 +55134,7 @@
     {
         "guid": 110030,
         "name_id": 4770,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2811,
         "unknown6": 0,
         "tint": 0,
@@ -55178,7 +55178,7 @@
     {
         "guid": 110031,
         "name_id": 3130,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2391,
         "unknown6": 0,
         "tint": 0,
@@ -55222,7 +55222,7 @@
     {
         "guid": 110032,
         "name_id": 4749,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2789,
         "unknown6": 0,
         "tint": 0,
@@ -55266,7 +55266,7 @@
     {
         "guid": 110033,
         "name_id": 52798,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3108,
         "unknown6": 0,
         "tint": 0,
@@ -55310,7 +55310,7 @@
     {
         "guid": 110034,
         "name_id": 2408,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 238,
         "unknown6": 0,
         "tint": 0,
@@ -55354,7 +55354,7 @@
     {
         "guid": 110035,
         "name_id": 8781,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 240,
         "unknown6": 0,
         "tint": 0,
@@ -55398,7 +55398,7 @@
     {
         "guid": 110036,
         "name_id": 8784,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 239,
         "unknown6": 0,
         "tint": 0,
@@ -55442,7 +55442,7 @@
     {
         "guid": 110037,
         "name_id": 60183,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3726,
         "unknown6": 0,
         "tint": 0,
@@ -55486,7 +55486,7 @@
     {
         "guid": 110038,
         "name_id": 4482,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2571,
         "unknown6": 0,
         "tint": 0,
@@ -55530,7 +55530,7 @@
     {
         "guid": 110039,
         "name_id": 0,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 241,
         "unknown6": 0,
         "tint": 0,
@@ -55574,7 +55574,7 @@
     {
         "guid": 110040,
         "name_id": 4542,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2659,
         "unknown6": 0,
         "tint": 0,
@@ -55618,7 +55618,7 @@
     {
         "guid": 110041,
         "name_id": 53491,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3158,
         "unknown6": 0,
         "tint": 0,
@@ -55662,7 +55662,7 @@
     {
         "guid": 110042,
         "name_id": 4882,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2924,
         "unknown6": 0,
         "tint": 0,
@@ -55706,7 +55706,7 @@
     {
         "guid": 110043,
         "name_id": 4883,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2925,
         "unknown6": 0,
         "tint": 0,
@@ -55750,7 +55750,7 @@
     {
         "guid": 110044,
         "name_id": 4766,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2808,
         "unknown6": 0,
         "tint": 0,
@@ -55794,7 +55794,7 @@
     {
         "guid": 110045,
         "name_id": 4767,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2808,
         "unknown6": 0,
         "tint": 0,
@@ -55838,7 +55838,7 @@
     {
         "guid": 110046,
         "name_id": 54263,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3637,
         "unknown6": 0,
         "tint": 0,
@@ -55882,7 +55882,7 @@
     {
         "guid": 110047,
         "name_id": 4685,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2734,
         "unknown6": 0,
         "tint": 0,
@@ -55926,7 +55926,7 @@
     {
         "guid": 110048,
         "name_id": 60672,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3783,
         "unknown6": 0,
         "tint": 0,
@@ -55970,7 +55970,7 @@
     {
         "guid": 110049,
         "name_id": 4686,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2734,
         "unknown6": 0,
         "tint": 0,
@@ -56014,7 +56014,7 @@
     {
         "guid": 110050,
         "name_id": 60673,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3783,
         "unknown6": 0,
         "tint": 0,
@@ -56058,7 +56058,7 @@
     {
         "guid": 110051,
         "name_id": 2410,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 244,
         "unknown6": 0,
         "tint": 0,
@@ -56102,7 +56102,7 @@
     {
         "guid": 110052,
         "name_id": 2896,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2312,
         "unknown6": 0,
         "tint": 0,
@@ -56146,7 +56146,7 @@
     {
         "guid": 110053,
         "name_id": 2897,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2312,
         "unknown6": 0,
         "tint": 0,
@@ -56190,7 +56190,7 @@
     {
         "guid": 110054,
         "name_id": 65,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 244,
         "unknown6": 0,
         "tint": 0,
@@ -56234,7 +56234,7 @@
     {
         "guid": 110055,
         "name_id": 2412,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 245,
         "unknown6": 0,
         "tint": 0,
@@ -56278,7 +56278,7 @@
     {
         "guid": 110056,
         "name_id": 2414,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 246,
         "unknown6": 0,
         "tint": 0,
@@ -56322,7 +56322,7 @@
     {
         "guid": 110057,
         "name_id": 1803,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1409,
         "unknown6": 0,
         "tint": 0,
@@ -56366,7 +56366,7 @@
     {
         "guid": 110058,
         "name_id": 1805,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1409,
         "unknown6": 0,
         "tint": 0,
@@ -56410,7 +56410,7 @@
     {
         "guid": 110059,
         "name_id": 8792,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 247,
         "unknown6": 0,
         "tint": 0,
@@ -56454,7 +56454,7 @@
     {
         "guid": 110060,
         "name_id": 2406,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 248,
         "unknown6": 0,
         "tint": 0,
@@ -56498,7 +56498,7 @@
     {
         "guid": 110061,
         "name_id": 1293,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 248,
         "unknown6": 0,
         "tint": 0,
@@ -56542,7 +56542,7 @@
     {
         "guid": 110062,
         "name_id": 52805,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3143,
         "unknown6": 0,
         "tint": 0,
@@ -56586,7 +56586,7 @@
     {
         "guid": 110063,
         "name_id": 52804,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3143,
         "unknown6": 0,
         "tint": 0,
@@ -56630,7 +56630,7 @@
     {
         "guid": 110064,
         "name_id": 1713,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1327,
         "unknown6": 0,
         "tint": 0,
@@ -56674,7 +56674,7 @@
     {
         "guid": 110065,
         "name_id": 54264,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3638,
         "unknown6": 0,
         "tint": 0,
@@ -56718,7 +56718,7 @@
     {
         "guid": 110066,
         "name_id": 8791,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 249,
         "unknown6": 0,
         "tint": 0,
@@ -56762,7 +56762,7 @@
     {
         "guid": 110067,
         "name_id": 54522,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3792,
         "unknown6": 0,
         "tint": 0,
@@ -56806,7 +56806,7 @@
     {
         "guid": 110068,
         "name_id": 0,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3792,
         "unknown6": 0,
         "tint": 0,
@@ -56850,7 +56850,7 @@
     {
         "guid": 110069,
         "name_id": 53492,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3159,
         "unknown6": 0,
         "tint": 0,
@@ -56894,7 +56894,7 @@
     {
         "guid": 110070,
         "name_id": 8793,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 250,
         "unknown6": 0,
         "tint": 0,
@@ -56938,7 +56938,7 @@
     {
         "guid": 110071,
         "name_id": 3068,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2337,
         "unknown6": 0,
         "tint": 0,
@@ -56982,7 +56982,7 @@
     {
         "guid": 110072,
         "name_id": 4463,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2518,
         "unknown6": 0,
         "tint": 0,
@@ -57026,7 +57026,7 @@
     {
         "guid": 110073,
         "name_id": 8799,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 251,
         "unknown6": 0,
         "tint": 0,
@@ -57070,7 +57070,7 @@
     {
         "guid": 110074,
         "name_id": 52541,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3002,
         "unknown6": 0,
         "tint": 0,
@@ -57114,7 +57114,7 @@
     {
         "guid": 110075,
         "name_id": 1811,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1353,
         "unknown6": 0,
         "tint": 0,
@@ -57158,7 +57158,7 @@
     {
         "guid": 110076,
         "name_id": 32983,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1632,
         "unknown6": 0,
         "tint": 0,
@@ -57202,7 +57202,7 @@
     {
         "guid": 110077,
         "name_id": 4280,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2399,
         "unknown6": 0,
         "tint": 0,
@@ -57246,7 +57246,7 @@
     {
         "guid": 110078,
         "name_id": 8798,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 252,
         "unknown6": 0,
         "tint": 0,
@@ -57290,7 +57290,7 @@
     {
         "guid": 110079,
         "name_id": 300,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 253,
         "unknown6": 0,
         "tint": 0,
@@ -57334,7 +57334,7 @@
     {
         "guid": 110080,
         "name_id": 97,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 518,
         "unknown6": 0,
         "tint": 0,
@@ -57378,7 +57378,7 @@
     {
         "guid": 110081,
         "name_id": 44661,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2001,
         "unknown6": 0,
         "tint": 0,
@@ -57422,7 +57422,7 @@
     {
         "guid": 110082,
         "name_id": 44662,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2002,
         "unknown6": 0,
         "tint": 0,
@@ -57466,7 +57466,7 @@
     {
         "guid": 110083,
         "name_id": 44663,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2003,
         "unknown6": 0,
         "tint": 0,
@@ -57510,7 +57510,7 @@
     {
         "guid": 110084,
         "name_id": 44664,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2004,
         "unknown6": 0,
         "tint": 0,
@@ -57554,7 +57554,7 @@
     {
         "guid": 110085,
         "name_id": 44665,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2005,
         "unknown6": 0,
         "tint": 0,
@@ -57598,7 +57598,7 @@
     {
         "guid": 110086,
         "name_id": 44666,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2006,
         "unknown6": 0,
         "tint": 0,
@@ -57642,7 +57642,7 @@
     {
         "guid": 110087,
         "name_id": 44667,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 2007,
         "unknown6": 0,
         "tint": 0,
@@ -57686,7 +57686,7 @@
     {
         "guid": 110088,
         "name_id": 10423,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 681,
         "unknown6": 0,
         "tint": 0,
@@ -57730,7 +57730,7 @@
     {
         "guid": 120000,
         "name_id": 554,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 715,
         "unknown6": 0,
         "tint": 0,
@@ -57774,7 +57774,7 @@
     {
         "guid": 120001,
         "name_id": 13874,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 716,
         "unknown6": 0,
         "tint": 0,
@@ -57818,7 +57818,7 @@
     {
         "guid": 120002,
         "name_id": 553,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 713,
         "unknown6": 0,
         "tint": 0,
@@ -57862,7 +57862,7 @@
     {
         "guid": 120003,
         "name_id": 556,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 718,
         "unknown6": 0,
         "tint": 0,
@@ -57906,7 +57906,7 @@
     {
         "guid": 120004,
         "name_id": 13876,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 717,
         "unknown6": 0,
         "tint": 0,
@@ -57950,7 +57950,7 @@
     {
         "guid": 120005,
         "name_id": 13875,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 714,
         "unknown6": 0,
         "tint": 0,
@@ -57994,7 +57994,7 @@
     {
         "guid": 120006,
         "name_id": 13875,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 712,
         "unknown6": 0,
         "tint": 0,
@@ -58038,7 +58038,7 @@
     {
         "guid": 120007,
         "name_id": 552,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 728,
         "unknown6": 0,
         "tint": 0,
@@ -58082,7 +58082,7 @@
     {
         "guid": 120008,
         "name_id": 562,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 734,
         "unknown6": 0,
         "tint": 0,
@@ -58126,7 +58126,7 @@
     {
         "guid": 120009,
         "name_id": 558,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 731,
         "unknown6": 0,
         "tint": 0,
@@ -58170,7 +58170,7 @@
     {
         "guid": 120010,
         "name_id": 563,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 735,
         "unknown6": 0,
         "tint": 0,
@@ -58214,7 +58214,7 @@
     {
         "guid": 120011,
         "name_id": 561,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 733,
         "unknown6": 0,
         "tint": 0,
@@ -58258,7 +58258,7 @@
     {
         "guid": 120012,
         "name_id": 560,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 732,
         "unknown6": 0,
         "tint": 0,
@@ -58302,7 +58302,7 @@
     {
         "guid": 120013,
         "name_id": 770,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 729,
         "unknown6": 0,
         "tint": 0,
@@ -58346,7 +58346,7 @@
     {
         "guid": 120014,
         "name_id": 559,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 730,
         "unknown6": 0,
         "tint": 0,
@@ -58390,7 +58390,7 @@
     {
         "guid": 120015,
         "name_id": 1249,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 738,
         "unknown6": 0,
         "tint": 0,
@@ -58434,7 +58434,7 @@
     {
         "guid": 120016,
         "name_id": 1251,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 739,
         "unknown6": 0,
         "tint": 0,
@@ -58478,7 +58478,7 @@
     {
         "guid": 120017,
         "name_id": 782,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 745,
         "unknown6": 0,
         "tint": 0,
@@ -58522,7 +58522,7 @@
     {
         "guid": 120018,
         "name_id": 780,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 747,
         "unknown6": 0,
         "tint": 0,
@@ -58566,7 +58566,7 @@
     {
         "guid": 120019,
         "name_id": 776,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 746,
         "unknown6": 0,
         "tint": 0,
@@ -58610,7 +58610,7 @@
     {
         "guid": 120020,
         "name_id": 778,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 744,
         "unknown6": 0,
         "tint": 0,
@@ -58654,7 +58654,7 @@
     {
         "guid": 120021,
         "name_id": 772,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 725,
         "unknown6": 0,
         "tint": 0,
@@ -58698,7 +58698,7 @@
     {
         "guid": 120022,
         "name_id": 15428,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 726,
         "unknown6": 0,
         "tint": 0,
@@ -58742,7 +58742,7 @@
     {
         "guid": 120023,
         "name_id": 774,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 727,
         "unknown6": 0,
         "tint": 0,
@@ -58786,7 +58786,7 @@
     {
         "guid": 120024,
         "name_id": 1681,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1316,
         "unknown6": 0,
         "tint": 0,
@@ -58830,7 +58830,7 @@
     {
         "guid": 120025,
         "name_id": 43475,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1806,
         "unknown6": 0,
         "tint": 0,
@@ -58874,7 +58874,7 @@
     {
         "guid": 120026,
         "name_id": 43483,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1805,
         "unknown6": 0,
         "tint": 0,
@@ -58918,7 +58918,7 @@
     {
         "guid": 120027,
         "name_id": 43473,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1803,
         "unknown6": 0,
         "tint": 0,
@@ -58962,7 +58962,7 @@
     {
         "guid": 120028,
         "name_id": 43474,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1807,
         "unknown6": 0,
         "tint": 0,
@@ -59006,7 +59006,7 @@
     {
         "guid": 120029,
         "name_id": 43476,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1804,
         "unknown6": 0,
         "tint": 0,
@@ -59050,7 +59050,7 @@
     {
         "guid": 130000,
         "name_id": 402,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 531,
         "unknown6": 0,
         "tint": 0,
@@ -59094,7 +59094,7 @@
     {
         "guid": 130001,
         "name_id": 2584,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 542,
         "unknown6": 0,
         "tint": 0,
@@ -59138,7 +59138,7 @@
     {
         "guid": 130002,
         "name_id": 1435,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 532,
         "unknown6": 0,
         "tint": 0,
@@ -59182,7 +59182,7 @@
     {
         "guid": 130003,
         "name_id": 15416,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 533,
         "unknown6": 0,
         "tint": 0,
@@ -59226,7 +59226,7 @@
     {
         "guid": 130004,
         "name_id": 404,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 534,
         "unknown6": 0,
         "tint": 0,
@@ -59270,7 +59270,7 @@
     {
         "guid": 130005,
         "name_id": 406,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 536,
         "unknown6": 0,
         "tint": 0,
@@ -59314,7 +59314,7 @@
     {
         "guid": 130006,
         "name_id": 2996,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 535,
         "unknown6": 0,
         "tint": 0,
@@ -59358,7 +59358,7 @@
     {
         "guid": 130007,
         "name_id": 764,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 537,
         "unknown6": 0,
         "tint": 0,
@@ -59402,7 +59402,7 @@
     {
         "guid": 130008,
         "name_id": 15417,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 538,
         "unknown6": 0,
         "tint": 0,
@@ -59446,7 +59446,7 @@
     {
         "guid": 130009,
         "name_id": 2583,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 539,
         "unknown6": 0,
         "tint": 0,
@@ -59490,7 +59490,7 @@
     {
         "guid": 130010,
         "name_id": 15418,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 540,
         "unknown6": 0,
         "tint": 0,
@@ -59534,7 +59534,7 @@
     {
         "guid": 130011,
         "name_id": 54306,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3657,
         "unknown6": 0,
         "tint": 0,
@@ -59578,7 +59578,7 @@
     {
         "guid": 130012,
         "name_id": 15419,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 541,
         "unknown6": 0,
         "tint": 0,
@@ -59622,7 +59622,7 @@
     {
         "guid": 130013,
         "name_id": 54174,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3596,
         "unknown6": 0,
         "tint": 0,
@@ -59666,7 +59666,7 @@
     {
         "guid": 130014,
         "name_id": 19639,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1437,
         "unknown6": 0,
         "tint": 0,
@@ -59710,7 +59710,7 @@
     {
         "guid": 130015,
         "name_id": 15413,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 519,
         "unknown6": 0,
         "tint": 0,
@@ -59754,7 +59754,7 @@
     {
         "guid": 130016,
         "name_id": 1715,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 520,
         "unknown6": 0,
         "tint": 0,
@@ -59798,7 +59798,7 @@
     {
         "guid": 130017,
         "name_id": 390,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 521,
         "unknown6": 0,
         "tint": 0,
@@ -59842,7 +59842,7 @@
     {
         "guid": 130018,
         "name_id": 2588,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 611,
         "unknown6": 0,
         "tint": 0,
@@ -59886,7 +59886,7 @@
     {
         "guid": 130019,
         "name_id": 15414,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 612,
         "unknown6": 0,
         "tint": 0,
@@ -59930,7 +59930,7 @@
     {
         "guid": 130020,
         "name_id": 392,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 523,
         "unknown6": 0,
         "tint": 0,
@@ -59974,7 +59974,7 @@
     {
         "guid": 130021,
         "name_id": 2589,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 522,
         "unknown6": 0,
         "tint": 0,
@@ -60018,7 +60018,7 @@
     {
         "guid": 130022,
         "name_id": 15415,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 524,
         "unknown6": 0,
         "tint": 0,
@@ -60062,7 +60062,7 @@
     {
         "guid": 130023,
         "name_id": 13834,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 525,
         "unknown6": 0,
         "tint": 0,
@@ -60106,7 +60106,7 @@
     {
         "guid": 130024,
         "name_id": 54305,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3656,
         "unknown6": 0,
         "tint": 0,
@@ -60150,7 +60150,7 @@
     {
         "guid": 130025,
         "name_id": 19986,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1466,
         "unknown6": 0,
         "tint": 0,
@@ -60194,7 +60194,7 @@
     {
         "guid": 130026,
         "name_id": 2591,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 526,
         "unknown6": 0,
         "tint": 0,
@@ -60238,7 +60238,7 @@
     {
         "guid": 130027,
         "name_id": 2590,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 613,
         "unknown6": 0,
         "tint": 0,
@@ -60282,7 +60282,7 @@
     {
         "guid": 130028,
         "name_id": 394,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 527,
         "unknown6": 0,
         "tint": 0,
@@ -60326,7 +60326,7 @@
     {
         "guid": 130029,
         "name_id": 54173,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3597,
         "unknown6": 0,
         "tint": 0,
@@ -60370,7 +60370,7 @@
     {
         "guid": 130030,
         "name_id": 2592,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 614,
         "unknown6": 0,
         "tint": 0,
@@ -60414,7 +60414,7 @@
     {
         "guid": 130031,
         "name_id": 1715,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 588,
         "unknown6": 0,
         "tint": 0,
@@ -60458,7 +60458,7 @@
     {
         "guid": 130032,
         "name_id": 396,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 589,
         "unknown6": 0,
         "tint": 0,
@@ -60502,7 +60502,7 @@
     {
         "guid": 130033,
         "name_id": 398,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 590,
         "unknown6": 0,
         "tint": 0,
@@ -60546,7 +60546,7 @@
     {
         "guid": 130034,
         "name_id": 13777,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 591,
         "unknown6": 0,
         "tint": 0,
@@ -60590,7 +60590,7 @@
     {
         "guid": 130035,
         "name_id": 15409,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 592,
         "unknown6": 0,
         "tint": 0,
@@ -60634,7 +60634,7 @@
     {
         "guid": 130036,
         "name_id": 13778,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 593,
         "unknown6": 0,
         "tint": 0,
@@ -60678,7 +60678,7 @@
     {
         "guid": 130037,
         "name_id": 15410,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 594,
         "unknown6": 0,
         "tint": 0,
@@ -60722,7 +60722,7 @@
     {
         "guid": 130038,
         "name_id": 400,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 595,
         "unknown6": 0,
         "tint": 0,
@@ -60766,7 +60766,7 @@
     {
         "guid": 130039,
         "name_id": 13779,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 596,
         "unknown6": 0,
         "tint": 0,
@@ -60810,7 +60810,7 @@
     {
         "guid": 130040,
         "name_id": 15411,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 597,
         "unknown6": 0,
         "tint": 0,
@@ -60854,7 +60854,7 @@
     {
         "guid": 130041,
         "name_id": 766,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 598,
         "unknown6": 0,
         "tint": 0,
@@ -60898,7 +60898,7 @@
     {
         "guid": 130042,
         "name_id": 15412,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 599,
         "unknown6": 0,
         "tint": 0,
@@ -60942,7 +60942,7 @@
     {
         "guid": 130043,
         "name_id": 13780,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 600,
         "unknown6": 0,
         "tint": 0,
@@ -60986,7 +60986,7 @@
     {
         "guid": 130044,
         "name_id": 414,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 567,
         "unknown6": 0,
         "tint": 0,
@@ -61030,7 +61030,7 @@
     {
         "guid": 130045,
         "name_id": 15429,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 564,
         "unknown6": 0,
         "tint": 0,
@@ -61074,7 +61074,7 @@
     {
         "guid": 130046,
         "name_id": 13842,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 563,
         "unknown6": 0,
         "tint": 0,
@@ -61118,7 +61118,7 @@
     {
         "guid": 130047,
         "name_id": 15432,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 570,
         "unknown6": 0,
         "tint": 0,
@@ -61162,7 +61162,7 @@
     {
         "guid": 130048,
         "name_id": 13843,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 566,
         "unknown6": 0,
         "tint": 0,
@@ -61206,7 +61206,7 @@
     {
         "guid": 130049,
         "name_id": 13844,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 568,
         "unknown6": 0,
         "tint": 0,
@@ -61250,7 +61250,7 @@
     {
         "guid": 130050,
         "name_id": 15430,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 565,
         "unknown6": 0,
         "tint": 0,
@@ -61294,7 +61294,7 @@
     {
         "guid": 130051,
         "name_id": 15431,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 569,
         "unknown6": 0,
         "tint": 0,
@@ -61338,7 +61338,7 @@
     {
         "guid": 130052,
         "name_id": 15429,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 556,
         "unknown6": 0,
         "tint": 0,
@@ -61382,7 +61382,7 @@
     {
         "guid": 130053,
         "name_id": 13845,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 555,
         "unknown6": 0,
         "tint": 0,
@@ -61426,7 +61426,7 @@
     {
         "guid": 130054,
         "name_id": 15432,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 562,
         "unknown6": 0,
         "tint": 0,
@@ -61470,7 +61470,7 @@
     {
         "guid": 130055,
         "name_id": 13846,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 558,
         "unknown6": 0,
         "tint": 0,
@@ -61514,7 +61514,7 @@
     {
         "guid": 130056,
         "name_id": 13847,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 560,
         "unknown6": 0,
         "tint": 0,
@@ -61558,7 +61558,7 @@
     {
         "guid": 130057,
         "name_id": 1441,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 559,
         "unknown6": 0,
         "tint": 0,
@@ -61602,7 +61602,7 @@
     {
         "guid": 130058,
         "name_id": 15430,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 557,
         "unknown6": 0,
         "tint": 0,
@@ -61646,7 +61646,7 @@
     {
         "guid": 130059,
         "name_id": 15431,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 561,
         "unknown6": 0,
         "tint": 0,
@@ -61690,7 +61690,7 @@
     {
         "guid": 130060,
         "name_id": 15435,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 580,
         "unknown6": 0,
         "tint": 0,
@@ -61734,7 +61734,7 @@
     {
         "guid": 130061,
         "name_id": 13860,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1166,
         "unknown6": 0,
         "tint": 0,
@@ -61778,7 +61778,7 @@
     {
         "guid": 130062,
         "name_id": 15434,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 655,
         "unknown6": 0,
         "tint": 0,
@@ -61822,7 +61822,7 @@
     {
         "guid": 130063,
         "name_id": 784,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 578,
         "unknown6": 0,
         "tint": 0,
@@ -61866,7 +61866,7 @@
     {
         "guid": 130064,
         "name_id": 13861,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 579,
         "unknown6": 0,
         "tint": 0,
@@ -61910,7 +61910,7 @@
     {
         "guid": 130065,
         "name_id": 15433,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 654,
         "unknown6": 0,
         "tint": 0,
@@ -61954,7 +61954,7 @@
     {
         "guid": 130066,
         "name_id": 786,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 581,
         "unknown6": 0,
         "tint": 0,
@@ -61998,7 +61998,7 @@
     {
         "guid": 130067,
         "name_id": 54307,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3658,
         "unknown6": 0,
         "tint": 0,
@@ -62042,7 +62042,7 @@
     {
         "guid": 130068,
         "name_id": 15436,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 582,
         "unknown6": 0,
         "tint": 0,
@@ -62086,7 +62086,7 @@
     {
         "guid": 130069,
         "name_id": 15437,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 583,
         "unknown6": 0,
         "tint": 0,
@@ -62130,7 +62130,7 @@
     {
         "guid": 130070,
         "name_id": 788,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 584,
         "unknown6": 0,
         "tint": 0,
@@ -62174,7 +62174,7 @@
     {
         "guid": 130071,
         "name_id": 15435,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 573,
         "unknown6": 0,
         "tint": 0,
@@ -62218,7 +62218,7 @@
     {
         "guid": 130072,
         "name_id": 13860,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1165,
         "unknown6": 0,
         "tint": 0,
@@ -62262,7 +62262,7 @@
     {
         "guid": 130073,
         "name_id": 15434,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 642,
         "unknown6": 0,
         "tint": 0,
@@ -62306,7 +62306,7 @@
     {
         "guid": 130074,
         "name_id": 784,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 571,
         "unknown6": 0,
         "tint": 0,
@@ -62350,7 +62350,7 @@
     {
         "guid": 130075,
         "name_id": 13861,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 572,
         "unknown6": 0,
         "tint": 0,
@@ -62394,7 +62394,7 @@
     {
         "guid": 130076,
         "name_id": 15433,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 641,
         "unknown6": 0,
         "tint": 0,
@@ -62438,7 +62438,7 @@
     {
         "guid": 130077,
         "name_id": 786,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 574,
         "unknown6": 0,
         "tint": 0,
@@ -62482,7 +62482,7 @@
     {
         "guid": 130078,
         "name_id": 54307,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3678,
         "unknown6": 0,
         "tint": 0,
@@ -62526,7 +62526,7 @@
     {
         "guid": 130079,
         "name_id": 15436,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 575,
         "unknown6": 0,
         "tint": 0,
@@ -62570,7 +62570,7 @@
     {
         "guid": 130080,
         "name_id": 15437,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 576,
         "unknown6": 0,
         "tint": 0,
@@ -62614,7 +62614,7 @@
     {
         "guid": 130081,
         "name_id": 788,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 577,
         "unknown6": 0,
         "tint": 0,
@@ -62658,7 +62658,7 @@
     {
         "guid": 130082,
         "name_id": 13839,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 549,
         "unknown6": 0,
         "tint": 0,
@@ -62702,7 +62702,7 @@
     {
         "guid": 130083,
         "name_id": 13841,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 553,
         "unknown6": 0,
         "tint": 0,
@@ -62746,7 +62746,7 @@
     {
         "guid": 130084,
         "name_id": 13840,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 551,
         "unknown6": 0,
         "tint": 0,
@@ -62790,7 +62790,7 @@
     {
         "guid": 130085,
         "name_id": 13839,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 543,
         "unknown6": 0,
         "tint": 0,
@@ -62834,7 +62834,7 @@
     {
         "guid": 130086,
         "name_id": 13841,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 547,
         "unknown6": 0,
         "tint": 0,
@@ -62878,7 +62878,7 @@
     {
         "guid": 130087,
         "name_id": 13840,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 545,
         "unknown6": 0,
         "tint": 0,
@@ -62922,7 +62922,7 @@
     {
         "guid": 130088,
         "name_id": 1717,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1289,
         "unknown6": 0,
         "tint": 0,
@@ -62966,7 +62966,7 @@
     {
         "guid": 130089,
         "name_id": 18037,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1290,
         "unknown6": 0,
         "tint": 0,
@@ -63010,7 +63010,7 @@
     {
         "guid": 130090,
         "name_id": 18038,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1291,
         "unknown6": 0,
         "tint": 0,
@@ -63054,7 +63054,7 @@
     {
         "guid": 130091,
         "name_id": 18039,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1292,
         "unknown6": 0,
         "tint": 0,
@@ -63098,7 +63098,7 @@
     {
         "guid": 130092,
         "name_id": 18040,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1293,
         "unknown6": 0,
         "tint": 0,
@@ -63142,7 +63142,7 @@
     {
         "guid": 130093,
         "name_id": 18041,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1294,
         "unknown6": 0,
         "tint": 0,
@@ -63186,7 +63186,7 @@
     {
         "guid": 130094,
         "name_id": 18042,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1295,
         "unknown6": 0,
         "tint": 0,
@@ -63230,7 +63230,7 @@
     {
         "guid": 130095,
         "name_id": 18043,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1296,
         "unknown6": 0,
         "tint": 0,
@@ -63274,7 +63274,7 @@
     {
         "guid": 130096,
         "name_id": 1717,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1261,
         "unknown6": 0,
         "tint": 0,
@@ -63318,7 +63318,7 @@
     {
         "guid": 130097,
         "name_id": 18027,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1262,
         "unknown6": 0,
         "tint": 0,
@@ -63362,7 +63362,7 @@
     {
         "guid": 130098,
         "name_id": 18028,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1263,
         "unknown6": 0,
         "tint": 0,
@@ -63406,7 +63406,7 @@
     {
         "guid": 130099,
         "name_id": 18029,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1264,
         "unknown6": 0,
         "tint": 0,
@@ -63450,7 +63450,7 @@
     {
         "guid": 130100,
         "name_id": 18030,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1265,
         "unknown6": 0,
         "tint": 0,
@@ -63494,7 +63494,7 @@
     {
         "guid": 130101,
         "name_id": 18031,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1266,
         "unknown6": 0,
         "tint": 0,
@@ -63538,7 +63538,7 @@
     {
         "guid": 130102,
         "name_id": 18032,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1267,
         "unknown6": 0,
         "tint": 0,
@@ -63582,7 +63582,7 @@
     {
         "guid": 130103,
         "name_id": 18034,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1269,
         "unknown6": 0,
         "tint": 0,
@@ -63626,7 +63626,7 @@
     {
         "guid": 130104,
         "name_id": 18033,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1268,
         "unknown6": 0,
         "tint": 0,
@@ -63670,7 +63670,7 @@
     {
         "guid": 130105,
         "name_id": 18035,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1270,
         "unknown6": 0,
         "tint": 0,
@@ -63714,7 +63714,7 @@
     {
         "guid": 130106,
         "name_id": 18036,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1271,
         "unknown6": 0,
         "tint": 0,
@@ -63758,7 +63758,7 @@
     {
         "guid": 130107,
         "name_id": 43468,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1829,
         "unknown6": 0,
         "tint": 0,
@@ -63802,7 +63802,7 @@
     {
         "guid": 130108,
         "name_id": 43469,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1830,
         "unknown6": 0,
         "tint": 0,
@@ -63846,7 +63846,7 @@
     {
         "guid": 130109,
         "name_id": 43470,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1835,
         "unknown6": 0,
         "tint": 0,
@@ -63890,7 +63890,7 @@
     {
         "guid": 130110,
         "name_id": 43471,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1831,
         "unknown6": 0,
         "tint": 0,
@@ -63934,7 +63934,7 @@
     {
         "guid": 130111,
         "name_id": 43472,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1836,
         "unknown6": 0,
         "tint": 0,
@@ -63978,7 +63978,7 @@
     {
         "guid": 130112,
         "name_id": 43467,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1832,
         "unknown6": 0,
         "tint": 0,
@@ -64022,7 +64022,7 @@
     {
         "guid": 130113,
         "name_id": 43468,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1819,
         "unknown6": 0,
         "tint": 0,
@@ -64066,7 +64066,7 @@
     {
         "guid": 130114,
         "name_id": 43469,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1820,
         "unknown6": 0,
         "tint": 0,
@@ -64110,7 +64110,7 @@
     {
         "guid": 130115,
         "name_id": 43470,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1833,
         "unknown6": 0,
         "tint": 0,
@@ -64154,7 +64154,7 @@
     {
         "guid": 130116,
         "name_id": 43471,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1821,
         "unknown6": 0,
         "tint": 0,
@@ -64198,7 +64198,7 @@
     {
         "guid": 130117,
         "name_id": 43472,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1834,
         "unknown6": 0,
         "tint": 0,
@@ -64242,7 +64242,7 @@
     {
         "guid": 130118,
         "name_id": 43467,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1822,
         "unknown6": 0,
         "tint": 0,
@@ -64286,7 +64286,7 @@
     {
         "guid": 140000,
         "name_id": 452,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 755,
         "unknown6": 0,
         "tint": 0,
@@ -64330,7 +64330,7 @@
     {
         "guid": 140001,
         "name_id": 454,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 757,
         "unknown6": 0,
         "tint": 0,
@@ -64374,7 +64374,7 @@
     {
         "guid": 140002,
         "name_id": 440,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 749,
         "unknown6": 0,
         "tint": 0,
@@ -64418,7 +64418,7 @@
     {
         "guid": 140003,
         "name_id": 442,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 750,
         "unknown6": 0,
         "tint": 0,
@@ -64462,7 +64462,7 @@
     {
         "guid": 140004,
         "name_id": 444,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 753,
         "unknown6": 0,
         "tint": 0,
@@ -64506,7 +64506,7 @@
     {
         "guid": 140005,
         "name_id": 446,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 751,
         "unknown6": 0,
         "tint": 0,
@@ -64550,7 +64550,7 @@
     {
         "guid": 140006,
         "name_id": 450,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 754,
         "unknown6": 0,
         "tint": 0,
@@ -64594,7 +64594,7 @@
     {
         "guid": 140007,
         "name_id": 18047,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3598,
         "unknown6": 0,
         "tint": 0,
@@ -64638,7 +64638,7 @@
     {
         "guid": 140008,
         "name_id": 448,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 756,
         "unknown6": 0,
         "tint": 0,
@@ -64682,7 +64682,7 @@
     {
         "guid": 140009,
         "name_id": 93,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 758,
         "unknown6": 0,
         "tint": 0,
@@ -64726,7 +64726,7 @@
     {
         "guid": 140010,
         "name_id": 91,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 752,
         "unknown6": 0,
         "tint": 0,
@@ -64770,7 +64770,7 @@
     {
         "guid": 140011,
         "name_id": 95,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 748,
         "unknown6": 0,
         "tint": 0,
@@ -64814,7 +64814,7 @@
     {
         "guid": 140012,
         "name_id": 2634,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 724,
         "unknown6": 0,
         "tint": 0,
@@ -64858,7 +64858,7 @@
     {
         "guid": 140013,
         "name_id": 2630,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 722,
         "unknown6": 0,
         "tint": 0,
@@ -64902,7 +64902,7 @@
     {
         "guid": 140014,
         "name_id": 2632,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 723,
         "unknown6": 0,
         "tint": 0,
@@ -64946,7 +64946,7 @@
     {
         "guid": 140015,
         "name_id": 18049,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1313,
         "unknown6": 0,
         "tint": 0,
@@ -64990,7 +64990,7 @@
     {
         "guid": 140016,
         "name_id": 18050,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1309,
         "unknown6": 0,
         "tint": 0,
@@ -65034,7 +65034,7 @@
     {
         "guid": 140017,
         "name_id": 18046,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1310,
         "unknown6": 0,
         "tint": 0,
@@ -65078,7 +65078,7 @@
     {
         "guid": 140018,
         "name_id": 18047,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1315,
         "unknown6": 0,
         "tint": 0,
@@ -65122,7 +65122,7 @@
     {
         "guid": 140019,
         "name_id": 18044,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1311,
         "unknown6": 0,
         "tint": 0,
@@ -65166,7 +65166,7 @@
     {
         "guid": 140020,
         "name_id": 18048,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1314,
         "unknown6": 0,
         "tint": 0,
@@ -65210,7 +65210,7 @@
     {
         "guid": 140021,
         "name_id": 18045,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1312,
         "unknown6": 0,
         "tint": 0,
@@ -65254,7 +65254,7 @@
     {
         "guid": 150000,
         "name_id": 428,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 710,
         "unknown6": 0,
         "tint": 0,
@@ -65298,7 +65298,7 @@
     {
         "guid": 150001,
         "name_id": 422,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 706,
         "unknown6": 0,
         "tint": 0,
@@ -65342,7 +65342,7 @@
     {
         "guid": 150002,
         "name_id": 420,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 711,
         "unknown6": 0,
         "tint": 0,
@@ -65386,7 +65386,7 @@
     {
         "guid": 150003,
         "name_id": 430,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 707,
         "unknown6": 0,
         "tint": 0,
@@ -65430,7 +65430,7 @@
     {
         "guid": 150004,
         "name_id": 424,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 705,
         "unknown6": 0,
         "tint": 0,
@@ -65474,7 +65474,7 @@
     {
         "guid": 150005,
         "name_id": 432,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 709,
         "unknown6": 0,
         "tint": 0,
@@ -65518,7 +65518,7 @@
     {
         "guid": 150006,
         "name_id": 434,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 708,
         "unknown6": 0,
         "tint": 0,
@@ -65562,7 +65562,7 @@
     {
         "guid": 150007,
         "name_id": 426,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 704,
         "unknown6": 0,
         "tint": 0,
@@ -65606,7 +65606,7 @@
     {
         "guid": 150008,
         "name_id": 43485,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1809,
         "unknown6": 0,
         "tint": 0,
@@ -65650,7 +65650,7 @@
     {
         "guid": 150009,
         "name_id": 43484,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1808,
         "unknown6": 0,
         "tint": 0,
@@ -65694,7 +65694,7 @@
     {
         "guid": 150010,
         "name_id": 420,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1811,
         "unknown6": 0,
         "tint": 0,
@@ -65738,7 +65738,7 @@
     {
         "guid": 150011,
         "name_id": 43488,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1812,
         "unknown6": 0,
         "tint": 0,
@@ -65782,7 +65782,7 @@
     {
         "guid": 150012,
         "name_id": 43486,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1810,
         "unknown6": 0,
         "tint": 0,
@@ -65826,7 +65826,7 @@
     {
         "guid": 160000,
         "name_id": 13836,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 530,
         "unknown6": 0,
         "tint": 0,
@@ -65870,7 +65870,7 @@
     {
         "guid": 160001,
         "name_id": 768,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 529,
         "unknown6": 0,
         "tint": 0,
@@ -65914,7 +65914,7 @@
     {
         "guid": 160002,
         "name_id": 5848,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 532,
         "unknown6": 0,
         "tint": 0,
@@ -65958,7 +65958,7 @@
     {
         "guid": 160003,
         "name_id": 321,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 528,
         "unknown6": 0,
         "tint": 0,
@@ -66002,7 +66002,7 @@
     {
         "guid": 160004,
         "name_id": 5848,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 588,
         "unknown6": 0,
         "tint": 0,
@@ -66046,7 +66046,7 @@
     {
         "guid": 160005,
         "name_id": 13781,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 585,
         "unknown6": 0,
         "tint": 0,
@@ -66090,7 +66090,7 @@
     {
         "guid": 160006,
         "name_id": 0,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 0,
         "unknown6": 0,
         "tint": 0,
@@ -66134,7 +66134,7 @@
     {
         "guid": 160007,
         "name_id": 13782,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 586,
         "unknown6": 0,
         "tint": 0,
@@ -66178,7 +66178,7 @@
     {
         "guid": 160008,
         "name_id": 13831,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 587,
         "unknown6": 0,
         "tint": 0,
@@ -66222,7 +66222,7 @@
     {
         "guid": 160009,
         "name_id": 18052,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1289,
         "unknown6": 0,
         "tint": 0,
@@ -66266,7 +66266,7 @@
     {
         "guid": 160010,
         "name_id": 18053,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1284,
         "unknown6": 0,
         "tint": 0,
@@ -66310,7 +66310,7 @@
     {
         "guid": 160011,
         "name_id": 18055,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1286,
         "unknown6": 0,
         "tint": 0,
@@ -66354,7 +66354,7 @@
     {
         "guid": 160012,
         "name_id": 18056,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1287,
         "unknown6": 0,
         "tint": 0,
@@ -66398,7 +66398,7 @@
     {
         "guid": 160013,
         "name_id": 18054,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1285,
         "unknown6": 0,
         "tint": 0,
@@ -66442,7 +66442,7 @@
     {
         "guid": 160014,
         "name_id": 18051,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1288,
         "unknown6": 0,
         "tint": 0,
@@ -66486,7 +66486,7 @@
     {
         "guid": 170000,
         "name_id": 792,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 607,
         "unknown6": 0,
         "tint": 0,
@@ -66530,7 +66530,7 @@
     {
         "guid": 170001,
         "name_id": 590,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 604,
         "unknown6": 0,
         "tint": 0,
@@ -66574,7 +66574,7 @@
     {
         "guid": 170002,
         "name_id": 584,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 601,
         "unknown6": 0,
         "tint": 0,
@@ -66618,7 +66618,7 @@
     {
         "guid": 170003,
         "name_id": 588,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 602,
         "unknown6": 0,
         "tint": 0,
@@ -66662,7 +66662,7 @@
     {
         "guid": 170004,
         "name_id": 54304,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 3655,
         "unknown6": 0,
         "tint": 0,
@@ -66706,7 +66706,7 @@
     {
         "guid": 170005,
         "name_id": 576,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 605,
         "unknown6": 0,
         "tint": 0,
@@ -66750,7 +66750,7 @@
     {
         "guid": 170006,
         "name_id": 2600,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 588,
         "unknown6": 0,
         "tint": 0,
@@ -66794,7 +66794,7 @@
     {
         "guid": 170007,
         "name_id": 592,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 606,
         "unknown6": 0,
         "tint": 0,
@@ -66838,7 +66838,7 @@
     {
         "guid": 170008,
         "name_id": 586,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 603,
         "unknown6": 0,
         "tint": 0,
@@ -66882,7 +66882,7 @@
     {
         "guid": 170009,
         "name_id": 582,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 608,
         "unknown6": 0,
         "tint": 0,
@@ -66926,7 +66926,7 @@
     {
         "guid": 170010,
         "name_id": 580,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 609,
         "unknown6": 0,
         "tint": 0,
@@ -66970,7 +66970,7 @@
     {
         "guid": 170011,
         "name_id": 578,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 610,
         "unknown6": 0,
         "tint": 0,
@@ -67014,7 +67014,7 @@
     {
         "guid": 170012,
         "name_id": 0,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 0,
         "unknown6": 0,
         "tint": 0,
@@ -67058,7 +67058,7 @@
     {
         "guid": 170013,
         "name_id": 13853,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 636,
         "unknown6": 0,
         "tint": 0,
@@ -67102,7 +67102,7 @@
     {
         "guid": 170014,
         "name_id": 13854,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 635,
         "unknown6": 0,
         "tint": 0,
@@ -67146,7 +67146,7 @@
     {
         "guid": 170015,
         "name_id": 13849,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 633,
         "unknown6": 0,
         "tint": 0,
@@ -67190,7 +67190,7 @@
     {
         "guid": 170016,
         "name_id": 13850,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 634,
         "unknown6": 0,
         "tint": 0,
@@ -67234,7 +67234,7 @@
     {
         "guid": 170017,
         "name_id": 13856,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 637,
         "unknown6": 0,
         "tint": 0,
@@ -67278,7 +67278,7 @@
     {
         "guid": 170018,
         "name_id": 13857,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 638,
         "unknown6": 0,
         "tint": 0,
@@ -67322,7 +67322,7 @@
     {
         "guid": 170019,
         "name_id": 13858,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 640,
         "unknown6": 0,
         "tint": 0,
@@ -67366,7 +67366,7 @@
     {
         "guid": 170020,
         "name_id": 13848,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 639,
         "unknown6": 0,
         "tint": 0,
@@ -67410,7 +67410,7 @@
     {
         "guid": 170021,
         "name_id": 2600,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1164,
         "unknown6": 0,
         "tint": 0,
@@ -67454,7 +67454,7 @@
     {
         "guid": 170022,
         "name_id": 15438,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 656,
         "unknown6": 0,
         "tint": 0,
@@ -67498,7 +67498,7 @@
     {
         "guid": 170023,
         "name_id": 13873,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 657,
         "unknown6": 0,
         "tint": 0,
@@ -67542,7 +67542,7 @@
     {
         "guid": 170024,
         "name_id": 13872,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 658,
         "unknown6": 0,
         "tint": 0,
@@ -67586,7 +67586,7 @@
     {
         "guid": 170025,
         "name_id": 33042,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1633,
         "unknown6": 0,
         "tint": 0,
@@ -67630,7 +67630,7 @@
     {
         "guid": 170026,
         "name_id": 13866,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 662,
         "unknown6": 0,
         "tint": 0,
@@ -67674,7 +67674,7 @@
     {
         "guid": 170027,
         "name_id": 33044,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1634,
         "unknown6": 0,
         "tint": 0,
@@ -67718,7 +67718,7 @@
     {
         "guid": 170028,
         "name_id": 13870,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 660,
         "unknown6": 0,
         "tint": 0,
@@ -67762,7 +67762,7 @@
     {
         "guid": 170029,
         "name_id": 13867,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 661,
         "unknown6": 0,
         "tint": 0,
@@ -67806,7 +67806,7 @@
     {
         "guid": 170030,
         "name_id": 13871,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 663,
         "unknown6": 0,
         "tint": 0,
@@ -67850,7 +67850,7 @@
     {
         "guid": 170031,
         "name_id": 33046,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1635,
         "unknown6": 0,
         "tint": 0,
@@ -67894,7 +67894,7 @@
     {
         "guid": 170032,
         "name_id": 33048,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1636,
         "unknown6": 0,
         "tint": 0,
@@ -67938,7 +67938,7 @@
     {
         "guid": 170033,
         "name_id": 13865,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 664,
         "unknown6": 0,
         "tint": 0,
@@ -67982,7 +67982,7 @@
     {
         "guid": 170034,
         "name_id": 15439,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 665,
         "unknown6": 0,
         "tint": 0,
@@ -68026,7 +68026,7 @@
     {
         "guid": 170035,
         "name_id": 13869,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 666,
         "unknown6": 0,
         "tint": 0,
@@ -68070,7 +68070,7 @@
     {
         "guid": 170036,
         "name_id": 13868,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 659,
         "unknown6": 0,
         "tint": 0,
@@ -68114,7 +68114,7 @@
     {
         "guid": 170037,
         "name_id": 598,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 620,
         "unknown6": 0,
         "tint": 0,
@@ -68158,7 +68158,7 @@
     {
         "guid": 170038,
         "name_id": 596,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 621,
         "unknown6": 0,
         "tint": 0,
@@ -68202,7 +68202,7 @@
     {
         "guid": 170039,
         "name_id": 600,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 622,
         "unknown6": 0,
         "tint": 0,
@@ -68246,7 +68246,7 @@
     {
         "guid": 170040,
         "name_id": 604,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1372,
         "unknown6": 0,
         "tint": 0,
@@ -68290,7 +68290,7 @@
     {
         "guid": 170041,
         "name_id": 1870,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1371,
         "unknown6": 0,
         "tint": 0,
@@ -68334,7 +68334,7 @@
     {
         "guid": 170042,
         "name_id": 15427,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 623,
         "unknown6": 0,
         "tint": 0,
@@ -68378,7 +68378,7 @@
     {
         "guid": 170043,
         "name_id": 602,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 624,
         "unknown6": 0,
         "tint": 0,
@@ -68422,7 +68422,7 @@
     {
         "guid": 170044,
         "name_id": 13877,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 619,
         "unknown6": 0,
         "tint": 0,
@@ -68466,7 +68466,7 @@
     {
         "guid": 170045,
         "name_id": 18064,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1297,
         "unknown6": 0,
         "tint": 0,
@@ -68510,7 +68510,7 @@
     {
         "guid": 170046,
         "name_id": 18062,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1298,
         "unknown6": 0,
         "tint": 0,
@@ -68554,7 +68554,7 @@
     {
         "guid": 170047,
         "name_id": 18063,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1299,
         "unknown6": 0,
         "tint": 0,
@@ -68598,7 +68598,7 @@
     {
         "guid": 170048,
         "name_id": 18058,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1300,
         "unknown6": 0,
         "tint": 0,
@@ -68642,7 +68642,7 @@
     {
         "guid": 170049,
         "name_id": 18069,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1301,
         "unknown6": 0,
         "tint": 0,
@@ -68686,7 +68686,7 @@
     {
         "guid": 170050,
         "name_id": 18059,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1302,
         "unknown6": 0,
         "tint": 0,
@@ -68730,7 +68730,7 @@
     {
         "guid": 170051,
         "name_id": 18061,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1303,
         "unknown6": 0,
         "tint": 0,
@@ -68774,7 +68774,7 @@
     {
         "guid": 170052,
         "name_id": 18065,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1304,
         "unknown6": 0,
         "tint": 0,
@@ -68818,7 +68818,7 @@
     {
         "guid": 170053,
         "name_id": 18060,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1305,
         "unknown6": 0,
         "tint": 0,
@@ -68862,7 +68862,7 @@
     {
         "guid": 170054,
         "name_id": 18066,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1306,
         "unknown6": 0,
         "tint": 0,
@@ -68906,7 +68906,7 @@
     {
         "guid": 170055,
         "name_id": 18068,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1307,
         "unknown6": 0,
         "tint": 0,
@@ -68950,7 +68950,7 @@
     {
         "guid": 170056,
         "name_id": 18067,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1308,
         "unknown6": 0,
         "tint": 0,
@@ -68994,7 +68994,7 @@
     {
         "guid": 170057,
         "name_id": 43477,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1823,
         "unknown6": 0,
         "tint": 0,
@@ -69038,7 +69038,7 @@
     {
         "guid": 170058,
         "name_id": 43478,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1824,
         "unknown6": 0,
         "tint": 0,
@@ -69082,7 +69082,7 @@
     {
         "guid": 170059,
         "name_id": 43479,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1825,
         "unknown6": 0,
         "tint": 0,
@@ -69126,7 +69126,7 @@
     {
         "guid": 170060,
         "name_id": 43480,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1826,
         "unknown6": 0,
         "tint": 0,
@@ -69170,7 +69170,7 @@
     {
         "guid": 170061,
         "name_id": 43481,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1827,
         "unknown6": 0,
         "tint": 0,
@@ -69214,7 +69214,7 @@
     {
         "guid": 170062,
         "name_id": 43482,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1828,
         "unknown6": 0,
         "tint": 0,
@@ -69258,7 +69258,7 @@
     {
         "guid": 180000,
         "name_id": 436,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1171,
         "unknown6": 0,
         "tint": 0,
@@ -69302,7 +69302,7 @@
     {
         "guid": 180001,
         "name_id": 4,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1173,
         "unknown6": 0,
         "tint": 0,
@@ -69346,7 +69346,7 @@
     {
         "guid": 180002,
         "name_id": 1677,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1318,
         "unknown6": 0,
         "tint": 0,
@@ -69390,7 +69390,7 @@
     {
         "guid": 180003,
         "name_id": 439,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1175,
         "unknown6": 0,
         "tint": 0,
@@ -69434,7 +69434,7 @@
     {
         "guid": 180004,
         "name_id": 2174,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1849,
         "unknown6": 0,
         "tint": 0,
@@ -69478,7 +69478,7 @@
     {
         "guid": 180005,
         "name_id": 437,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1177,
         "unknown6": 0,
         "tint": 0,
@@ -69522,7 +69522,7 @@
     {
         "guid": 180006,
         "name_id": 438,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1179,
         "unknown6": 0,
         "tint": 0,
@@ -69566,7 +69566,7 @@
     {
         "guid": 180007,
         "name_id": 4,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1172,
         "unknown6": 0,
         "tint": 0,
@@ -69610,7 +69610,7 @@
     {
         "guid": 180008,
         "name_id": 1677,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1317,
         "unknown6": 0,
         "tint": 0,
@@ -69654,7 +69654,7 @@
     {
         "guid": 180009,
         "name_id": 439,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1174,
         "unknown6": 0,
         "tint": 0,
@@ -69698,7 +69698,7 @@
     {
         "guid": 180010,
         "name_id": 2174,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1850,
         "unknown6": 0,
         "tint": 0,
@@ -69742,7 +69742,7 @@
     {
         "guid": 180011,
         "name_id": 437,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1176,
         "unknown6": 0,
         "tint": 0,
@@ -69786,7 +69786,7 @@
     {
         "guid": 180012,
         "name_id": 438,
-        "description_id": 0,
+        "description_id": 14,
         "icon_set_id": 1178,
         "unknown6": 0,
         "tint": 0,


### PR DESCRIPTION
Fix item names being used as individual item descriptions by setting the description to an empty string ID.