### PR TITLE
Synchronize inventory between players, fix secondary equip bug

### DIFF
--- a/src/game_server/handlers/inventory.rs
+++ b/src/game_server/handlers/inventory.rs
@@ -685,6 +685,14 @@ fn equip_item_in_slot<'a>(
                         player_data.battle_classes.get_mut(&equip_guid.battle_class);
 
                     if let Some(battle_class) = possible_battle_class {
+                        if equip_guid.slot == EquipmentSlot::SecondaryWeapon
+                            && !battle_class
+                                .items
+                                .contains_key(&EquipmentSlot::PrimaryWeapon)
+                        {
+                            return Ok((Vec::new(), 0));
+                        }
+
                         if let Some(item_def) = game_server.items().get(&equip_guid.item_guid) {
                             let mut sender_only_packets =
                                 vec![GamePacket::serialize(&TunneledPacket {

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -439,7 +439,16 @@ impl GameServer {
                                                         })?);
 
                                                         if let Some(battle_class) = player.battle_classes.get(&player.active_battle_class) {
-                                                            character_broadcasts.append(&mut update_saber_tints(sender, &battle_class.items, player.active_battle_class, self)?);
+                                                            character_broadcasts.append(&mut update_saber_tints(
+                                                                sender,
+                                                                characters_table_read_handle,
+                                                                instance_guid,
+                                                                chunk,
+                                                                &battle_class.items,
+                                                                player.active_battle_class,
+                                                                character_write_handle.wield_type(),
+                                                                self
+                                                            )?);
                                                         }
                                                     }
 

--- a/src/game_server/packets/player_update.rs
+++ b/src/game_server/packets/player_update.rs
@@ -499,10 +499,10 @@ impl GamePacket for SetAnimation {
 #[derive(SerializePacket)]
 pub struct UpdateEquippedItem {
     pub guid: u64,
-    pub unknown: u32,
+    pub item_guid: u32,
     pub item: Attachment,
     pub battle_class: u32,
-    pub wield_type: u32,
+    pub wield_type: WieldType,
 }
 
 impl GamePacket for UpdateEquippedItem {


### PR DESCRIPTION
* Synchronize item equip/unequip between multiple characters
* Disallow equipping a weapon in the secondary slot if a primary slot item is not equipped
* Customization was already synchronized previously