### PR TITLE
Fix Turret Tactics music playing after ending the game

### DIFF
--- a/config/minigames.json
+++ b/config/minigames.json
@@ -1157,7 +1157,7 @@
                                 "short_name": "",
                                 "flash_game": "TurretTactics.swf",
                                 "zone_template_guid": 200,
-                                "score_to_credits_expression": "x / 141"
+                                "score_to_credits_expression": "x / 69.5"
                             }
                         }
                     ]

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -1336,6 +1336,21 @@ fn end_active_minigame(
                             vec![
                                 GamePacket::serialize(&TunneledPacket {
                                     unknown1: true,
+                                    inner: FlashPayload {
+                                        header: MinigameHeader {
+                                            stage_guid: minigame_status.stage_guid,
+                                            unknown2: -1,
+                                            stage_group_guid: minigame_status.stage_group_guid,
+                                        },
+                                        payload: if minigame_status.game_won {
+                                            "OnGameWonMsg".to_string()
+                                        } else {
+                                            "OnGameLostMsg".to_string()
+                                        },
+                                    },
+                                })?,
+                                GamePacket::serialize(&TunneledPacket {
+                                    unknown1: true,
                                     inner: UpdateCredits { new_credits },
                                 })?,
                                 GamePacket::serialize(&TunneledPacket {


### PR DESCRIPTION
Fix Turret Tactics music playing after ending the game, as well as the cursor not reverting back to the normal cursor. Fix Turret Tactics credit ratio.