### PR TITLE
Fix missing inclusivity for ranges with max chunk

### DIFF
--- a/src/game_server/handlers/zone.rs
+++ b/src/game_server/handlers/zone.rs
@@ -1072,7 +1072,7 @@ pub fn clean_up_zone_if_no_players(
         instance_guid,
         Character::MIN_CHUNK,
     )
-        ..(
+        ..=(
             CharacterCategory::PlayerReady,
             instance_guid,
             Character::MAX_CHUNK,
@@ -1082,7 +1082,7 @@ pub fn clean_up_zone_if_no_players(
         instance_guid,
         Character::MIN_CHUNK,
     )
-        ..(
+        ..=(
             CharacterCategory::PlayerUnready,
             instance_guid,
             Character::MAX_CHUNK,
@@ -1107,7 +1107,7 @@ fn clean_up_zone(
 ) {
     for category in CharacterCategory::iter() {
         let range = (category, instance_guid, Character::MIN_CHUNK)
-            ..(category, instance_guid, Character::MAX_CHUNK);
+            ..=(category, instance_guid, Character::MAX_CHUNK);
         let characters_to_remove: Vec<u64> = characters_table_write_handle
             .keys_by_index1_range(range)
             .collect();


### PR DESCRIPTION
A few ranges for GUID table queries are exclusive rather than inclusive of the max chunk. We don't see this in-game because there are no characters placed in the max chunk. This is technically a logical bug, so we should fix it anyway.