### PR TITLE
Check player can play minigame before starting

### DIFF
--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -300,7 +300,7 @@ impl MinigameStageGroupConfig {
                 }
                 MinigameStageGroupChild::Stage(stage) => {
                     let unlocked = stage.unlocked(player, previous_completed);
-                    previous_completed = player.minigame_stats.has_completed(stage.guid);
+                    previous_completed = stage.has_completed(player);
 
                     stage_instances.push(MinigameStageInstance {
                         stage_instance_guid: stage.guid,

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -545,7 +545,7 @@ impl AllMinigameConfigs {
             })
     }
 
-    pub fn stage_unlocked(&self, stage_group_guid: i32, stage_guid: i32, player: &Player) -> bool {
+    pub fn can_play_stage(&self, stage_group_guid: i32, stage_guid: i32, player: &Player) -> bool {
         if let Some((root_stage_group, _)) = self.stage_groups.get(&stage_group_guid) {
             let mut previous_completed = true;
 
@@ -559,7 +559,7 @@ impl AllMinigameConfigs {
                         previous_completed = stage.has_completed(player);
 
                         if stage_guid == stage.guid {
-                            return unlocked;
+                            return unlocked && (!stage.members_only || player.member);
                         }
                     }
                 }
@@ -730,7 +730,7 @@ fn handle_request_create_active_minigame(
                 // TODO: Handle multiplayer minigames and wait for a full group
                 if let Some(character_lock) = characters_table_write_handle.get(player_guid(sender)) {
                     if let CharacterType::Player(player) = &mut character_lock.write().stats.character_type {
-                        if game_server.minigames().stage_unlocked(request.header.stage_group_guid, request.header.stage_guid, player) {
+                        if game_server.minigames().can_play_stage(request.header.stage_group_guid, request.header.stage_guid, player) {
                             player.minigame_status = Some(MinigameStatus {
                                 stage_group_guid: request.header.stage_group_guid,
                                 stage_guid: request.header.stage_guid,


### PR DESCRIPTION
While the UI properly locks minigames when prerequisite stages haven't been completed or the player isn't a member, we currently don't check this server-side. This PR ensures that the player is actually allowed to play before the server starts a game.