### PR TITLE
Fix minigame tick race condition

### DIFF
--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -1037,10 +1037,11 @@ impl GameServer {
                 for stage in self.minigames().stage_configs() {
                     let timeout =
                         Duration::from_millis(stage.stage_config.matchmaking_timeout_millis as u64);
+                    // Make sure max time is larger than start time
                     let max_time = match now.checked_sub(timeout) {
                         Some(max_time) => max_time,
                         None => continue,
-                    };
+                    }.max(self.start_time);
                     let stage_group_guid = stage.stage_group_guid;
                     let stage_guid = stage.stage_config.guid;
                     let min_players = stage.stage_config.min_players;

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -1037,7 +1037,7 @@ impl GameServer {
                 for stage in self.minigames().stage_configs() {
                     let timeout =
                         Duration::from_millis(stage.stage_config.matchmaking_timeout_millis as u64);
-                    // Make sure max time is larger than start time
+                    // Make sure max time is greater than or equal to start time so that the range is valid
                     let max_time = match now.checked_sub(timeout) {
                         Some(max_time) => max_time,
                         None => continue,


### PR DESCRIPTION
Fix a race condition where (current time - timeout) can be smaller than the start time tracked by the game server, creating a range where the upper bound is smaller than the lower bound and making the tick thread panic. This only occurs when starting a minigame quickly after server startup.