### PR TITLE
Send play time packet on Flash game win

### DIFF
--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -989,6 +989,7 @@ pub struct MinigameStatus {
     pub game_won: bool,
     pub score_entries: Vec<ScoreEntry>,
     pub total_score: i32,
+    pub start_time: Instant,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Send the play time in milliseconds upon winning a Flash game. This fixes the issue where Republic Gunship does not properly when surviving at least through the first round.