### PR TITLE
Properly handle the Flash game end round payload

### DIFF
--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -982,6 +982,7 @@ pub struct MinigameStatus {
     pub game_won: bool,
     pub score_entries: Vec<ScoreEntry>,
     pub total_score: i32,
+    pub awarded_credits: u32,
     pub start_time: Instant,
 }
 


### PR DESCRIPTION
Currently, we end the game when receiving the `EndRoundNoValidation` payload. We should instead grant credits for that round but allow the game to continue (Stunt Gungan, Turret Tactics).

If we do grant credits at the end of each round, we shouldn't grant any credits at the end of the game (since they've already been granted). Furthermore, a game's end score will be the _highest_ score of any individual round, as in the OG. Otherwise, we'd be awarding players high scores for simply playing longer and not doing well in each round.