### PR TITLE
Fix multiplayer mount expected speed

### DIFF
--- a/src/game_server/handlers/mount.rs
+++ b/src/game_server/handlers/mount.rs
@@ -105,6 +105,13 @@ pub fn reply_dismount<'a>(
                                 timer: 1000,
                             },
                         })?,
+                        GamePacket::serialize(&TunneledPacket {
+                            unknown1: true,
+                            inner: UpdateSpeed {
+                                guid: player_guid(sender),
+                                speed: zone.speed,
+                            },
+                        })?,
                     ],
                 ),
                 Broadcast::Single(


### PR DESCRIPTION
Properly set the expected speed for other players when they mount/dismount. This fixes the issue where a mounted player lags behind their real position on other players' screens.