### PR TITLE
Support secondary and tertiary GUID table indices

### DIFF
--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -1316,7 +1316,7 @@ impl IndexedGuid<u64, CharacterIndex> for Character {
         self.stats.guid
     }
 
-    fn index(&self) -> CharacterIndex {
+    fn index1(&self) -> CharacterIndex {
         (
             match &self.stats.character_type {
                 CharacterType::Player(player) => match player.ready {

--- a/src/game_server/handlers/guid.rs
+++ b/src/game_server/handlers/guid.rs
@@ -28,10 +28,18 @@ pub trait Guid<T> {
     fn guid(&self) -> T;
 }
 
-pub trait IndexedGuid<T, I> {
+pub trait IndexedGuid<T, I1, I2 = (), I3 = ()> {
     fn guid(&self) -> T;
 
-    fn index(&self) -> I;
+    fn index1(&self) -> I1;
+
+    fn index2(&self) -> Option<I2> {
+        None
+    }
+
+    fn index3(&self) -> Option<I3> {
+        None
+    }
 }
 
 impl<T, G: Guid<T>> IndexedGuid<T, ()> for G {
@@ -39,186 +47,343 @@ impl<T, G: Guid<T>> IndexedGuid<T, ()> for G {
         self.guid()
     }
 
-    fn index(&self) {}
+    fn index1(&self) {}
 }
 
-struct GuidTableData<K, V, I> {
-    data: BTreeMap<K, (Lock<V>, I)>,
-    index: BTreeMap<I, BTreeSet<K>>,
+pub type GuidTableEntry<V, I1, I2, I3> = (Lock<V>, I1, Option<I2>, Option<I3>);
+
+struct GuidTableData<K, V, I1, I2, I3> {
+    data: BTreeMap<K, GuidTableEntry<V, I1, I2, I3>>,
+    index1: BTreeMap<I1, BTreeSet<K>>,
+    index2: BTreeMap<I2, BTreeSet<K>>,
+    index3: BTreeMap<I3, BTreeSet<K>>,
 }
 
-impl<K, V, I> GuidTableData<K, V, I> {
+impl<K, V, I1, I2, I3> GuidTableData<K, V, I1, I2, I3> {
     fn new() -> Self {
         GuidTableData {
             data: BTreeMap::new(),
-            index: BTreeMap::new(),
+            index1: BTreeMap::new(),
+            index2: BTreeMap::new(),
+            index3: BTreeMap::new(),
         }
     }
 }
 
-pub trait GuidTableIndexer<'a, K, V: 'a, I> {
-    fn index(&self, guid: K) -> Option<I>;
+pub trait GuidTableIndexer<'a, K, V: 'a, I1, I2 = (), I3 = ()> {
+    fn index1(&self, guid: K) -> Option<I1>;
+
+    fn index2(&self, guid: K) -> Option<I2>;
+
+    fn index3(&self, guid: K) -> Option<I3>;
 
     fn keys(&'a self) -> impl Iterator<Item = K>;
 
-    fn keys_by_index(&'a self, index: I) -> impl Iterator<Item = K>;
+    fn keys_by_index1(&'a self, index: I1) -> impl Iterator<Item = K>;
 
-    fn keys_by_range(&'a self, range: impl RangeBounds<I>) -> impl Iterator<Item = K>;
+    fn keys_by_index2(&'a self, index: I2) -> impl Iterator<Item = K>;
+
+    fn keys_by_index3(&'a self, index: I3) -> impl Iterator<Item = K>;
+
+    fn keys_by_index1_range(&'a self, range: impl RangeBounds<I1>) -> impl Iterator<Item = K>;
+
+    fn keys_by_index2_range(&'a self, range: impl RangeBounds<I2>) -> impl Iterator<Item = K>;
+
+    fn keys_by_index3_range(&'a self, range: impl RangeBounds<I3>) -> impl Iterator<Item = K>;
 }
 
-pub trait GuidTableHandle<'a, K, V: 'a, I>: GuidTableIndexer<'a, K, V, I> {
+pub trait GuidTableHandle<'a, K, V: 'a, I1, I2, I3>:
+    GuidTableIndexer<'a, K, V, I1, I2, I3>
+{
     fn get(&self, guid: K) -> Option<&Lock<V>>;
 }
 
-pub struct GuidTableReadHandle<'a, K, V, I = ()> {
-    guard: RwLockReadGuard<'a, GuidTableData<K, V, I>>,
+pub struct GuidTableReadHandle<'a, K, V, I1 = (), I2 = (), I3 = ()> {
+    guard: RwLockReadGuard<'a, GuidTableData<K, V, I1, I2, I3>>,
 }
 
-impl<'a, K: Copy + Ord, V, I: Copy + Ord> GuidTableIndexer<'a, K, V, I>
-    for GuidTableReadHandle<'a, K, V, I>
+impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Copy + Ord, I3: Copy + Ord>
+    GuidTableIndexer<'a, K, V, I1, I2, I3> for GuidTableReadHandle<'a, K, V, I1, I2, I3>
 {
-    fn index(&self, guid: K) -> Option<I> {
-        self.guard.data.get(&guid).map(|(_, index)| *index)
+    fn index1(&self, guid: K) -> Option<I1> {
+        self.guard.data.get(&guid).map(|(_, index1, _, _)| *index1)
+    }
+
+    fn index2(&self, guid: K) -> Option<I2> {
+        self.guard
+            .data
+            .get(&guid)
+            .and_then(|(_, _, index2, _)| *index2)
+    }
+
+    fn index3(&self, guid: K) -> Option<I3> {
+        self.guard
+            .data
+            .get(&guid)
+            .and_then(|(_, _, _, index3)| *index3)
     }
 
     fn keys(&'a self) -> impl Iterator<Item = K> {
         self.guard.data.keys().cloned()
     }
 
-    fn keys_by_index(&'a self, index: I) -> impl Iterator<Item = K> {
+    fn keys_by_index1(&'a self, index: I1) -> impl Iterator<Item = K> {
         self.guard
-            .index
+            .index1
             .get(&index)
             .map(|index_list| index_list.iter())
             .unwrap_or_default()
             .cloned()
     }
 
-    fn keys_by_range(&'a self, range: impl RangeBounds<I>) -> impl Iterator<Item = K> {
+    fn keys_by_index2(&'a self, index: I2) -> impl Iterator<Item = K> {
         self.guard
-            .index
+            .index2
+            .get(&index)
+            .map(|index_list| index_list.iter())
+            .unwrap_or_default()
+            .cloned()
+    }
+
+    fn keys_by_index3(&'a self, index: I3) -> impl Iterator<Item = K> {
+        self.guard
+            .index3
+            .get(&index)
+            .map(|index_list| index_list.iter())
+            .unwrap_or_default()
+            .cloned()
+    }
+
+    fn keys_by_index1_range(&'a self, range: impl RangeBounds<I1>) -> impl Iterator<Item = K> {
+        self.guard
+            .index1
+            .range(range)
+            .flat_map(|(_, keys)| keys.iter().copied())
+    }
+
+    fn keys_by_index2_range(&'a self, range: impl RangeBounds<I2>) -> impl Iterator<Item = K> {
+        self.guard
+            .index2
+            .range(range)
+            .flat_map(|(_, keys)| keys.iter().copied())
+    }
+
+    fn keys_by_index3_range(&'a self, range: impl RangeBounds<I3>) -> impl Iterator<Item = K> {
+        self.guard
+            .index3
             .range(range)
             .flat_map(|(_, keys)| keys.iter().copied())
     }
 }
 
-impl<'a, K: Copy + Ord, V, I: Copy + Ord> GuidTableHandle<'a, K, V, I>
-    for GuidTableReadHandle<'a, K, V, I>
+impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Copy + Ord, I3: Copy + Ord>
+    GuidTableHandle<'a, K, V, I1, I2, I3> for GuidTableReadHandle<'a, K, V, I1, I2, I3>
 {
     fn get(&self, guid: K) -> Option<&Lock<V>> {
-        self.guard.data.get(&guid).map(|(item, _)| item)
+        self.guard.data.get(&guid).map(|(item, _, _, _)| item)
     }
 }
 
-pub struct GuidTableWriteHandle<'a, K, V, I = ()> {
-    guard: RwLockWriteGuard<'a, GuidTableData<K, V, I>>,
+pub struct GuidTableWriteHandle<'a, K, V, I1 = (), I2 = (), I3 = ()> {
+    guard: RwLockWriteGuard<'a, GuidTableData<K, V, I1, I2, I3>>,
 }
 
-impl<K: Copy + Ord, V: IndexedGuid<K, I>, I: Copy + Ord> GuidTableWriteHandle<'_, K, V, I> {
+impl<
+        K: Copy + Ord,
+        V: IndexedGuid<K, I1, I2, I3>,
+        I1: Copy + Ord,
+        I2: Copy + Ord,
+        I3: Copy + Ord,
+    > GuidTableWriteHandle<'_, K, V, I1, I2, I3>
+{
     pub fn get(&self, guid: K) -> Option<&Lock<V>> {
-        self.guard.data.get(&guid).map(|(lock, _)| lock)
+        self.guard.data.get(&guid).map(|(lock, _, _, _)| lock)
     }
 
-    pub fn values_by_index(&self, index: I) -> impl Iterator<Item = &Lock<V>> {
-        self.keys_by_index(index)
-            .filter_map(|guid| self.guard.data.get(&guid).map(|(lock, _)| lock))
+    pub fn values_by_index(&self, index: I1) -> impl Iterator<Item = &Lock<V>> {
+        self.keys_by_index1(index)
+            .filter_map(|guid| self.guard.data.get(&guid).map(|(lock, _, _, _)| lock))
     }
 
     pub fn insert(&mut self, item: V) -> Option<Lock<V>> {
         let key = item.guid();
-        let index = item.index();
+        let index1 = item.index1();
+        let index2 = item.index2();
+        let index3 = item.index3();
 
-        self.insert_with_index(key, index, Lock::new(item))
+        self.insert_with_index(key, index1, index2, index3, Lock::new(item))
     }
 
-    pub fn insert_lock(&mut self, guid: K, index: I, lock: Lock<V>) -> Option<Lock<V>> {
-        self.insert_with_index(guid, index, lock)
+    pub fn insert_lock(
+        &mut self,
+        guid: K,
+        index1: I1,
+        index2: Option<I2>,
+        index3: Option<I3>,
+        lock: Lock<V>,
+    ) -> Option<Lock<V>> {
+        self.insert_with_index(guid, index1, index2, index3, lock)
     }
 
-    pub fn remove(&mut self, guid: K) -> Option<(Lock<V>, I)> {
+    pub fn remove(&mut self, guid: K) -> Option<GuidTableEntry<V, I1, I2, I3>> {
         let previous = self.guard.data.remove(&guid);
-        if let Some((_, previous_index)) = &previous {
+        if let Some((_, previous_index1, previous_index2, previous_index3)) = &previous {
             self.guard
-                .index
-                .get_mut(previous_index)
-                .expect("GUID table key was never added to index")
+                .index1
+                .get_mut(previous_index1)
+                .expect("GUID table key was never added to index1")
                 .remove(&guid);
+
+            if let Some(index2) = previous_index2 {
+                self.guard
+                    .index2
+                    .get_mut(index2)
+                    .expect("GUID table key was never added to index2")
+                    .remove(&guid);
+            }
+
+            if let Some(index3) = previous_index3 {
+                self.guard
+                    .index3
+                    .get_mut(index3)
+                    .expect("GUID table key was never added to index3")
+                    .remove(&guid);
+            }
         }
 
         previous
     }
 
-    fn insert_with_index(&mut self, key: K, index: I, item: Lock<V>) -> Option<Lock<V>> {
+    fn insert_with_index(
+        &mut self,
+        key: K,
+        index1: I1,
+        index2: Option<I2>,
+        index3: Option<I3>,
+        item: Lock<V>,
+    ) -> Option<Lock<V>> {
         // Remove from the index before inserting the new key in case the item has the same key
-        let previous = self.guard.data.insert(key, (item, index));
-        if let Some((_, previous_index)) = &previous {
-            self.guard
-                .index
-                .get_mut(previous_index)
-                .expect("GUID table key was never added to index")
-                .remove(&key);
+        let previous = self.remove(key);
+
+        self.guard.data.insert(key, (item, index1, index2, index3));
+        self.guard.index1.entry(index1).or_default().insert(key);
+        if let Some(value) = index2 {
+            self.guard.index2.entry(value).or_default().insert(key);
+        }
+        if let Some(value) = index3 {
+            self.guard.index3.entry(value).or_default().insert(key);
         }
 
-        self.guard.index.entry(index).or_default().insert(key);
-
-        previous.map(|(item, _)| item)
+        previous.map(|(item, _, _, _)| item)
     }
 }
 
-impl<'a, K: Copy + Ord, V, I: Copy + Ord> GuidTableIndexer<'a, K, V, I>
-    for GuidTableWriteHandle<'a, K, V, I>
+impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Copy + Ord, I3: Copy + Ord>
+    GuidTableIndexer<'a, K, V, I1, I2, I3> for GuidTableWriteHandle<'a, K, V, I1, I2, I3>
 {
-    fn index(&self, guid: K) -> Option<I> {
-        self.guard.data.get(&guid).map(|(_, index)| *index)
+    fn index1(&self, guid: K) -> Option<I1> {
+        self.guard.data.get(&guid).map(|(_, index, _, _)| *index)
+    }
+
+    fn index2(&self, guid: K) -> Option<I2> {
+        self.guard
+            .data
+            .get(&guid)
+            .and_then(|(_, _, index, _)| *index)
+    }
+
+    fn index3(&self, guid: K) -> Option<I3> {
+        self.guard
+            .data
+            .get(&guid)
+            .and_then(|(_, _, _, index)| *index)
     }
 
     fn keys(&'a self) -> impl Iterator<Item = K> {
         self.guard.data.keys().cloned()
     }
 
-    fn keys_by_index(&'a self, index: I) -> impl Iterator<Item = K> {
+    fn keys_by_index1(&'a self, index: I1) -> impl Iterator<Item = K> {
         self.guard
-            .index
+            .index1
             .get(&index)
             .map(|index_list| index_list.iter())
             .unwrap_or_default()
             .cloned()
     }
 
-    fn keys_by_range(&'a self, range: impl RangeBounds<I>) -> impl Iterator<Item = K> {
+    fn keys_by_index2(&'a self, index: I2) -> impl Iterator<Item = K> {
         self.guard
-            .index
+            .index2
+            .get(&index)
+            .map(|index_list| index_list.iter())
+            .unwrap_or_default()
+            .cloned()
+    }
+
+    fn keys_by_index3(&'a self, index: I3) -> impl Iterator<Item = K> {
+        self.guard
+            .index3
+            .get(&index)
+            .map(|index_list| index_list.iter())
+            .unwrap_or_default()
+            .cloned()
+    }
+
+    fn keys_by_index1_range(&'a self, range: impl RangeBounds<I1>) -> impl Iterator<Item = K> {
+        self.guard
+            .index1
+            .range(range)
+            .flat_map(|(_, keys)| keys.iter().copied())
+    }
+
+    fn keys_by_index2_range(&'a self, range: impl RangeBounds<I2>) -> impl Iterator<Item = K> {
+        self.guard
+            .index2
+            .range(range)
+            .flat_map(|(_, keys)| keys.iter().copied())
+    }
+
+    fn keys_by_index3_range(&'a self, range: impl RangeBounds<I3>) -> impl Iterator<Item = K> {
+        self.guard
+            .index3
             .range(range)
             .flat_map(|(_, keys)| keys.iter().copied())
     }
 }
 
-impl<'a, K: Copy + Ord, I: Copy + Ord, V: IndexedGuid<K, I>> GuidTableHandle<'a, K, V, I>
-    for GuidTableWriteHandle<'a, K, V, I>
+impl<
+        'a,
+        K: Copy + Ord,
+        I1: Copy + Ord,
+        I2: Copy + Ord,
+        I3: Copy + Ord,
+        V: IndexedGuid<K, I1, I2, I3>,
+    > GuidTableHandle<'a, K, V, I1, I2, I3> for GuidTableWriteHandle<'a, K, V, I1, I2, I3>
 {
     fn get(&self, guid: K) -> Option<&Lock<V>> {
-        self.guard.data.get(&guid).map(|(item, _)| item)
+        self.guard.data.get(&guid).map(|(item, _, _, _)| item)
     }
 }
 
-pub struct GuidTable<K, V, I = ()> {
-    data: Lock<GuidTableData<K, V, I>>,
+pub struct GuidTable<K, V, I1 = (), I2 = (), I3 = ()> {
+    data: Lock<GuidTableData<K, V, I1, I2, I3>>,
 }
 
-impl<K, I, V: IndexedGuid<K, I>> GuidTable<K, V, I> {
+impl<K, I1, I2, I3, V: IndexedGuid<K, I1, I2, I3>> GuidTable<K, V, I1, I2, I3> {
     pub fn new() -> Self {
         GuidTable {
             data: Lock::new(GuidTableData::new()),
         }
     }
 
-    pub fn read(&self) -> GuidTableReadHandle<K, V, I> {
+    pub fn read(&self) -> GuidTableReadHandle<K, V, I1, I2, I3> {
         GuidTableReadHandle {
             guard: self.data.read(),
         }
     }
 
-    pub fn write(&self) -> GuidTableWriteHandle<K, V, I> {
+    pub fn write(&self) -> GuidTableWriteHandle<K, V, I1, I2, I3> {
         GuidTableWriteHandle {
             guard: self.data.write(),
         }

--- a/src/game_server/handlers/housing.rs
+++ b/src/game_server/handlers/housing.rs
@@ -363,7 +363,7 @@ pub fn process_housing_packet(
                     read_guids: Vec::new(),
                     write_guids: Vec::new(),
                     character_consumer: |characters_table_read_handle, _, _, zones_lock_enforcer| {
-                        let packets = if let Some((_, instance_guid, _)) = characters_table_read_handle.index(player_guid(sender)) {
+                        let packets = if let Some((_, instance_guid, _)) = characters_table_read_handle.index1(player_guid(sender)) {
                             zones_lock_enforcer.read_zones(|_| ZoneLockRequest {
                                 read_guids: vec![instance_guid],
                                 write_guids: Vec::new(),

--- a/src/game_server/handlers/inventory.rs
+++ b/src/game_server/handlers/inventory.rs
@@ -250,7 +250,7 @@ fn process_unequip_slot(
                         })?
                     );
 
-                    let (_, instance_guid, chunk) = character_write_handle.index();
+                    let (_, instance_guid, chunk) = character_write_handle.index1();
                     let all_players_nearby = ZoneInstance::all_players_nearby(chunk, instance_guid, characters_table_read_handle)?;
                     broadcasts.push(Broadcast::Multi(all_players_nearby, all_player_packets));
 
@@ -294,7 +294,7 @@ fn process_equip_guid(
                                 if let Some(battle_class) =
                                     player.battle_classes.get(&player.active_battle_class)
                                 {
-                                    let (_, instance_guid, chunk) = character_write_handle.index();
+                                    let (_, instance_guid, chunk) = character_write_handle.index1();
                                     broadcasts.append(&mut update_saber_tints(
                                         sender,
                                         characters_table_read_handle,
@@ -477,7 +477,7 @@ fn process_equip_customization(
                                 .insert(customization.customization_slot, customization.guid);
                         }
 
-                        let (_, instance_guid, chunk) = character_write_handle.index();
+                        let (_, instance_guid, chunk) = character_write_handle.index1();
                         let nearby_players = ZoneInstance::all_players_nearby(
                             chunk,
                             instance_guid,
@@ -865,7 +865,7 @@ fn equip_item_in_slot<'a>(
                 ))
             }?;
 
-        let (_, instance_guid, chunk) = character_write_handle.index();
+        let (_, instance_guid, chunk) = character_write_handle.index1();
         let mut nearby_players = ZoneInstance::other_players_nearby(
             Some(sender),
             chunk,

--- a/src/game_server/handlers/lock_enforcer.rs
+++ b/src/game_server/handlers/lock_enforcer.rs
@@ -13,27 +13,51 @@ use super::{
     zone::ZoneInstance,
 };
 
-pub struct TableReadHandleWrapper<'a, K, V, I = ()> {
-    handle: GuidTableReadHandle<'a, K, V, I>,
+pub struct TableReadHandleWrapper<'a, K, V, I1 = (), I2 = (), I3 = ()> {
+    handle: GuidTableReadHandle<'a, K, V, I1, I2, I3>,
 }
 
-impl<'a, K: Copy + Ord, V, I: Copy + Ord> GuidTableIndexer<'a, K, V, I>
-    for TableReadHandleWrapper<'a, K, V, I>
+impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Copy + Ord, I3: Copy + Ord>
+    GuidTableIndexer<'a, K, V, I1, I2, I3> for TableReadHandleWrapper<'a, K, V, I1, I2, I3>
 {
-    fn index(&self, guid: K) -> Option<I> {
-        self.handle.index(guid)
+    fn index1(&self, guid: K) -> Option<I1> {
+        self.handle.index1(guid)
+    }
+
+    fn index2(&self, guid: K) -> Option<I2> {
+        self.handle.index2(guid)
+    }
+
+    fn index3(&self, guid: K) -> Option<I3> {
+        self.handle.index3(guid)
     }
 
     fn keys(&'a self) -> impl Iterator<Item = K> {
         self.handle.keys()
     }
 
-    fn keys_by_index(&'a self, index: I) -> impl Iterator<Item = K> {
-        self.handle.keys_by_index(index)
+    fn keys_by_index1(&'a self, index: I1) -> impl Iterator<Item = K> {
+        self.handle.keys_by_index1(index)
     }
 
-    fn keys_by_range(&'a self, range: impl RangeBounds<I>) -> impl Iterator<Item = K> {
-        self.handle.keys_by_range(range)
+    fn keys_by_index2(&'a self, index: I2) -> impl Iterator<Item = K> {
+        self.handle.keys_by_index2(index)
+    }
+
+    fn keys_by_index3(&'a self, index: I3) -> impl Iterator<Item = K> {
+        self.handle.keys_by_index3(index)
+    }
+
+    fn keys_by_index1_range(&'a self, range: impl RangeBounds<I1>) -> impl Iterator<Item = K> {
+        self.handle.keys_by_index1_range(range)
+    }
+
+    fn keys_by_index2_range(&'a self, range: impl RangeBounds<I2>) -> impl Iterator<Item = K> {
+        self.handle.keys_by_index2_range(range)
+    }
+
+    fn keys_by_index3_range(&'a self, range: impl RangeBounds<I3>) -> impl Iterator<Item = K> {
+        self.handle.keys_by_index3_range(range)
     }
 }
 

--- a/src/game_server/handlers/login.rs
+++ b/src/game_server/handlers/login.rs
@@ -135,7 +135,7 @@ pub fn log_out(
     game_server
         .lock_enforcer()
         .write_characters(|characters_table_write_handle, _| {
-            if let Some((character, (_, instance_guid, chunk))) =
+            if let Some((character, (_, instance_guid, chunk), _, _)) =
                 characters_table_write_handle.remove(player_guid(sender))
             {
                 let other_players_nearby = ZoneInstance::other_players_nearby(

--- a/src/game_server/handlers/mount.rs
+++ b/src/game_server/handlers/mount.rs
@@ -80,7 +80,7 @@ pub fn reply_dismount<'a>(
     if let Some(mount_id) = character.stats.mount_id {
         character.stats.mount_id = None;
         if let Some(mount) = mounts.get(&mount_id) {
-            let (_, instance_guid, chunk) = character.index();
+            let (_, instance_guid, chunk) = character.index1();
             let all_players_nearby =
                 ZoneInstance::all_players_nearby(chunk, instance_guid, characters_table_handle)?;
             Ok(vec![
@@ -252,7 +252,7 @@ fn process_mount_spawn(
 
                                 character_write_handle.stats.mount_id = Some(Guid::guid(mount));
 
-                                let (_, instance_guid, chunk) = character_write_handle.index();
+                                let (_, instance_guid, chunk) = character_write_handle.index1();
                                 let all_players_nearby = ZoneInstance::all_players_nearby(chunk, instance_guid, characters_table_read_handle)?;
                                 Ok(vec![
                                     Broadcast::Multi(all_players_nearby, packets),


### PR DESCRIPTION
Support optional secondary and tertiary indices for items in a GUID table. For multiplayer chat, we want to be able to efficiently retrieve a player by name or by squad GUID, which we can't do by selecting on a range of instance GUIDs and chunks in the current index. Hence, we need to add two new indices: one with names and one with squad GUIDs.

To conserve memory, items in the GUID table are not added to the secondary or tertiary indices if they do not have those indices. Hence, `index2()` and `index3()` return `Option` rather than `()` or some other direct value.

Note that this PR doesn't yet alter the characters or zone table indices.