### PR TITLE
Clean up zones without players

### DIFF
--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -841,6 +841,7 @@ impl Door {
                                 teleport_to_zone!(
                                     characters_table_write_handle,
                                     requester,
+                                    zones_table_write_handle,
                                     &destination_lock.read(),
                                     Some(destination_pos),
                                     Some(destination_rot),

--- a/src/game_server/handlers/guid.rs
+++ b/src/game_server/handlers/guid.rs
@@ -90,6 +90,18 @@ pub trait GuidTableIndexer<'a, K, V: 'a, I1, I2 = (), I3 = ()> {
     fn keys_by_index2_range(&'a self, range: impl RangeBounds<I2>) -> impl Iterator<Item = K>;
 
     fn keys_by_index3_range(&'a self, range: impl RangeBounds<I3>) -> impl Iterator<Item = K>;
+
+    fn any_by_index1_range(&'a self, range: impl RangeBounds<I1>) -> bool {
+        self.keys_by_index1_range(range).next().is_some()
+    }
+
+    fn any_by_index2_range(&'a self, range: impl RangeBounds<I2>) -> bool {
+        self.keys_by_index2_range(range).next().is_some()
+    }
+
+    fn any_by_index3_range(&'a self, range: impl RangeBounds<I3>) -> bool {
+        self.keys_by_index3_range(range).next().is_some()
+    }
 }
 
 pub trait GuidTableHandle<'a, K, V: 'a, I1, I2, I3>:

--- a/src/game_server/handlers/housing.rs
+++ b/src/game_server/handlers/housing.rs
@@ -449,6 +449,7 @@ pub fn process_housing_packet(
                                 teleport_to_zone!(
                                     characters_table_write_handle,
                                     sender,
+                                    zones_table_write_handle,
                                     &zone_read_handle.read(),
                                     None,
                                     None,

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -717,6 +717,7 @@ fn handle_request_create_active_minigame(
                 let teleport_broadcasts = teleport_to_zone!(
                     characters_table_write_handle,
                     sender,
+                    zones_table_write_handle,
                     &zones_table_write_handle.get(new_instance_guid)
                         .unwrap_or_else(|| panic!("Zone instance {} should have been created or already exist but is missing", new_instance_guid))
                         .read(),
@@ -1464,6 +1465,7 @@ fn end_active_minigame(
     let teleport_broadcasts: Result<Vec<Broadcast>, ProcessPacketError> = teleport_to_zone!(
         characters_table_write_handle,
         sender,
+        zones_table_write_handle,
         &zones_table_write_handle
             .get(instance_guid)
             .unwrap_or_else(|| panic!(

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -593,7 +593,9 @@ impl GameServer {
                                         zones_table_write_handle,
                                         &zones_table_write_handle
                                             .get(instance_guid)
-                                            .expect("any_instance returned invalid zone GUID")
+                                            .expect(
+                                                "get_or_create_instance returned invalid zone GUID"
+                                            )
                                             .read(),
                                         None,
                                         None,

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -51,7 +51,6 @@ use packets::update_position::{PlayerJump, UpdatePlayerPosition};
 use packets::zone::ZoneTeleportRequest;
 use packets::{GamePacket, OpCode};
 use rand::Rng;
-use strum::IntoEnumIterator;
 
 use crate::{info, teleport_to_zone};
 use packet_serialize::{DeserializePacket, DeserializePacketError, SerializePacketError};
@@ -228,65 +227,6 @@ impl GameServer {
         }
 
         Ok(broadcasts)
-    }
-
-    pub fn clean_up_zone_if_no_players(
-        &self,
-        instance_guid: u64,
-        characters_table_write_handle: &mut CharacterTableWriteHandle<'_>,
-        zones_table_write_handle: &mut ZoneTableWriteHandle<'_>,
-    ) {
-        let ready_range = (
-            CharacterCategory::PlayerReady,
-            instance_guid,
-            Character::MIN_CHUNK,
-        )
-            ..(
-                CharacterCategory::PlayerReady,
-                instance_guid,
-                Character::MAX_CHUNK,
-            );
-        let unready_range = (
-            CharacterCategory::PlayerUnready,
-            instance_guid,
-            Character::MIN_CHUNK,
-        )
-            ..(
-                CharacterCategory::PlayerUnready,
-                instance_guid,
-                Character::MAX_CHUNK,
-            );
-
-        let has_ready_players = characters_table_write_handle.any_by_index1_range(ready_range);
-        let has_unready_players = characters_table_write_handle.any_by_index1_range(unready_range);
-
-        if !has_ready_players && !has_unready_players {
-            self.clean_up_zone(
-                instance_guid,
-                characters_table_write_handle,
-                zones_table_write_handle,
-            );
-        }
-    }
-
-    fn clean_up_zone(
-        &self,
-        instance_guid: u64,
-        characters_table_write_handle: &mut CharacterTableWriteHandle<'_>,
-        zones_table_write_handle: &mut ZoneTableWriteHandle<'_>,
-    ) {
-        for category in CharacterCategory::iter() {
-            let range = (category, instance_guid, Character::MIN_CHUNK)
-                ..(category, instance_guid, Character::MAX_CHUNK);
-            let characters_to_remove: Vec<u64> = characters_table_write_handle
-                .keys_by_index1_range(range)
-                .collect();
-            for character_guid in characters_to_remove {
-                characters_table_write_handle.remove(character_guid);
-            }
-        }
-
-        zones_table_write_handle.remove(instance_guid);
     }
 
     pub fn process_packet(
@@ -650,6 +590,7 @@ impl GameServer {
                                     Ok(instance_guid) => teleport_to_zone!(
                                         characters_table_write_handle,
                                         sender,
+                                        zones_table_write_handle,
                                         &zones_table_write_handle
                                             .get(instance_guid)
                                             .expect("any_instance returned invalid zone GUID")


### PR DESCRIPTION
* Cleans up zones and their NPCs when a player logs out or teleports to a different zone if there aren't any other players remaining in the zone.
* Fixes a race condition when using a door to teleport to another zone because of dropping and re-acquiring the lock.
  * Technically, this bug was not apparent in the current version of the server. But if we had started locking the zones table without locking the characters table, it could have surfaced.