### PR TITLE
Add support for fourth index in GUID table

### DIFF
--- a/src/game_server/handlers/lock_enforcer.rs
+++ b/src/game_server/handlers/lock_enforcer.rs
@@ -13,12 +13,13 @@ use super::{
     zone::ZoneInstance,
 };
 
-pub struct TableReadHandleWrapper<'a, K, V, I1 = (), I2 = (), I3 = ()> {
-    handle: GuidTableReadHandle<'a, K, V, I1, I2, I3>,
+pub struct TableReadHandleWrapper<'a, K, V, I1 = (), I2 = (), I3 = (), I4 = ()> {
+    handle: GuidTableReadHandle<'a, K, V, I1, I2, I3, I4>,
 }
 
-impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Clone + Ord, I3: Clone + Ord>
-    GuidTableIndexer<'a, K, V, I1, I2, I3> for TableReadHandleWrapper<'a, K, V, I1, I2, I3>
+impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Clone + Ord, I3: Clone + Ord, I4: Clone + Ord>
+    GuidTableIndexer<'a, K, V, I1, I2, I3, I4>
+    for TableReadHandleWrapper<'a, K, V, I1, I2, I3, I4>
 {
     fn index1(&self, guid: K) -> Option<I1> {
         self.handle.index1(guid)
@@ -30,6 +31,10 @@ impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Clone + Ord, I3: Clone + Ord>
 
     fn index3(&self, guid: K) -> Option<&I3> {
         self.handle.index3(guid)
+    }
+
+    fn index4(&self, guid: K) -> Option<&I4> {
+        self.handle.index4(guid)
     }
 
     fn keys(&'a self) -> impl Iterator<Item = K> {
@@ -48,6 +53,10 @@ impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Clone + Ord, I3: Clone + Ord>
         self.handle.keys_by_index3(index)
     }
 
+    fn keys_by_index4(&'a self, index: &I4) -> impl Iterator<Item = K> {
+        self.handle.keys_by_index4(index)
+    }
+
     fn keys_by_index1_range(&'a self, range: impl RangeBounds<I1>) -> impl Iterator<Item = K> {
         self.handle.keys_by_index1_range(range)
     }
@@ -58,6 +67,10 @@ impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Clone + Ord, I3: Clone + Ord>
 
     fn keys_by_index3_range(&'a self, range: impl RangeBounds<I3>) -> impl Iterator<Item = K> {
         self.handle.keys_by_index3_range(range)
+    }
+
+    fn keys_by_index4_range(&'a self, range: impl RangeBounds<I4>) -> impl Iterator<Item = K> {
+        self.handle.keys_by_index4_range(range)
     }
 }
 

--- a/src/game_server/handlers/login.rs
+++ b/src/game_server/handlers/login.rs
@@ -136,7 +136,7 @@ pub fn log_out(
 ) -> Result<Vec<Broadcast>, ProcessPacketError> {
     game_server.lock_enforcer().write_characters(
         |characters_table_write_handle, zones_lock_enforcer| {
-            if let Some((character, (_, instance_guid, chunk), _, _)) =
+            if let Some((character, (_, instance_guid, chunk), ..)) =
                 characters_table_write_handle.remove(player_guid(sender))
             {
                 let other_players_nearby = ZoneInstance::other_players_nearby(

--- a/src/game_server/handlers/zone.rs
+++ b/src/game_server/handlers/zone.rs
@@ -620,8 +620,13 @@ impl ZoneInstance {
             game_server
                 .lock_enforcer()
                 .write_characters(|characters_table_write_handle, _| {
-                    if let Some((character, (category, instance_guid, old_chunk), index2, index3)) =
-                        characters_table_write_handle.remove(moved_character_guid)
+                    if let Some((
+                        character,
+                        (category, instance_guid, old_chunk),
+                        index2,
+                        index3,
+                        index4,
+                    )) = characters_table_write_handle.remove(moved_character_guid)
                     {
                         // Build characters read and write maps
                         let mut characters_write: BTreeMap<
@@ -692,6 +697,7 @@ impl ZoneInstance {
                             (category, instance_guid, new_chunk),
                             index2,
                             index3,
+                            index4,
                             character,
                         );
 
@@ -948,7 +954,7 @@ pub fn enter_zone(
     )?;
 
     let character = characters_table_write_handle.remove(player_guid(player));
-    if let Some((character, (character_category, _, _), index2, index3)) = character {
+    if let Some((character, (character_category, _, _), index2, index3, index4)) = character {
         let mut character_write_handle = character.write();
         let (_, instance_guid, chunk) = character_write_handle.index1();
         let other_players_nearby = ZoneInstance::other_players_nearby(
@@ -999,6 +1005,7 @@ pub fn enter_zone(
             ),
             index2,
             index3,
+            index4,
             character,
         );
     }

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -257,7 +257,7 @@ impl GameServer {
                     self.lock_enforcer()
                         .write_characters(|characters_table_write_handle, _| {
                             match characters_table_write_handle.remove(player_guid(sender)) {
-                                Some((character, _, _, _)) => {
+                                Some((character, ..)) => {
                                     let mut character_write_handle = character.write();
                                     if let CharacterType::Player(ref mut player) =
                                         &mut character_write_handle.stats.character_type
@@ -305,9 +305,11 @@ impl GameServer {
                                     let new_index1 = character_write_handle.index1();
                                     let new_index2 = character_write_handle.index2();
                                     let new_index3 = character_write_handle.index3();
+                                    let new_index4 = character_write_handle.index4();
                                     drop(character_write_handle);
                                     characters_table_write_handle.insert_lock(
-                                        guid, new_index1, new_index2, new_index3, character,
+                                        guid, new_index1, new_index2, new_index3, new_index4,
+                                        character,
                                     );
                                     Ok(())
                                 }
@@ -839,7 +841,7 @@ impl GameServer {
         required_capacity: u32,
     ) -> Vec<u64> {
         let unfilled_zones = zones
-            .values_by_index(template_guid)
+            .values_by_index1(template_guid)
             .filter_map(|zone_lock| {
                 let zone_read_handle = zone_lock.read();
                 let instance_guid = zone_read_handle.guid();


### PR DESCRIPTION
Support a 4th index in the GUID table. This will allow us to index characters by minigame group ID for matchmaking, though that will be added in a subsequent PR.