### PR TITLE
Implement multiplayer matchmaking

### DIFF
--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -1012,7 +1012,7 @@ pub struct Player {
     pub inventory: BTreeSet<u32>,
     pub customizations: BTreeMap<CustomizationSlot, u32>,
     pub minigame_stats: PlayerMinigameStats,
-    pub matchmaking_group_guid: Option<u32>,
+    pub matchmaking_group: Option<CharacterMatchmakingGroupIndex>,
     pub owned_matchmaking_group: Option<OwnedMatchmakingGroup>,
     pub minigame_status: Option<MinigameStatus>,
     pub update_previous_location_on_leave: bool,
@@ -1300,7 +1300,7 @@ pub type Chunk = (i32, i32);
 pub type CharacterLocationIndex = (CharacterCategory, u64, Chunk);
 pub type CharacterNameIndex = String;
 pub type CharacterSquadIndex = u64;
-pub type CharacterMatchmakingGroupIndex = u32;
+pub type CharacterMatchmakingGroupIndex = (i32, i32, Instant, u32);
 
 #[derive(Clone)]
 pub struct CharacterStat {
@@ -1391,7 +1391,7 @@ impl
 
     fn index4(&self) -> Option<CharacterMatchmakingGroupIndex> {
         match &self.stats.character_type {
-            CharacterType::Player(player) => player.matchmaking_group_guid,
+            CharacterType::Player(player) => player.matchmaking_group,
             _ => None,
         }
     }

--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -986,13 +986,6 @@ pub struct MinigameStatus {
 }
 
 #[derive(Clone)]
-pub struct OwnedMatchmakingGroup {
-    pub stage_group_guid: i32,
-    pub stage_guid: i32,
-    pub since: Instant,
-}
-
-#[derive(Clone)]
 pub struct PreviousLocation {
     pub template_guid: u8,
     pub pos: Pos,
@@ -1013,7 +1006,6 @@ pub struct Player {
     pub customizations: BTreeMap<CustomizationSlot, u32>,
     pub minigame_stats: PlayerMinigameStats,
     pub matchmaking_group: Option<CharacterMatchmakingGroupIndex>,
-    pub owned_matchmaking_group: Option<OwnedMatchmakingGroup>,
     pub minigame_status: Option<MinigameStatus>,
     pub update_previous_location_on_leave: bool,
     pub previous_location: PreviousLocation,

--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -1296,11 +1296,17 @@ impl NpcTemplate {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum MatchmakingGroupStatus {
+    OpenToAll,
+    OpenToFriends,
+}
+
 pub type Chunk = (i32, i32);
 pub type CharacterLocationIndex = (CharacterCategory, u64, Chunk);
 pub type CharacterNameIndex = String;
 pub type CharacterSquadIndex = u64;
-pub type CharacterMatchmakingGroupIndex = (i32, i32, Instant, u32);
+pub type CharacterMatchmakingGroupIndex = (MatchmakingGroupStatus, i32, i32, Instant, u32);
 
 #[derive(Clone)]
 pub struct CharacterStat {

--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -986,6 +986,13 @@ pub struct MinigameStatus {
 }
 
 #[derive(Clone)]
+pub struct OwnedMatchmakingGroup {
+    pub stage_group_guid: i32,
+    pub stage_guid: i32,
+    pub since: Instant,
+}
+
+#[derive(Clone)]
 pub struct PreviousLocation {
     pub template_guid: u8,
     pub pos: Pos,
@@ -1005,6 +1012,8 @@ pub struct Player {
     pub inventory: BTreeSet<u32>,
     pub customizations: BTreeMap<CustomizationSlot, u32>,
     pub minigame_stats: PlayerMinigameStats,
+    pub matchmaking_group_guid: Option<u32>,
+    pub owned_matchmaking_group: Option<OwnedMatchmakingGroup>,
     pub minigame_status: Option<MinigameStatus>,
     pub update_previous_location_on_leave: bool,
     pub previous_location: PreviousLocation,
@@ -1291,6 +1300,7 @@ pub type Chunk = (i32, i32);
 pub type CharacterLocationIndex = (CharacterCategory, u64, Chunk);
 pub type CharacterNameIndex = String;
 pub type CharacterSquadIndex = u64;
+pub type CharacterMatchmakingGroupIndex = u32;
 
 #[derive(Clone)]
 pub struct CharacterStat {
@@ -1338,8 +1348,14 @@ pub struct Character {
     pub synchronize_with: Option<u64>,
 }
 
-impl IndexedGuid<u64, CharacterLocationIndex, CharacterNameIndex, CharacterSquadIndex>
-    for Character
+impl
+    IndexedGuid<
+        u64,
+        CharacterLocationIndex,
+        CharacterNameIndex,
+        CharacterSquadIndex,
+        CharacterMatchmakingGroupIndex,
+    > for Character
 {
     fn guid(&self) -> u64 {
         self.stats.guid
@@ -1365,12 +1381,19 @@ impl IndexedGuid<u64, CharacterLocationIndex, CharacterNameIndex, CharacterSquad
         )
     }
 
-    fn index2(&self) -> Option<String> {
+    fn index2(&self) -> Option<CharacterNameIndex> {
         self.stats.name.clone()
     }
 
-    fn index3(&self) -> Option<u64> {
+    fn index3(&self) -> Option<CharacterSquadIndex> {
         self.stats.squad_guid
+    }
+
+    fn index4(&self) -> Option<CharacterMatchmakingGroupIndex> {
+        match &self.stats.character_type {
+            CharacterType::Player(player) => player.matchmaking_group_guid,
+            _ => None,
+        }
     }
 }
 

--- a/src/game_server/handlers/guid.rs
+++ b/src/game_server/handlers/guid.rs
@@ -4,8 +4,6 @@ use std::{
     ops::RangeBounds,
 };
 
-use crate::game_server::ProcessPacketError;
-
 pub struct Lock<T> {
     inner: RwLock<T>,
 }
@@ -484,8 +482,8 @@ impl<
     pub fn update_value_indices<T>(
         &mut self,
         guid: K,
-        mut f: impl FnMut(Option<&mut RwLockWriteGuard<V>>) -> Result<T, ProcessPacketError>,
-    ) -> Result<T, ProcessPacketError> {
+        mut f: impl FnMut(Option<&mut RwLockWriteGuard<V>>) -> T,
+    ) -> T {
         let entry = self.remove(guid);
         if let Some((lock, ..)) = entry {
             let mut value_write_handle = lock.write();

--- a/src/game_server/handlers/guid.rs
+++ b/src/game_server/handlers/guid.rs
@@ -121,11 +121,11 @@ pub trait GuidTableIndexer<'a, K, V: 'a, I1, I2: 'a = (), I3: 'a = (), I4: 'a = 
 
     fn indices1(&'a self) -> impl Iterator<Item = I1>;
 
-    fn indices2(&'a self) -> impl Iterator<Item = &I2>;
+    fn indices2(&'a self) -> impl Iterator<Item = &'a I2>;
 
-    fn indices3(&'a self) -> impl Iterator<Item = &I3>;
+    fn indices3(&'a self) -> impl Iterator<Item = &'a I3>;
 
-    fn indices4(&'a self) -> impl Iterator<Item = &I4>;
+    fn indices4(&'a self) -> impl Iterator<Item = &'a I4>;
 }
 
 pub trait GuidTableHandle<'a, K, V: 'a, I1, I2: 'a, I3: 'a, I4: 'a>:
@@ -241,15 +241,15 @@ impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Clone + Ord, I3: Clone + Ord, I4:
         self.guard.index1.keys().copied()
     }
 
-    fn indices2(&'a self) -> impl Iterator<Item = &I2> {
+    fn indices2(&'a self) -> impl Iterator<Item = &'a I2> {
         self.guard.index2.keys()
     }
 
-    fn indices3(&'a self) -> impl Iterator<Item = &I3> {
+    fn indices3(&'a self) -> impl Iterator<Item = &'a I3> {
         self.guard.index3.keys()
     }
 
-    fn indices4(&'a self) -> impl Iterator<Item = &I4> {
+    fn indices4(&'a self) -> impl Iterator<Item = &'a I4> {
         self.guard.index4.keys()
     }
 }
@@ -487,15 +487,15 @@ impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Clone + Ord, I3: Clone + Ord, I4:
         self.guard.index1.keys().copied()
     }
 
-    fn indices2(&'a self) -> impl Iterator<Item = &I2> {
+    fn indices2(&'a self) -> impl Iterator<Item = &'a I2> {
         self.guard.index2.keys()
     }
 
-    fn indices3(&'a self) -> impl Iterator<Item = &I3> {
+    fn indices3(&'a self) -> impl Iterator<Item = &'a I3> {
         self.guard.index3.keys()
     }
 
-    fn indices4(&'a self) -> impl Iterator<Item = &I4> {
+    fn indices4(&'a self) -> impl Iterator<Item = &'a I4> {
         self.guard.index4.keys()
     }
 }

--- a/src/game_server/handlers/guid.rs
+++ b/src/game_server/handlers/guid.rs
@@ -76,7 +76,7 @@ impl<K, V, I1, I2, I3, I4> GuidTableData<K, V, I1, I2, I3, I4> {
     }
 }
 
-pub trait GuidTableIndexer<'a, K, V: 'a, I1, I2 = (), I3 = (), I4 = ()> {
+pub trait GuidTableIndexer<'a, K, V: 'a, I1, I2: 'a = (), I3: 'a = (), I4: 'a = ()> {
     fn index1(&self, guid: K) -> Option<I1>;
 
     fn index2(&self, guid: K) -> Option<&I2>;
@@ -118,9 +118,17 @@ pub trait GuidTableIndexer<'a, K, V: 'a, I1, I2 = (), I3 = (), I4 = ()> {
     fn any_by_index4_range(&'a self, range: impl RangeBounds<I4>) -> bool {
         self.keys_by_index4_range(range).next().is_some()
     }
+
+    fn indices1(&'a self) -> impl Iterator<Item = I1>;
+
+    fn indices2(&'a self) -> impl Iterator<Item = &I2>;
+
+    fn indices3(&'a self) -> impl Iterator<Item = &I3>;
+
+    fn indices4(&'a self) -> impl Iterator<Item = &I4>;
 }
 
-pub trait GuidTableHandle<'a, K, V: 'a, I1, I2, I3, I4>:
+pub trait GuidTableHandle<'a, K, V: 'a, I1, I2: 'a, I3: 'a, I4: 'a>:
     GuidTableIndexer<'a, K, V, I1, I2, I3, I4>
 {
     fn get(&self, guid: K) -> Option<&Lock<V>>;
@@ -227,6 +235,22 @@ impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Clone + Ord, I3: Clone + Ord, I4:
             .index4
             .range(range)
             .flat_map(|(_, keys)| keys.iter().copied())
+    }
+
+    fn indices1(&'a self) -> impl Iterator<Item = I1> {
+        self.guard.index1.keys().copied()
+    }
+
+    fn indices2(&'a self) -> impl Iterator<Item = &I2> {
+        self.guard.index2.keys()
+    }
+
+    fn indices3(&'a self) -> impl Iterator<Item = &I3> {
+        self.guard.index3.keys()
+    }
+
+    fn indices4(&'a self) -> impl Iterator<Item = &I4> {
+        self.guard.index4.keys()
     }
 }
 
@@ -457,6 +481,22 @@ impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Clone + Ord, I3: Clone + Ord, I4:
             .index4
             .range(range)
             .flat_map(|(_, keys)| keys.iter().copied())
+    }
+
+    fn indices1(&'a self) -> impl Iterator<Item = I1> {
+        self.guard.index1.keys().copied()
+    }
+
+    fn indices2(&'a self) -> impl Iterator<Item = &I2> {
+        self.guard.index2.keys()
+    }
+
+    fn indices3(&'a self) -> impl Iterator<Item = &I3> {
+        self.guard.index3.keys()
+    }
+
+    fn indices4(&'a self) -> impl Iterator<Item = &I4> {
+        self.guard.index4.keys()
     }
 }
 

--- a/src/game_server/handlers/guid.rs
+++ b/src/game_server/handlers/guid.rs
@@ -138,6 +138,26 @@ pub trait GuidTableIndexer<'a, K, V: 'a, I1, I2: 'a = (), I3: 'a = (), I4: 'a = 
     fn indices3(&'a self) -> impl Iterator<Item = &'a I3>;
 
     fn indices4(&'a self) -> impl Iterator<Item = &'a I4>;
+
+    fn indices1_by_range(
+        &'a self,
+        range: impl RangeBounds<I1>,
+    ) -> impl DoubleEndedIterator<Item = I1>;
+
+    fn indices2_by_range(
+        &'a self,
+        range: impl RangeBounds<I2>,
+    ) -> impl DoubleEndedIterator<Item = &'a I2>;
+
+    fn indices3_by_range(
+        &'a self,
+        range: impl RangeBounds<I3>,
+    ) -> impl DoubleEndedIterator<Item = &'a I3>;
+
+    fn indices4_by_range(
+        &'a self,
+        range: impl RangeBounds<I4>,
+    ) -> impl DoubleEndedIterator<Item = &'a I4>;
 }
 
 pub trait GuidTableHandle<'a, K, V: 'a, I1, I2: 'a, I3: 'a, I4: 'a>:
@@ -275,6 +295,34 @@ impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Clone + Ord, I3: Clone + Ord, I4:
 
     fn indices4(&'a self) -> impl Iterator<Item = &'a I4> {
         self.guard.index4.keys()
+    }
+
+    fn indices1_by_range(
+        &'a self,
+        range: impl RangeBounds<I1>,
+    ) -> impl DoubleEndedIterator<Item = I1> {
+        self.guard.index1.range(range).map(|(index, _)| *index)
+    }
+
+    fn indices2_by_range(
+        &'a self,
+        range: impl RangeBounds<I2>,
+    ) -> impl DoubleEndedIterator<Item = &I2> {
+        self.guard.index2.range(range).map(|(index, _)| index)
+    }
+
+    fn indices3_by_range(
+        &'a self,
+        range: impl RangeBounds<I3>,
+    ) -> impl DoubleEndedIterator<Item = &I3> {
+        self.guard.index3.range(range).map(|(index, _)| index)
+    }
+
+    fn indices4_by_range(
+        &'a self,
+        range: impl RangeBounds<I4>,
+    ) -> impl DoubleEndedIterator<Item = &I4> {
+        self.guard.index4.range(range).map(|(index, _)| index)
     }
 }
 
@@ -533,6 +581,34 @@ impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Clone + Ord, I3: Clone + Ord, I4:
 
     fn indices4(&'a self) -> impl Iterator<Item = &'a I4> {
         self.guard.index4.keys()
+    }
+
+    fn indices1_by_range(
+        &'a self,
+        range: impl RangeBounds<I1>,
+    ) -> impl DoubleEndedIterator<Item = I1> {
+        self.guard.index1.range(range).map(|(index, _)| *index)
+    }
+
+    fn indices2_by_range(
+        &'a self,
+        range: impl RangeBounds<I2>,
+    ) -> impl DoubleEndedIterator<Item = &I2> {
+        self.guard.index2.range(range).map(|(index, _)| index)
+    }
+
+    fn indices3_by_range(
+        &'a self,
+        range: impl RangeBounds<I3>,
+    ) -> impl DoubleEndedIterator<Item = &I3> {
+        self.guard.index3.range(range).map(|(index, _)| index)
+    }
+
+    fn indices4_by_range(
+        &'a self,
+        range: impl RangeBounds<I4>,
+    ) -> impl DoubleEndedIterator<Item = &I4> {
+        self.guard.index4.range(range).map(|(index, _)| index)
     }
 }
 

--- a/src/game_server/handlers/guid.rs
+++ b/src/game_server/handlers/guid.rs
@@ -452,27 +452,39 @@ impl<
                 .remove(&guid);
 
             if let Some(index2) = previous_index2 {
-                self.guard
+                let values_for_index = self
+                    .guard
                     .index2
                     .get_mut(index2)
-                    .expect("GUID table key was never added to index2")
-                    .remove(&guid);
+                    .expect("GUID table key was never added to index2");
+                values_for_index.remove(&guid);
+                if values_for_index.is_empty() {
+                    self.guard.index2.remove(index2);
+                }
             }
 
             if let Some(index3) = previous_index3 {
-                self.guard
+                let values_for_index = self
+                    .guard
                     .index3
                     .get_mut(index3)
-                    .expect("GUID table key was never added to index3")
-                    .remove(&guid);
+                    .expect("GUID table key was never added to index3");
+                values_for_index.remove(&guid);
+                if values_for_index.is_empty() {
+                    self.guard.index3.remove(index3);
+                }
             }
 
             if let Some(index4) = previous_index4 {
-                self.guard
+                let values_for_index = self
+                    .guard
                     .index4
                     .get_mut(index4)
-                    .expect("GUID table key was never added to index4")
-                    .remove(&guid);
+                    .expect("GUID table key was never added to index4");
+                values_for_index.remove(&guid);
+                if values_for_index.is_empty() {
+                    self.guard.index4.remove(index4);
+                }
             }
         }
 

--- a/src/game_server/handlers/guid.rs
+++ b/src/game_server/handlers/guid.rs
@@ -95,13 +95,25 @@ pub trait GuidTableIndexer<'a, K, V: 'a, I1, I2: 'a = (), I3: 'a = (), I4: 'a = 
 
     fn keys_by_index4<'b>(&'a self, index: &'b I4) -> impl Iterator<Item = K>;
 
-    fn keys_by_index1_range(&'a self, range: impl RangeBounds<I1>) -> impl Iterator<Item = K>;
+    fn keys_by_index1_range(
+        &'a self,
+        range: impl RangeBounds<I1>,
+    ) -> impl DoubleEndedIterator<Item = K>;
 
-    fn keys_by_index2_range(&'a self, range: impl RangeBounds<I2>) -> impl Iterator<Item = K>;
+    fn keys_by_index2_range(
+        &'a self,
+        range: impl RangeBounds<I2>,
+    ) -> impl DoubleEndedIterator<Item = K>;
 
-    fn keys_by_index3_range(&'a self, range: impl RangeBounds<I3>) -> impl Iterator<Item = K>;
+    fn keys_by_index3_range(
+        &'a self,
+        range: impl RangeBounds<I3>,
+    ) -> impl DoubleEndedIterator<Item = K>;
 
-    fn keys_by_index4_range(&'a self, range: impl RangeBounds<I4>) -> impl Iterator<Item = K>;
+    fn keys_by_index4_range(
+        &'a self,
+        range: impl RangeBounds<I4>,
+    ) -> impl DoubleEndedIterator<Item = K>;
 
     fn any_by_index1_range(&'a self, range: impl RangeBounds<I1>) -> bool {
         self.keys_by_index1_range(range).next().is_some()
@@ -209,28 +221,40 @@ impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Clone + Ord, I3: Clone + Ord, I4:
             .cloned()
     }
 
-    fn keys_by_index1_range(&'a self, range: impl RangeBounds<I1>) -> impl Iterator<Item = K> {
+    fn keys_by_index1_range(
+        &'a self,
+        range: impl RangeBounds<I1>,
+    ) -> impl DoubleEndedIterator<Item = K> {
         self.guard
             .index1
             .range(range)
             .flat_map(|(_, keys)| keys.iter().copied())
     }
 
-    fn keys_by_index2_range(&'a self, range: impl RangeBounds<I2>) -> impl Iterator<Item = K> {
+    fn keys_by_index2_range(
+        &'a self,
+        range: impl RangeBounds<I2>,
+    ) -> impl DoubleEndedIterator<Item = K> {
         self.guard
             .index2
             .range(range)
             .flat_map(|(_, keys)| keys.iter().copied())
     }
 
-    fn keys_by_index3_range(&'a self, range: impl RangeBounds<I3>) -> impl Iterator<Item = K> {
+    fn keys_by_index3_range(
+        &'a self,
+        range: impl RangeBounds<I3>,
+    ) -> impl DoubleEndedIterator<Item = K> {
         self.guard
             .index3
             .range(range)
             .flat_map(|(_, keys)| keys.iter().copied())
     }
 
-    fn keys_by_index4_range(&'a self, range: impl RangeBounds<I4>) -> impl Iterator<Item = K> {
+    fn keys_by_index4_range(
+        &'a self,
+        range: impl RangeBounds<I4>,
+    ) -> impl DoubleEndedIterator<Item = K> {
         self.guard
             .index4
             .range(range)
@@ -455,28 +479,40 @@ impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Clone + Ord, I3: Clone + Ord, I4:
             .cloned()
     }
 
-    fn keys_by_index1_range(&'a self, range: impl RangeBounds<I1>) -> impl Iterator<Item = K> {
+    fn keys_by_index1_range(
+        &'a self,
+        range: impl RangeBounds<I1>,
+    ) -> impl DoubleEndedIterator<Item = K> {
         self.guard
             .index1
             .range(range)
             .flat_map(|(_, keys)| keys.iter().copied())
     }
 
-    fn keys_by_index2_range(&'a self, range: impl RangeBounds<I2>) -> impl Iterator<Item = K> {
+    fn keys_by_index2_range(
+        &'a self,
+        range: impl RangeBounds<I2>,
+    ) -> impl DoubleEndedIterator<Item = K> {
         self.guard
             .index2
             .range(range)
             .flat_map(|(_, keys)| keys.iter().copied())
     }
 
-    fn keys_by_index3_range(&'a self, range: impl RangeBounds<I3>) -> impl Iterator<Item = K> {
+    fn keys_by_index3_range(
+        &'a self,
+        range: impl RangeBounds<I3>,
+    ) -> impl DoubleEndedIterator<Item = K> {
         self.guard
             .index3
             .range(range)
             .flat_map(|(_, keys)| keys.iter().copied())
     }
 
-    fn keys_by_index4_range(&'a self, range: impl RangeBounds<I4>) -> impl Iterator<Item = K> {
+    fn keys_by_index4_range(
+        &'a self,
+        range: impl RangeBounds<I4>,
+    ) -> impl DoubleEndedIterator<Item = K> {
         self.guard
             .index4
             .range(range)

--- a/src/game_server/handlers/guid.rs
+++ b/src/game_server/handlers/guid.rs
@@ -282,47 +282,109 @@ impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Clone + Ord, I3: Clone + Ord, I4:
     }
 
     fn indices1(&'a self) -> impl Iterator<Item = I1> {
-        self.guard.index1.keys().copied()
+        self.guard.index1.iter().filter_map(
+            |(index, guids)| {
+                if guids.is_empty() {
+                    None
+                } else {
+                    Some(*index)
+                }
+            },
+        )
     }
 
     fn indices2(&'a self) -> impl Iterator<Item = &'a I2> {
-        self.guard.index2.keys()
+        self.guard.index2.iter().filter_map(
+            |(index, guids)| {
+                if guids.is_empty() {
+                    None
+                } else {
+                    Some(index)
+                }
+            },
+        )
     }
 
     fn indices3(&'a self) -> impl Iterator<Item = &'a I3> {
-        self.guard.index3.keys()
+        self.guard.index3.iter().filter_map(
+            |(index, guids)| {
+                if guids.is_empty() {
+                    None
+                } else {
+                    Some(index)
+                }
+            },
+        )
     }
 
     fn indices4(&'a self) -> impl Iterator<Item = &'a I4> {
-        self.guard.index4.keys()
+        self.guard.index4.iter().filter_map(
+            |(index, guids)| {
+                if guids.is_empty() {
+                    None
+                } else {
+                    Some(index)
+                }
+            },
+        )
     }
 
     fn indices1_by_range(
         &'a self,
         range: impl RangeBounds<I1>,
     ) -> impl DoubleEndedIterator<Item = I1> {
-        self.guard.index1.range(range).map(|(index, _)| *index)
+        self.guard.index1.range(range).filter_map(|(index, guids)| {
+            if guids.is_empty() {
+                None
+            } else {
+                Some(*index)
+            }
+        })
     }
 
     fn indices2_by_range(
         &'a self,
         range: impl RangeBounds<I2>,
     ) -> impl DoubleEndedIterator<Item = &'a I2> {
-        self.guard.index2.range(range).map(|(index, _)| index)
+        self.guard.index2.range(range).filter_map(
+            |(index, guids)| {
+                if guids.is_empty() {
+                    None
+                } else {
+                    Some(index)
+                }
+            },
+        )
     }
 
     fn indices3_by_range(
         &'a self,
         range: impl RangeBounds<I3>,
     ) -> impl DoubleEndedIterator<Item = &'a I3> {
-        self.guard.index3.range(range).map(|(index, _)| index)
+        self.guard.index3.range(range).filter_map(
+            |(index, guids)| {
+                if guids.is_empty() {
+                    None
+                } else {
+                    Some(index)
+                }
+            },
+        )
     }
 
     fn indices4_by_range(
         &'a self,
         range: impl RangeBounds<I4>,
     ) -> impl DoubleEndedIterator<Item = &'a I4> {
-        self.guard.index4.range(range).map(|(index, _)| index)
+        self.guard.index4.range(range).filter_map(
+            |(index, guids)| {
+                if guids.is_empty() {
+                    None
+                } else {
+                    Some(index)
+                }
+            },
+        )
     }
 }
 
@@ -568,47 +630,109 @@ impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Clone + Ord, I3: Clone + Ord, I4:
     }
 
     fn indices1(&'a self) -> impl Iterator<Item = I1> {
-        self.guard.index1.keys().copied()
+        self.guard.index1.iter().filter_map(
+            |(index, guids)| {
+                if guids.is_empty() {
+                    None
+                } else {
+                    Some(*index)
+                }
+            },
+        )
     }
 
     fn indices2(&'a self) -> impl Iterator<Item = &'a I2> {
-        self.guard.index2.keys()
+        self.guard.index2.iter().filter_map(
+            |(index, guids)| {
+                if guids.is_empty() {
+                    None
+                } else {
+                    Some(index)
+                }
+            },
+        )
     }
 
     fn indices3(&'a self) -> impl Iterator<Item = &'a I3> {
-        self.guard.index3.keys()
+        self.guard.index3.iter().filter_map(
+            |(index, guids)| {
+                if guids.is_empty() {
+                    None
+                } else {
+                    Some(index)
+                }
+            },
+        )
     }
 
     fn indices4(&'a self) -> impl Iterator<Item = &'a I4> {
-        self.guard.index4.keys()
+        self.guard.index4.iter().filter_map(
+            |(index, guids)| {
+                if guids.is_empty() {
+                    None
+                } else {
+                    Some(index)
+                }
+            },
+        )
     }
 
     fn indices1_by_range(
         &'a self,
         range: impl RangeBounds<I1>,
     ) -> impl DoubleEndedIterator<Item = I1> {
-        self.guard.index1.range(range).map(|(index, _)| *index)
+        self.guard.index1.range(range).filter_map(|(index, guids)| {
+            if guids.is_empty() {
+                None
+            } else {
+                Some(*index)
+            }
+        })
     }
 
     fn indices2_by_range(
         &'a self,
         range: impl RangeBounds<I2>,
     ) -> impl DoubleEndedIterator<Item = &'a I2> {
-        self.guard.index2.range(range).map(|(index, _)| index)
+        self.guard.index2.range(range).filter_map(
+            |(index, guids)| {
+                if guids.is_empty() {
+                    None
+                } else {
+                    Some(index)
+                }
+            },
+        )
     }
 
     fn indices3_by_range(
         &'a self,
         range: impl RangeBounds<I3>,
     ) -> impl DoubleEndedIterator<Item = &'a I3> {
-        self.guard.index3.range(range).map(|(index, _)| index)
+        self.guard.index3.range(range).filter_map(
+            |(index, guids)| {
+                if guids.is_empty() {
+                    None
+                } else {
+                    Some(index)
+                }
+            },
+        )
     }
 
     fn indices4_by_range(
         &'a self,
         range: impl RangeBounds<I4>,
     ) -> impl DoubleEndedIterator<Item = &'a I4> {
-        self.guard.index4.range(range).map(|(index, _)| index)
+        self.guard.index4.range(range).filter_map(
+            |(index, guids)| {
+                if guids.is_empty() {
+                    None
+                } else {
+                    Some(index)
+                }
+            },
+        )
     }
 }
 

--- a/src/game_server/handlers/guid.rs
+++ b/src/game_server/handlers/guid.rs
@@ -482,13 +482,13 @@ impl<
     pub fn update_value_indices<T>(
         &mut self,
         guid: K,
-        mut f: impl FnMut(Option<&mut RwLockWriteGuard<V>>) -> T,
+        mut f: impl FnMut(Option<&mut RwLockWriteGuard<V>>, &Self) -> T,
     ) -> T {
         let entry = self.remove(guid);
         if let Some((lock, ..)) = entry {
             let mut value_write_handle = lock.write();
 
-            let result = f(Some(&mut value_write_handle));
+            let result = f(Some(&mut value_write_handle), self);
 
             let index1 = value_write_handle.index1();
             let index2 = value_write_handle.index2();
@@ -499,7 +499,7 @@ impl<
 
             result
         } else {
-            f(None)
+            f(None, self)
         }
     }
 

--- a/src/game_server/handlers/guid.rs
+++ b/src/game_server/handlers/guid.rs
@@ -307,21 +307,21 @@ impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Clone + Ord, I3: Clone + Ord, I4:
     fn indices2_by_range(
         &'a self,
         range: impl RangeBounds<I2>,
-    ) -> impl DoubleEndedIterator<Item = &I2> {
+    ) -> impl DoubleEndedIterator<Item = &'a I2> {
         self.guard.index2.range(range).map(|(index, _)| index)
     }
 
     fn indices3_by_range(
         &'a self,
         range: impl RangeBounds<I3>,
-    ) -> impl DoubleEndedIterator<Item = &I3> {
+    ) -> impl DoubleEndedIterator<Item = &'a I3> {
         self.guard.index3.range(range).map(|(index, _)| index)
     }
 
     fn indices4_by_range(
         &'a self,
         range: impl RangeBounds<I4>,
-    ) -> impl DoubleEndedIterator<Item = &I4> {
+    ) -> impl DoubleEndedIterator<Item = &'a I4> {
         self.guard.index4.range(range).map(|(index, _)| index)
     }
 }
@@ -593,21 +593,21 @@ impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Clone + Ord, I3: Clone + Ord, I4:
     fn indices2_by_range(
         &'a self,
         range: impl RangeBounds<I2>,
-    ) -> impl DoubleEndedIterator<Item = &I2> {
+    ) -> impl DoubleEndedIterator<Item = &'a I2> {
         self.guard.index2.range(range).map(|(index, _)| index)
     }
 
     fn indices3_by_range(
         &'a self,
         range: impl RangeBounds<I3>,
-    ) -> impl DoubleEndedIterator<Item = &I3> {
+    ) -> impl DoubleEndedIterator<Item = &'a I3> {
         self.guard.index3.range(range).map(|(index, _)| index)
     }
 
     fn indices4_by_range(
         &'a self,
         range: impl RangeBounds<I4>,
-    ) -> impl DoubleEndedIterator<Item = &I4> {
+    ) -> impl DoubleEndedIterator<Item = &'a I4> {
         self.guard.index4.range(range).map(|(index, _)| index)
     }
 }

--- a/src/game_server/handlers/inventory.rs
+++ b/src/game_server/handlers/inventory.rs
@@ -34,8 +34,8 @@ use crate::{
 
 use super::{
     character::{
-        Character, CharacterLocationIndex, CharacterNameIndex, CharacterSquadIndex, CharacterType,
-        Chunk,
+        Character, CharacterLocationIndex, CharacterMatchmakingGroupIndex, CharacterNameIndex,
+        CharacterSquadIndex, CharacterType, Chunk,
     },
     guid::{GuidTableIndexer, IndexedGuid},
     lock_enforcer::CharacterLockRequest,
@@ -558,6 +558,7 @@ pub fn update_saber_tints<'a>(
         CharacterLocationIndex,
         CharacterNameIndex,
         CharacterSquadIndex,
+        CharacterMatchmakingGroupIndex,
     >,
     instance_guid: u64,
     chunk: Chunk,
@@ -677,6 +678,7 @@ fn equip_item_in_slot<'a>(
         CharacterLocationIndex,
         CharacterNameIndex,
         CharacterSquadIndex,
+        CharacterMatchmakingGroupIndex,
     >,
     characters_write: &mut BTreeMap<u64, RwLockWriteGuard<Character>>,
     game_server: &GameServer,

--- a/src/game_server/handlers/lock_enforcer.rs
+++ b/src/game_server/handlers/lock_enforcer.rs
@@ -80,15 +80,15 @@ impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Clone + Ord, I3: Clone + Ord, I4:
         self.handle.indices1()
     }
 
-    fn indices2(&'a self) -> impl Iterator<Item = &I2> {
+    fn indices2(&'a self) -> impl Iterator<Item = &'a I2> {
         self.handle.indices2()
     }
 
-    fn indices3(&'a self) -> impl Iterator<Item = &I3> {
+    fn indices3(&'a self) -> impl Iterator<Item = &'a I3> {
         self.handle.indices3()
     }
 
-    fn indices4(&'a self) -> impl Iterator<Item = &I4> {
+    fn indices4(&'a self) -> impl Iterator<Item = &'a I4> {
         self.handle.indices4()
     }
 }

--- a/src/game_server/handlers/lock_enforcer.rs
+++ b/src/game_server/handlers/lock_enforcer.rs
@@ -6,7 +6,10 @@ use std::{
 use parking_lot::{RwLockReadGuard, RwLockWriteGuard};
 
 use super::{
-    character::{Character, CharacterLocationIndex, CharacterNameIndex, CharacterSquadIndex},
+    character::{
+        Character, CharacterLocationIndex, CharacterMatchmakingGroupIndex, CharacterNameIndex,
+        CharacterSquadIndex,
+    },
     guid::{
         GuidTable, GuidTableHandle, GuidTableIndexer, GuidTableReadHandle, GuidTableWriteHandle,
     },
@@ -74,10 +77,10 @@ impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Clone + Ord, I3: Clone + Ord, I4:
     }
 }
 
-impl<'a, K, V, I1, I2, I3> From<GuidTableReadHandle<'a, K, V, I1, I2, I3>>
-    for TableReadHandleWrapper<'a, K, V, I1, I2, I3>
+impl<'a, K, V, I1, I2, I3, I4> From<GuidTableReadHandle<'a, K, V, I1, I2, I3, I4>>
+    for TableReadHandleWrapper<'a, K, V, I1, I2, I3, I4>
 {
-    fn from(value: GuidTableReadHandle<'a, K, V, I1, I2, I3>) -> Self {
+    fn from(value: GuidTableReadHandle<'a, K, V, I1, I2, I3, I4>) -> Self {
         TableReadHandleWrapper { handle: value }
     }
 }
@@ -89,6 +92,7 @@ pub type CharacterTableReadHandle<'a> = TableReadHandleWrapper<
     CharacterLocationIndex,
     CharacterNameIndex,
     CharacterSquadIndex,
+    CharacterMatchmakingGroupIndex,
 >;
 pub type CharacterTableWriteHandle<'a> = GuidTableWriteHandle<
     'a,
@@ -97,6 +101,7 @@ pub type CharacterTableWriteHandle<'a> = GuidTableWriteHandle<
     CharacterLocationIndex,
     CharacterNameIndex,
     CharacterSquadIndex,
+    CharacterMatchmakingGroupIndex,
 >;
 pub type CharacterReadGuard<'a> = RwLockReadGuard<'a, Character>;
 pub type CharacterWriteGuard<'a> = RwLockWriteGuard<'a, Character>;
@@ -192,6 +197,7 @@ pub struct LockEnforcer<'a> {
         CharacterLocationIndex,
         CharacterNameIndex,
         CharacterSquadIndex,
+        CharacterMatchmakingGroupIndex,
     >,
     zones: &'a GuidTable<u64, ZoneInstance, u8>,
 }
@@ -264,8 +270,14 @@ impl<'a> From<LockEnforcer<'a>> for ZoneLockEnforcer<'a> {
 }
 
 pub struct LockEnforcerSource {
-    characters:
-        GuidTable<u64, Character, CharacterLocationIndex, CharacterNameIndex, CharacterSquadIndex>,
+    characters: GuidTable<
+        u64,
+        Character,
+        CharacterLocationIndex,
+        CharacterNameIndex,
+        CharacterSquadIndex,
+        CharacterMatchmakingGroupIndex,
+    >,
     zones: GuidTable<u64, ZoneInstance, u8>,
 }
 
@@ -277,6 +289,7 @@ impl LockEnforcerSource {
             CharacterLocationIndex,
             CharacterNameIndex,
             CharacterSquadIndex,
+            CharacterMatchmakingGroupIndex,
         >,
         zones: GuidTable<u64, ZoneInstance, u8>,
     ) -> LockEnforcerSource {

--- a/src/game_server/handlers/lock_enforcer.rs
+++ b/src/game_server/handlers/lock_enforcer.rs
@@ -103,6 +103,34 @@ impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Clone + Ord, I3: Clone + Ord, I4:
     fn indices4(&'a self) -> impl Iterator<Item = &'a I4> {
         self.handle.indices4()
     }
+
+    fn indices1_by_range(
+        &'a self,
+        range: impl RangeBounds<I1>,
+    ) -> impl DoubleEndedIterator<Item = I1> {
+        self.handle.indices1_by_range(range)
+    }
+
+    fn indices2_by_range(
+        &'a self,
+        range: impl RangeBounds<I2>,
+    ) -> impl DoubleEndedIterator<Item = &I2> {
+        self.handle.indices2_by_range(range)
+    }
+
+    fn indices3_by_range(
+        &'a self,
+        range: impl RangeBounds<I3>,
+    ) -> impl DoubleEndedIterator<Item = &I3> {
+        self.handle.indices3_by_range(range)
+    }
+
+    fn indices4_by_range(
+        &'a self,
+        range: impl RangeBounds<I4>,
+    ) -> impl DoubleEndedIterator<Item = &I4> {
+        self.handle.indices4_by_range(range)
+    }
 }
 
 impl<'a, K, V, I1, I2, I3, I4> From<GuidTableReadHandle<'a, K, V, I1, I2, I3, I4>>

--- a/src/game_server/handlers/lock_enforcer.rs
+++ b/src/game_server/handlers/lock_enforcer.rs
@@ -114,21 +114,21 @@ impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Clone + Ord, I3: Clone + Ord, I4:
     fn indices2_by_range(
         &'a self,
         range: impl RangeBounds<I2>,
-    ) -> impl DoubleEndedIterator<Item = &I2> {
+    ) -> impl DoubleEndedIterator<Item = &'a I2> {
         self.handle.indices2_by_range(range)
     }
 
     fn indices3_by_range(
         &'a self,
         range: impl RangeBounds<I3>,
-    ) -> impl DoubleEndedIterator<Item = &I3> {
+    ) -> impl DoubleEndedIterator<Item = &'a I3> {
         self.handle.indices3_by_range(range)
     }
 
     fn indices4_by_range(
         &'a self,
         range: impl RangeBounds<I4>,
-    ) -> impl DoubleEndedIterator<Item = &I4> {
+    ) -> impl DoubleEndedIterator<Item = &'a I4> {
         self.handle.indices4_by_range(range)
     }
 }

--- a/src/game_server/handlers/lock_enforcer.rs
+++ b/src/game_server/handlers/lock_enforcer.rs
@@ -60,19 +60,31 @@ impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Clone + Ord, I3: Clone + Ord, I4:
         self.handle.keys_by_index4(index)
     }
 
-    fn keys_by_index1_range(&'a self, range: impl RangeBounds<I1>) -> impl Iterator<Item = K> {
+    fn keys_by_index1_range(
+        &'a self,
+        range: impl RangeBounds<I1>,
+    ) -> impl DoubleEndedIterator<Item = K> {
         self.handle.keys_by_index1_range(range)
     }
 
-    fn keys_by_index2_range(&'a self, range: impl RangeBounds<I2>) -> impl Iterator<Item = K> {
+    fn keys_by_index2_range(
+        &'a self,
+        range: impl RangeBounds<I2>,
+    ) -> impl DoubleEndedIterator<Item = K> {
         self.handle.keys_by_index2_range(range)
     }
 
-    fn keys_by_index3_range(&'a self, range: impl RangeBounds<I3>) -> impl Iterator<Item = K> {
+    fn keys_by_index3_range(
+        &'a self,
+        range: impl RangeBounds<I3>,
+    ) -> impl DoubleEndedIterator<Item = K> {
         self.handle.keys_by_index3_range(range)
     }
 
-    fn keys_by_index4_range(&'a self, range: impl RangeBounds<I4>) -> impl Iterator<Item = K> {
+    fn keys_by_index4_range(
+        &'a self,
+        range: impl RangeBounds<I4>,
+    ) -> impl DoubleEndedIterator<Item = K> {
         self.handle.keys_by_index4_range(range)
     }
 

--- a/src/game_server/handlers/lock_enforcer.rs
+++ b/src/game_server/handlers/lock_enforcer.rs
@@ -75,6 +75,22 @@ impl<'a, K: Copy + Ord, V, I1: Copy + Ord, I2: Clone + Ord, I3: Clone + Ord, I4:
     fn keys_by_index4_range(&'a self, range: impl RangeBounds<I4>) -> impl Iterator<Item = K> {
         self.handle.keys_by_index4_range(range)
     }
+
+    fn indices1(&'a self) -> impl Iterator<Item = I1> {
+        self.handle.indices1()
+    }
+
+    fn indices2(&'a self) -> impl Iterator<Item = &I2> {
+        self.handle.indices2()
+    }
+
+    fn indices3(&'a self) -> impl Iterator<Item = &I3> {
+        self.handle.indices3()
+    }
+
+    fn indices4(&'a self) -> impl Iterator<Item = &I4> {
+        self.handle.indices4()
+    }
 }
 
 impl<'a, K, V, I1, I2, I3, I4> From<GuidTableReadHandle<'a, K, V, I1, I2, I3, I4>>

--- a/src/game_server/handlers/login.rs
+++ b/src/game_server/handlers/login.rs
@@ -115,7 +115,6 @@ pub fn log_in(sender: u32, game_server: &GameServer) -> Result<Vec<Broadcast>, P
                     customizations: make_test_customizations(),
                     minigame_stats: PlayerMinigameStats::default(),
                     matchmaking_group: None,
-                    owned_matchmaking_group: None,
                     minigame_status: None,
                     update_previous_location_on_leave: true,
                     previous_location: PreviousLocation {

--- a/src/game_server/handlers/login.rs
+++ b/src/game_server/handlers/login.rs
@@ -114,7 +114,7 @@ pub fn log_in(sender: u32, game_server: &GameServer) -> Result<Vec<Broadcast>, P
                     inventory: player.inner.data.inventory.into_keys().collect(),
                     customizations: make_test_customizations(),
                     minigame_stats: PlayerMinigameStats::default(),
-                    matchmaking_group_guid: None,
+                    matchmaking_group: None,
                     owned_matchmaking_group: None,
                     minigame_status: None,
                     update_previous_location_on_leave: true,

--- a/src/game_server/handlers/login.rs
+++ b/src/game_server/handlers/login.rs
@@ -114,6 +114,8 @@ pub fn log_in(sender: u32, game_server: &GameServer) -> Result<Vec<Broadcast>, P
                     inventory: player.inner.data.inventory.into_keys().collect(),
                     customizations: make_test_customizations(),
                     minigame_stats: PlayerMinigameStats::default(),
+                    matchmaking_group_guid: None,
+                    owned_matchmaking_group: None,
                     minigame_status: None,
                     update_previous_location_on_leave: true,
                     previous_location: PreviousLocation {

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -814,7 +814,7 @@ fn handle_request_create_active_minigame(
                         )
                     });
 
-                    characters_table_write_handle.update_value_indices(player_guid(sender), |possible_character_write_handle| {
+                    characters_table_write_handle.update_value_indices(player_guid(sender), |possible_character_write_handle, _| {
                         if let Some(character_write_handle) = possible_character_write_handle {
                             if let CharacterType::Player(ref mut player) =
                                 &mut character_write_handle.stats.character_type
@@ -879,7 +879,7 @@ fn remove_from_matchmaking(
     was_teleported: bool,
     game_server: &GameServer,
 ) -> Result<Vec<Broadcast>, ProcessPacketError> {
-    let previous_location = characters_table_write_handle.update_value_indices(player_guid(player), |possible_character_write_handle| {
+    let previous_location = characters_table_write_handle.update_value_indices(player_guid(player), |possible_character_write_handle, _| {
         if let Some(character_write_handle) = possible_character_write_handle {
             if let CharacterType::Player(player) =
                 &mut character_write_handle.stats.character_type
@@ -951,7 +951,7 @@ pub fn prepare_active_minigame_instance(
             let mut teleport_broadcasts = Vec::new();
             let now = Instant::now();
             for member_guid in members {
-                characters_table_write_handle.update_value_indices(player_guid(*member_guid), |possible_character_write_handle| {
+                characters_table_write_handle.update_value_indices(player_guid(*member_guid), |possible_character_write_handle, _| {
                     if let Some(character_write_handle) = possible_character_write_handle {
                         if let CharacterType::Player(player) = &mut character_write_handle.stats.character_type {
                             if game_server.minigames().stage_unlocked(stage_group_guid, stage_guid, player) {

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -897,7 +897,7 @@ fn remove_from_matchmaking(
             Err(ProcessPacketError::new(
                 ProcessPacketErrorType::ConstraintViolated,
                 format!(
-                    "Remove player {} from matchmaking, but their character isn't a player",
+                    "Tried to remove player {} from matchmaking, but their character isn't a player",
                     player
                 ),
             ))

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -1470,6 +1470,7 @@ pub fn create_active_minigame(
                         was_successful: true,
                     },
                 })?,
+                // Re-send the stage group instance to populate the stage data in the settings menu
                 GamePacket::serialize(&TunneledPacket {
                     unknown1: true,
                     inner: CreateActiveMinigame {

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -1054,7 +1054,15 @@ fn handle_request_start_active_minigame(
                 if let CharacterType::Player(player) = &character_read_handle.stats.character_type {
                     if let Some(minigame_status) = &player.minigame_status {
                         if request.header.stage_guid == minigame_status.stage_guid {
+                            // Re-send the stage group instance to populate the stage data in the settings menu
+                            let mut stage_group_instance = game_server.minigames.stage_group_instance(minigame_status.stage_group_guid, player)?;
+                            stage_group_instance.header.stage_guid = minigame_status.stage_guid;
+
                             let mut packets = vec![
+                                GamePacket::serialize(&TunneledPacket {
+                                    unknown1: true,
+                                    inner: stage_group_instance,
+                                })?,
                                 GamePacket::serialize(&TunneledPacket {
                                     unknown1: true,
                                     inner: StartActiveMinigame {

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -90,6 +90,12 @@ impl PlayerMinigameStats {
 }
 
 #[derive(Deserialize)]
+pub struct StageLocator {
+    pub stage_group_guid: i32,
+    pub stage_guid: i32,
+}
+
+#[derive(Deserialize)]
 pub struct MinigameStageConfig {
     pub guid: i32,
     pub name_id: u32,
@@ -111,7 +117,7 @@ pub struct MinigameStageConfig {
     pub score_to_credits_expression: String,
     #[serde(default = "default_matchmaking_timeout_millis")]
     pub matchmaking_timeout_millis: u32,
-    pub single_player_stage_guid: Option<i32>,
+    pub single_player_stage_guid: Option<StageLocator>,
 }
 
 impl MinigameStageConfig {

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -793,9 +793,10 @@ fn handle_request_create_active_minigame(
                     ))
                 } else {
                     let mut broadcasts = Vec::new();
+                    let required_space = 1;
                     let (open_group, space_left) = find_matchmaking_group(
                         characters_table_write_handle,
-                        1,
+                        required_space,
                         stage_config.stage_config.max_players,
                         stage_config.stage_group_guid,
                         stage_config.stage_config.guid,
@@ -809,7 +810,7 @@ fn handle_request_create_active_minigame(
                                 Instant::now(),
                                 sender,
                             ),
-                            stage_config.stage_config.max_players.saturating_sub(1),
+                            stage_config.stage_config.max_players,
                         )
                     });
 
@@ -848,7 +849,7 @@ fn handle_request_create_active_minigame(
                         );
                         result?;
 
-                        if space_left == 0 {
+                        if space_left <= required_space {
                             let players_in_group: Vec<u32> = characters_table_write_handle
                                 .keys_by_index4(&open_group)
                                 .filter_map(|guid| shorten_player_guid(guid).ok())

--- a/src/game_server/handlers/mount.rs
+++ b/src/game_server/handlers/mount.rs
@@ -26,7 +26,10 @@ use crate::{
 };
 
 use super::{
-    character::{Character, CharacterLocationIndex, CharacterNameIndex, CharacterSquadIndex},
+    character::{
+        Character, CharacterLocationIndex, CharacterMatchmakingGroupIndex, CharacterNameIndex,
+        CharacterSquadIndex,
+    },
     guid::{Guid, GuidTableIndexer, IndexedGuid},
     lock_enforcer::{CharacterLockRequest, ZoneLockRequest},
     unique_guid::{mount_guid, player_guid},
@@ -79,6 +82,7 @@ pub fn reply_dismount<'a>(
         CharacterLocationIndex,
         CharacterNameIndex,
         CharacterSquadIndex,
+        CharacterMatchmakingGroupIndex,
     >,
     zone: &RwLockReadGuard<ZoneInstance>,
     character: &mut RwLockWriteGuard<Character>,

--- a/src/game_server/handlers/zone.rs
+++ b/src/game_server/handlers/zone.rs
@@ -30,9 +30,9 @@ use crate::{
 use super::{
     character::{
         coerce_to_broadcast_supplier, AmbientNpcConfig, Character, CharacterCategory,
-        CharacterLocationIndex, CharacterNameIndex, CharacterSquadIndex, CharacterType, Chunk,
-        DoorConfig, NpcTemplate, PreviousFixture, PreviousLocation, TransportConfig,
-        WriteLockingBroadcastSupplier,
+        CharacterLocationIndex, CharacterMatchmakingGroupIndex, CharacterNameIndex,
+        CharacterSquadIndex, CharacterType, Chunk, DoorConfig, NpcTemplate, PreviousFixture,
+        PreviousLocation, TransportConfig, WriteLockingBroadcastSupplier,
     },
     distance3,
     guid::{Guid, GuidTable, GuidTableIndexer, GuidTableWriteHandle, IndexedGuid},
@@ -115,7 +115,14 @@ impl Guid<u8> for ZoneTemplate {
 }
 
 impl From<&Vec<Character>>
-    for GuidTable<u64, Character, CharacterLocationIndex, CharacterNameIndex, CharacterSquadIndex>
+    for GuidTable<
+        u64,
+        Character,
+        CharacterLocationIndex,
+        CharacterNameIndex,
+        CharacterSquadIndex,
+        CharacterMatchmakingGroupIndex,
+    >
 {
     fn from(value: &Vec<Character>) -> Self {
         let table = GuidTable::new();
@@ -144,6 +151,7 @@ impl ZoneTemplate {
             CharacterLocationIndex,
             CharacterNameIndex,
             CharacterSquadIndex,
+            CharacterMatchmakingGroupIndex,
         >,
     ) -> ZoneInstance {
         let keys_to_guid: HashMap<&String, u64> = self
@@ -268,6 +276,7 @@ impl ZoneInstance {
             CharacterLocationIndex,
             CharacterNameIndex,
             CharacterSquadIndex,
+            CharacterMatchmakingGroupIndex,
         >,
     ) -> Self {
         for (index, fixture) in house.fixtures.iter().enumerate() {
@@ -334,6 +343,7 @@ impl ZoneInstance {
             CharacterLocationIndex,
             CharacterNameIndex,
             CharacterSquadIndex,
+            CharacterMatchmakingGroupIndex,
         >,
     ) -> Result<Vec<u32>, ProcessPacketError> {
         let mut guids = Vec::new();
@@ -366,6 +376,7 @@ impl ZoneInstance {
             CharacterLocationIndex,
             CharacterNameIndex,
             CharacterSquadIndex,
+            CharacterMatchmakingGroupIndex,
         >,
     ) -> Result<Vec<u32>, ProcessPacketError> {
         ZoneInstance::other_players_nearby(None, chunk, instance_guid, characters_table_handle)
@@ -382,6 +393,7 @@ impl ZoneInstance {
             CharacterLocationIndex,
             CharacterNameIndex,
             CharacterSquadIndex,
+            CharacterMatchmakingGroupIndex,
         >,
         moved_character_guid: u64,
     ) -> CharacterDiffResult {

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -1081,6 +1081,7 @@ impl GameServer {
                                         characters_table_write_handle,
                                         zones_table_write_handle,
                                         false,
+                                        Some(33781),
                                         self,
                                     )?);
                                 }

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -28,7 +28,7 @@ use handlers::lock_enforcer::{
 use handlers::login::{log_in, log_out, send_points_of_interest};
 use handlers::minigame::{
     create_active_minigame, load_all_minigames, prepare_active_minigame_instance,
-    process_minigame_packet, remove_from_matchmaking, AllMinigameConfigs, StageLocator,
+    process_minigame_packet, remove_from_matchmaking, AllMinigameConfigs,
 };
 use handlers::mount::{load_mounts, process_mount_packet, MountConfig};
 use handlers::reference_data::{load_categories, load_item_classes, load_item_groups};
@@ -1070,6 +1070,7 @@ impl GameServer {
                                     &stage,
                                     characters_table_write_handle,
                                     zones_table_write_handle,
+                                    None,
                                     self,
                                 ));
                                 return Ok::<(), ProcessPacketError>(());
@@ -1085,6 +1086,7 @@ impl GameServer {
                                                 &replacement_stage,
                                                 characters_table_write_handle,
                                                 zones_table_write_handle,
+                                                Some(44218),
                                                 self,
                                             ));
                                             return Ok::<(), ProcessPacketError>(());

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -785,6 +785,10 @@ impl GameServer {
         &self.mounts
     }
 
+    pub fn start_time(&self) -> Instant {
+        self.start_time
+    }
+
     pub fn lock_enforcer(&self) -> LockEnforcer {
         self.lock_enforcer_source.lock_enforcer()
     }

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -261,7 +261,7 @@ impl GameServer {
                     // Set the player as ready
                     self.lock_enforcer()
                         .write_characters(|characters_table_write_handle, _| {
-                            characters_table_write_handle.update_value_indices(player_guid(sender), |possible_character_write_handle| {
+                            characters_table_write_handle.update_value_indices(player_guid(sender), |possible_character_write_handle, _| {
                                 if let Some(character_write_handle) = possible_character_write_handle {
                                     if let CharacterType::Player(ref mut player) =
                                         &mut character_write_handle.stats.character_type

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -9,8 +9,8 @@ use std::vec;
 
 use byteorder::{LittleEndian, ReadBytesExt};
 use handlers::character::{
-    Character, CharacterCategory, CharacterLocationIndex, CharacterNameIndex, CharacterSquadIndex,
-    CharacterType, Chunk,
+    Character, CharacterCategory, CharacterLocationIndex, CharacterMatchmakingGroupIndex,
+    CharacterNameIndex, CharacterSquadIndex, CharacterType, Chunk,
 };
 use handlers::chat::process_chat_packet;
 use handlers::command::process_command;
@@ -585,6 +585,7 @@ impl GameServer {
                             CharacterLocationIndex,
                             CharacterNameIndex,
                             CharacterSquadIndex,
+                            CharacterMatchmakingGroupIndex,
                         >,
                          zones_lock_enforcer| {
                             zones_lock_enforcer.write_zones(|zones_table_write_handle| {


### PR DESCRIPTION
* Implement multiplayer matchmaking, including error handling when failing to find enough players or starting a single-player game when available.
* Every tick, the game checks for timed out matchmaking groups to decide whether to start the game (if it has enough players, but not the maximum number of players) or cancel the game (returning all players to the world).
* Groups currently have status `OpenToAll` or `OpenToFriends` (unused). We will use `OpenToFriends` once friend invitations are supported.
* Characters are now indexed by their matchmaking group. The matchmaking groups are ordered by status, stage group GUID, stage GUID, time of creation, and owner GUID. This allows us to efficiently select groups for a given stage that are open to all and timed out, for example.
  * This ordering requires us to iterate over all stages during a tick, as opposed to only selecting timed out groups. (We can select a range based on stage group, stage, and time, but not a range solely based on time.) However, the number of stages is a fairly small fixed constant, and searching for stage config currently requires a linear search anyway, so iterating over all the stages isn't that inefficient.
* Fixes an issue after #115 where the minigame name stopped showing in the options menu.
* Adds a `update_value_indices` for GUID tables, which neatly removes and re-inserts an entry after performing some operation. This is useful because we have a few places where an error would cause a player to be removed from the table, but never re-inserted. That case is impossible when using `update_value_indices`.
* Coordinated start (waiting for all players to be ready) and ending games when too many players leave will be implemented separately.