### PR TITLE
Fix other players' mounts' jump height

### DIFF
--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -181,7 +181,7 @@ impl BaseNpc {
                 name_offset_z: self.name_offset_z,
                 terrain_object_id: self.terrain_object_id,
                 invisible: !self.visible,
-                speed: character.stats.speed,
+                speed: character.stats.speed.total(),
                 unknown21: false,
                 interactable_size_pct: 100,
                 unknown23: -1,
@@ -323,7 +323,7 @@ impl TickableStep {
         let mut packets_for_all = Vec::new();
 
         if let Some(speed) = self.speed {
-            character.speed = speed;
+            character.speed.base = speed;
             packets_for_all.push(GamePacket::serialize(&TunneledPacket {
                 unknown1: true,
                 inner: UpdateSpeed {
@@ -1143,7 +1143,7 @@ impl Player {
                     .and_then(|customization_guid| customizations.get(customization_guid))
                     .map(|customization| customization.customization_param1.clone())
                     .unwrap_or_default(),
-                speed: character.stats.speed,
+                speed: character.stats.speed.total(),
                 underage: false,
                 member: self.member,
                 moderator: false,
@@ -1260,8 +1260,14 @@ impl NpcTemplate {
                 wield_type: (self.wield_type, self.wield_type.holster()),
                 holstered: false,
                 animation_id: self.animation_id,
-                speed: 0.0,
-                jump_height_multiplier: 1.0,
+                speed: CharacterStat {
+                    base: 0.0,
+                    mount_multiplier: 1.0,
+                },
+                jump_height_multiplier: CharacterStat {
+                    base: 1.0,
+                    mount_multiplier: 1.0,
+                },
                 cursor: self.cursor,
             },
             tickable_procedure_tracker: TickableProcedureTracker::new(
@@ -1282,6 +1288,18 @@ pub type Chunk = (i32, i32);
 pub type CharacterIndex = (CharacterCategory, u64, Chunk);
 
 #[derive(Clone)]
+pub struct CharacterStat {
+    pub base: f32,
+    pub mount_multiplier: f32,
+}
+
+impl CharacterStat {
+    pub fn total(&self) -> f32 {
+        self.base * self.mount_multiplier
+    }
+}
+
+#[derive(Clone)]
 pub struct CharacterStats {
     guid: u64,
     pub pos: Pos,
@@ -1293,8 +1311,8 @@ pub struct CharacterStats {
     pub auto_interact_radius: f32,
     pub instance_guid: u64,
     pub animation_id: i32,
-    pub speed: f32,
-    pub jump_height_multiplier: f32,
+    pub speed: CharacterStat,
+    pub jump_height_multiplier: CharacterStat,
     pub cursor: Option<u8>,
     wield_type: (WieldType, WieldType),
     holstered: bool,
@@ -1378,8 +1396,14 @@ impl Character {
                 wield_type: (wield_type, wield_type.holster()),
                 holstered: false,
                 animation_id,
-                speed: 0.0,
-                jump_height_multiplier: 1.0,
+                speed: CharacterStat {
+                    base: 0.0,
+                    mount_multiplier: 1.0,
+                },
+                jump_height_multiplier: CharacterStat {
+                    base: 1.0,
+                    mount_multiplier: 1.0,
+                },
             },
             tickable_procedure_tracker: TickableProcedureTracker::new(
                 tickable_procedures,
@@ -1436,8 +1460,14 @@ impl Character {
                 wield_type: (wield_type, wield_type.holster()),
                 holstered: false,
                 animation_id: 0,
-                speed: 0.0,
-                jump_height_multiplier: 1.0,
+                speed: CharacterStat {
+                    base: 0.0,
+                    mount_multiplier: 1.0,
+                },
+                jump_height_multiplier: CharacterStat {
+                    base: 1.0,
+                    mount_multiplier: 1.0,
+                },
             },
             tickable_procedure_tracker: TickableProcedureTracker::new(HashMap::new(), Vec::new()),
             synchronize_with: None,

--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -1261,6 +1261,7 @@ impl NpcTemplate {
                 holstered: false,
                 animation_id: self.animation_id,
                 speed: 0.0,
+                jump_height_multiplier: 1.0,
                 cursor: self.cursor,
             },
             tickable_procedure_tracker: TickableProcedureTracker::new(
@@ -1293,6 +1294,7 @@ pub struct CharacterStats {
     pub instance_guid: u64,
     pub animation_id: i32,
     pub speed: f32,
+    pub jump_height_multiplier: f32,
     pub cursor: Option<u8>,
     wield_type: (WieldType, WieldType),
     holstered: bool,
@@ -1377,6 +1379,7 @@ impl Character {
                 holstered: false,
                 animation_id,
                 speed: 0.0,
+                jump_height_multiplier: 1.0,
             },
             tickable_procedure_tracker: TickableProcedureTracker::new(
                 tickable_procedures,
@@ -1434,6 +1437,7 @@ impl Character {
                 holstered: false,
                 animation_id: 0,
                 speed: 0.0,
+                jump_height_multiplier: 1.0,
             },
             tickable_procedure_tracker: TickableProcedureTracker::new(HashMap::new(), Vec::new()),
             synchronize_with: None,

--- a/src/game_server/handlers/mod.rs
+++ b/src/game_server/handlers/mod.rs
@@ -16,6 +16,7 @@ pub mod store;
 pub mod test_data;
 pub mod time;
 pub mod unique_guid;
+pub mod update_position;
 pub mod zone;
 
 pub fn distance3_pos(pos1: Pos, pos2: Pos) -> f32 {

--- a/src/game_server/handlers/mount.rs
+++ b/src/game_server/handlers/mount.rs
@@ -80,7 +80,7 @@ pub fn reply_dismount<'a>(
     if let Some(mount_id) = character.stats.mount_id {
         character.stats.mount_id = None;
         if let Some(mount) = mounts.get(&mount_id) {
-            character.stats.jump_height_multiplier /= mount.jump_height_multiplier;
+            character.stats.jump_height_multiplier.mount_multiplier = mount.jump_height_multiplier;
             let (_, instance_guid, chunk) = character.index1();
             let all_players_nearby =
                 ZoneInstance::all_players_nearby(chunk, instance_guid, characters_table_handle)?;
@@ -252,7 +252,7 @@ fn process_mount_spawn(
                                 }
 
                                 character_write_handle.stats.mount_id = Some(Guid::guid(mount));
-                                character_write_handle.stats.jump_height_multiplier *= mount.jump_height_multiplier;
+                                character_write_handle.stats.jump_height_multiplier.mount_multiplier = mount.jump_height_multiplier;
 
                                 let (_, instance_guid, chunk) = character_write_handle.index1();
                                 let all_players_nearby = ZoneInstance::all_players_nearby(chunk, instance_guid, characters_table_read_handle)?;

--- a/src/game_server/handlers/mount.rs
+++ b/src/game_server/handlers/mount.rs
@@ -80,6 +80,7 @@ pub fn reply_dismount<'a>(
     if let Some(mount_id) = character.stats.mount_id {
         character.stats.mount_id = None;
         if let Some(mount) = mounts.get(&mount_id) {
+            character.stats.jump_height_multiplier /= mount.jump_height_multiplier;
             let (_, instance_guid, chunk) = character.index1();
             let all_players_nearby =
                 ZoneInstance::all_players_nearby(chunk, instance_guid, characters_table_handle)?;
@@ -251,6 +252,7 @@ fn process_mount_spawn(
                                 }
 
                                 character_write_handle.stats.mount_id = Some(Guid::guid(mount));
+                                character_write_handle.stats.jump_height_multiplier *= mount.jump_height_multiplier;
 
                                 let (_, instance_guid, chunk) = character_write_handle.index1();
                                 let all_players_nearby = ZoneInstance::all_players_nearby(chunk, instance_guid, characters_table_read_handle)?;

--- a/src/game_server/handlers/update_position.rs
+++ b/src/game_server/handlers/update_position.rs
@@ -1,0 +1,58 @@
+use crate::game_server::packets::{
+    update_position::{PlayerJump, UpdatePlayerPosition},
+    GamePacket, Pos,
+};
+
+pub trait UpdatePositionPacket: Copy + GamePacket {
+    fn apply_jump_height_multiplier(&mut self, multiplier: f32);
+
+    fn guid(&self) -> u64;
+
+    fn pos(&self) -> Pos;
+
+    fn rot(&self) -> Pos;
+}
+
+impl UpdatePositionPacket for UpdatePlayerPosition {
+    fn apply_jump_height_multiplier(&mut self, _: f32) {}
+
+    fn guid(&self) -> u64 {
+        self.guid
+    }
+
+    fn pos(&self) -> Pos {
+        Pos {
+            x: self.pos_x,
+            y: self.pos_y,
+            z: self.pos_z,
+            w: 1.0,
+        }
+    }
+
+    fn rot(&self) -> Pos {
+        Pos {
+            x: self.rot_x,
+            y: self.rot_y,
+            z: self.rot_z,
+            w: 1.0,
+        }
+    }
+}
+
+impl UpdatePositionPacket for PlayerJump {
+    fn apply_jump_height_multiplier(&mut self, multiplier: f32) {
+        self.vertical_speed *= multiplier;
+    }
+
+    fn guid(&self) -> u64 {
+        self.pos_update.guid()
+    }
+
+    fn pos(&self) -> Pos {
+        self.pos_update.pos()
+    }
+
+    fn rot(&self) -> Pos {
+        self.pos_update.rot()
+    }
+}

--- a/src/game_server/handlers/zone.rs
+++ b/src/game_server/handlers/zone.rs
@@ -20,7 +20,6 @@ use crate::{
             player_update::Customization,
             tunnel::TunneledPacket,
             ui::ExecuteScriptWithParams,
-            update_position::UpdatePlayerPosition,
             GamePacket, Pos,
         },
         Broadcast, GameServer, ProcessPacketError,
@@ -45,6 +44,7 @@ use super::{
         npc_guid, player_guid, shorten_player_guid, zone_template_guid, AMBIENT_NPC_DISCRIMINANT,
         FIXTURE_DISCRIMINANT,
     },
+    update_position::UpdatePositionPacket,
 };
 
 use strum::IntoEnumIterator;
@@ -484,25 +484,14 @@ impl ZoneInstance {
         }
     }
 
-    pub fn move_character<T: Copy + GamePacket>(
-        pos_update: UpdatePlayerPosition,
-        full_update_packet: T,
+    pub fn move_character<T: UpdatePositionPacket>(
+        mut full_update_packet: T,
         should_teleport: bool,
         game_server: &GameServer,
     ) -> Result<Vec<Broadcast>, ProcessPacketError> {
-        let moved_character_guid = pos_update.guid;
-        let new_pos = Pos {
-            x: pos_update.pos_x,
-            y: pos_update.pos_y,
-            z: pos_update.pos_z,
-            w: 1.0,
-        };
-        let new_rot = Pos {
-            x: pos_update.rot_x,
-            y: pos_update.rot_y,
-            z: pos_update.rot_z,
-            w: 0.0,
-        };
+        let moved_character_guid = full_update_packet.guid();
+        let new_pos = full_update_packet.pos();
+        let new_rot = full_update_packet.rot();
         let new_chunk = Character::chunk(new_pos.x, new_pos.z);
 
         let (character_exists, same_chunk, mut broadcasts, npcs_to_interact_if_same_chunk) = game_server
@@ -536,6 +525,11 @@ impl ZoneInstance {
                         if let Some(instance_guid) = instance_guid_if_exists {
                             if same_chunk {
                                 let mut broadcasts = Vec::new();
+                                let jump_multiplier = characters_write.get(&moved_character_guid)
+                                    .map(|character_handle| character_handle.stats.jump_height_multiplier)
+                                    .unwrap_or(1.0);
+                                full_update_packet.apply_jump_height_multiplier(jump_multiplier);
+
                                 let filtered_npcs_to_interact = ZoneInstance::move_character_with_locks(
                                     auto_interact_npcs,
                                     characters_read,
@@ -555,7 +549,7 @@ impl ZoneInstance {
                                 )?;
                                 broadcasts.push(Broadcast::Multi(other_players_nearby, vec![GamePacket::serialize(&TunneledPacket {
                                     unknown1: true,
-                                    inner: full_update_packet
+                                    inner: full_update_packet,
                                 })?]));
                                 Ok::<(bool, bool, Vec<Broadcast>, Vec<u64>), ProcessPacketError>((true, same_chunk, broadcasts, filtered_npcs_to_interact,))
                             } else {
@@ -657,6 +651,10 @@ impl ZoneInstance {
                             .get(moved_character_guid)
                             .expect("Character was removed from table after moving")
                             .write();
+                        let jump_multiplier =
+                            moved_character_write_handle.stats.jump_height_multiplier;
+                        full_update_packet.apply_jump_height_multiplier(jump_multiplier);
+
                         let other_players_nearby = ZoneInstance::other_players_nearby(
                             shorten_player_guid(moved_character_guid).ok(),
                             new_chunk,

--- a/src/game_server/handlers/zone.rs
+++ b/src/game_server/handlers/zone.rs
@@ -526,7 +526,7 @@ impl ZoneInstance {
                             if same_chunk {
                                 let mut broadcasts = Vec::new();
                                 let jump_multiplier = characters_write.get(&moved_character_guid)
-                                    .map(|character_handle| character_handle.stats.jump_height_multiplier)
+                                    .map(|character_handle| character_handle.stats.jump_height_multiplier.total())
                                     .unwrap_or(1.0);
                                 full_update_packet.apply_jump_height_multiplier(jump_multiplier);
 
@@ -651,8 +651,10 @@ impl ZoneInstance {
                             .get(moved_character_guid)
                             .expect("Character was removed from table after moving")
                             .write();
-                        let jump_multiplier =
-                            moved_character_write_handle.stats.jump_height_multiplier;
+                        let jump_multiplier = moved_character_write_handle
+                            .stats
+                            .jump_height_multiplier
+                            .total();
                         full_update_packet.apply_jump_height_multiplier(jump_multiplier);
 
                         let other_players_nearby = ZoneInstance::other_players_nearby(

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -421,8 +421,8 @@ impl GameServer {
                                                 let mut character_broadcasts = Vec::new();
 
                                                 if let Some(character_write_handle) = characters_write.get_mut(&player_guid(sender)) {
-                                                    character_write_handle.stats.speed = zone.speed;
-                                                    character_write_handle.stats.jump_height_multiplier = zone.jump_height_multiplier;
+                                                    character_write_handle.stats.speed.base = zone.speed;
+                                                    character_write_handle.stats.jump_height_multiplier.base = zone.jump_height_multiplier;
 
                                                     let mut global_packets = character_write_handle.add_packets(self.mounts(), self.items(), self.customizations())?;
                                                     let wield_type = TunneledPacket {

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -422,6 +422,7 @@ impl GameServer {
 
                                                 if let Some(character_write_handle) = characters_write.get_mut(&player_guid(sender)) {
                                                     character_write_handle.stats.speed = zone.speed;
+                                                    character_write_handle.stats.jump_height_multiplier = zone.jump_height_multiplier;
 
                                                     let mut global_packets = character_write_handle.add_packets(self.mounts(), self.items(), self.customizations())?;
                                                     let wield_type = TunneledPacket {
@@ -546,20 +547,13 @@ impl GameServer {
                         DeserializePacket::deserialize(&mut cursor)?;
                     // Don't allow players to update another player's position
                     pos_update.guid = player_guid(sender);
-                    broadcasts.append(&mut ZoneInstance::move_character(
-                        pos_update, pos_update, false, self,
-                    )?);
+                    broadcasts.append(&mut ZoneInstance::move_character(pos_update, false, self)?);
                 }
                 OpCode::PlayerJump => {
                     let mut player_jump: PlayerJump = DeserializePacket::deserialize(&mut cursor)?;
                     // Don't allow players to update another player's position
                     player_jump.pos_update.guid = player_guid(sender);
-                    broadcasts.append(&mut ZoneInstance::move_character(
-                        player_jump.pos_update,
-                        player_jump,
-                        false,
-                        self,
-                    )?);
+                    broadcasts.append(&mut ZoneInstance::move_character(player_jump, false, self)?);
                 }
                 OpCode::UpdatePlayerCamera => {
                     // Ignore this unused packet to reduce log spam for now


### PR DESCRIPTION
* Fix the jump height when viewing another player's mount (brezak)
* Splits speed and jump height stats into two components. This allows us to independently modify base speed/jump height without changing the mount speed/jump height. For example, if we allowed a player to remain mounted between zones, we would currently overwrite their mounted speed with a foot speed when they change zones. This new approach ensures we calculate the proper speed.