### PR TITLE
Fix adding and removing characters moved between chunks

### DIFF
--- a/src/game_server/handlers/inventory.rs
+++ b/src/game_server/handlers/inventory.rs
@@ -447,7 +447,6 @@ fn process_equip_customization(
 
                         let (_, instance_guid, chunk) = character_write_handle.index();
                         let nearby_players = ZoneInstance::all_players_nearby(
-                            Some(sender),
                             chunk,
                             instance_guid,
                             characters_table_read_handle,

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -443,7 +443,7 @@ impl GameServer {
                                                         }
                                                     }
 
-                                                    let all_players_nearby = ZoneInstance::all_players_nearby(Some(sender), chunk, instance_guid, characters_table_read_handle)?;
+                                                    let all_players_nearby = ZoneInstance::all_players_nearby(chunk, instance_guid, characters_table_read_handle)?;
                                                     character_broadcasts.push(Broadcast::Multi(all_players_nearby, global_packets));
                                                 } else {
                                                     return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Unknown player {} sent a ready packet", sender)));
@@ -676,7 +676,7 @@ impl GameServer {
                                 character_write_handle.brandish_or_holster();
 
                                 let (_, instance_guid, chunk) = character_write_handle.index();
-                                let all_players_nearby = ZoneInstance::all_players_nearby(Some(sender), chunk, instance_guid, characters_table_read_handle)?;
+                                let all_players_nearby = ZoneInstance::all_players_nearby(chunk, instance_guid, characters_table_read_handle)?;
                                 broadcasts.push(Broadcast::Multi(all_players_nearby, vec![
                                     GamePacket::serialize(&TunneledPacket {
                                         unknown1: true,
@@ -917,7 +917,7 @@ impl GameServer {
         broadcasts: &mut Vec<Broadcast>,
     ) -> Result<(), ProcessPacketError> {
         self.lock_enforcer().read_characters(|characters_table_read_handle| {
-            let nearby_player_guids = ZoneInstance::all_players_nearby(None, chunk, instance_guid, characters_table_read_handle)
+            let nearby_player_guids = ZoneInstance::all_players_nearby(chunk, instance_guid, characters_table_read_handle)
                 .unwrap_or_default();
             let nearby_players: Vec<u64> = nearby_player_guids.iter()
                 .map(|guid| *guid as u64)


### PR DESCRIPTION
Currently, characters that are moved between chunks within a zone aren't properly added and removed on other clients. This creates strange behavior when entering doors and also means any existing players in other rooms don't appear. This PR properly sends add/remove packets to other players when a character changes chunks.