### PR TITLE
Fix movement synchronization when on a platform

### DIFF
--- a/src/game_server/handlers/update_position.rs
+++ b/src/game_server/handlers/update_position.rs
@@ -1,5 +1,5 @@
 use crate::game_server::packets::{
-    update_position::{PlayerJump, UpdatePlayerPosition},
+    update_position::{PlayerJump, UpdatePlayerPlatformPosition, UpdatePlayerPosition},
     GamePacket, Pos,
 };
 
@@ -42,6 +42,24 @@ impl UpdatePositionPacket for UpdatePlayerPosition {
 impl UpdatePositionPacket for PlayerJump {
     fn apply_jump_height_multiplier(&mut self, multiplier: f32) {
         self.vertical_speed *= multiplier;
+    }
+
+    fn guid(&self) -> u64 {
+        self.pos_update.guid()
+    }
+
+    fn pos(&self) -> Pos {
+        self.pos_update.pos()
+    }
+
+    fn rot(&self) -> Pos {
+        self.pos_update.rot()
+    }
+}
+
+impl UpdatePositionPacket for UpdatePlayerPlatformPosition {
+    fn apply_jump_height_multiplier(&mut self, multiplier: f32) {
+        self.pos_update.apply_jump_height_multiplier(multiplier);
     }
 
     fn guid(&self) -> u64 {

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -47,7 +47,7 @@ use packets::player_update::{Customization, InitCustomizations, QueueAnimation, 
 use packets::reference_data::{CategoryDefinitions, ItemClassDefinitions, ItemGroupDefinitions};
 use packets::store::StoreItemList;
 use packets::tunnel::{TunneledPacket, TunneledWorldPacket};
-use packets::update_position::{PlayerJump, UpdatePlayerPosition};
+use packets::update_position::{PlayerJump, UpdatePlayerPlatformPosition, UpdatePlayerPosition};
 use packets::zone::ZoneTeleportRequest;
 use packets::{GamePacket, OpCode};
 use rand::Rng;
@@ -557,6 +557,17 @@ impl GameServer {
                     // Don't allow players to update another player's position
                     player_jump.pos_update.guid = player_guid(sender);
                     broadcasts.append(&mut ZoneInstance::move_character(player_jump, false, self)?);
+                }
+                OpCode::UpdatePlayerPlatformPosition => {
+                    let mut platform_pos_update: UpdatePlayerPlatformPosition =
+                        DeserializePacket::deserialize(&mut cursor)?;
+                    // Don't allow players to update another player's position
+                    platform_pos_update.pos_update.guid = player_guid(sender);
+                    broadcasts.append(&mut ZoneInstance::move_character(
+                        platform_pos_update,
+                        false,
+                        self,
+                    )?);
                 }
                 OpCode::UpdatePlayerCamera => {
                     // Ignore this unused packet to reduce log spam for now

--- a/src/game_server/packets/mod.rs
+++ b/src/game_server/packets/mod.rs
@@ -61,6 +61,7 @@ pub enum OpCode {
     UpdatePlayerCamera = 0x7e,
     Housing = 0x7f,
     Squad = 0x81,
+    UpdatePlayerPlatformPosition = 0xb8,
     ClientGameSettings = 0x8f,
     Portrait = 0x9b,
     PlayerJump = 0xa3,

--- a/src/game_server/packets/update_position.rs
+++ b/src/game_server/packets/update_position.rs
@@ -1,6 +1,6 @@
 use packet_serialize::{DeserializePacket, SerializePacket};
 
-use super::{GamePacket, OpCode};
+use super::{GamePacket, OpCode, Pos};
 
 #[derive(Copy, Clone, SerializePacket, DeserializePacket)]
 pub struct UpdatePlayerPosition {
@@ -29,4 +29,16 @@ pub struct PlayerJump {
 impl GamePacket for PlayerJump {
     type Header = OpCode;
     const HEADER: Self::Header = OpCode::PlayerJump;
+}
+
+#[derive(Copy, Clone, SerializePacket, DeserializePacket)]
+pub struct UpdatePlayerPlatformPosition {
+    pub pos_update: UpdatePlayerPosition,
+    pub platform_guid: u64,
+    pub player_pos_relative_to_platform: Pos,
+}
+
+impl GamePacket for UpdatePlayerPlatformPosition {
+    type Header = OpCode;
+    const HEADER: Self::Header = OpCode::UpdatePlayerPlatformPosition;
 }


### PR DESCRIPTION
Add support for the `UpdatePlayerPlatformPosition` packet so that movement is properly synchronized between players on a platform.