### PR TITLE
Add all Saber Strike levels

### DIFF
--- a/config/minigames.json
+++ b/config/minigames.json
@@ -131,7 +131,7 @@
                     "name_id": 7103,
                     "description_id": 9754,
                     "icon_id": 542,
-                    "stage_icon_id": 5129,
+                    "stage_icon_id": 542,
                     "members_only": false,
                     "stage_select_map_name": "",
                     "stages": [
@@ -270,7 +270,7 @@
                 "param1": 0,
                 "icon_id": 1248,
                 "background_icon_id": 0,
-                "is_popular": true,
+                "is_popular": false,
                 "is_game_of_day": false,
                 "sort_order": 12000,
                 "tutorial_swf": "HowtoRocketRescue.swf",
@@ -1360,6 +1360,896 @@
         "icon_id": 5809,
         "sort_order": 3,
         "portal_entries": [
+            {
+                "guid": 1004,
+                "name_id": 7040,
+                "description_id": 7041,
+                "members_only": false,
+                "is_flash": false,
+                "is_active": true,
+                "param1": 0,
+                "icon_id": 1249,
+                "background_icon_id": 0,
+                "is_popular": true,
+                "is_game_of_day": false,
+                "sort_order": 15000,
+                "tutorial_swf": "HowtoSaberStrike.swf",
+                "stage_group": {
+                    "guid": 13,
+                    "name_id": 7040,
+                    "description_id": 7041,
+                    "icon_id": 369,
+                    "stage_icon_id": 369,
+                    "members_only": false,
+                    "stage_select_map_name": "saberStrike",
+                    "stages": [
+                        {
+                            "Stage": {
+                                "guid": 27001,
+                                "name_id": 7270,
+                                "description_id": 9000,
+                                "stage_icon_id": 247,
+                                "start_screen_icon_id": 663,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 1,
+                                "start_sound_id": 1510,
+                                "members_only": false,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage01",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 11
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 129"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27002,
+                                "name_id": 7271,
+                                "description_id": 9001,
+                                "stage_icon_id": 248,
+                                "start_screen_icon_id": 664,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 1,
+                                "start_sound_id": 3055,
+                                "members_only": false,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage02",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 24
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 94"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27003,
+                                "name_id": 7272,
+                                "description_id": 9002,
+                                "stage_icon_id": 249,
+                                "start_screen_icon_id": 665,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 1,
+                                "start_sound_id": 3056,
+                                "members_only": false,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage03",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 12
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 160"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27004,
+                                "name_id": 7273,
+                                "description_id": 9003,
+                                "stage_icon_id": 250,
+                                "start_screen_icon_id": 666,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 1,
+                                "start_sound_id": 3223,
+                                "members_only": false,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage04",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 25
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 143"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27005,
+                                "name_id": 7274,
+                                "description_id": 9004,
+                                "stage_icon_id": 251,
+                                "start_screen_icon_id": 667,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 1,
+                                "start_sound_id": 3224,
+                                "members_only": false,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage05",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 13
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 157"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27006,
+                                "name_id": 7275,
+                                "description_id": 9005,
+                                "stage_icon_id": 252,
+                                "start_screen_icon_id": 668,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 1,
+                                "start_sound_id": 3225,
+                                "members_only": false,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage06",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 17
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 120"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27007,
+                                "name_id": 7276,
+                                "description_id": 9006,
+                                "stage_icon_id": 253,
+                                "start_screen_icon_id": 669,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 1,
+                                "start_sound_id": 3226,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage07",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 20
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 244"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27008,
+                                "name_id": 7277,
+                                "description_id": 9007,
+                                "stage_icon_id": 254,
+                                "start_screen_icon_id": 670,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 1,
+                                "start_sound_id": 3227,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage08",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 32
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 1148"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27009,
+                                "name_id": 8421,
+                                "description_id": 9008,
+                                "stage_icon_id": 255,
+                                "start_screen_icon_id": 671,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 1,
+                                "start_sound_id": 3228,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage09",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 132
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 1014"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27010,
+                                "name_id": 7278,
+                                "description_id": 9009,
+                                "stage_icon_id": 256,
+                                "start_screen_icon_id": 690,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 2,
+                                "start_sound_id": 3229,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage10",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 23
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 114"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27011,
+                                "name_id": 7279,
+                                "description_id": 9010,
+                                "stage_icon_id": 257,
+                                "start_screen_icon_id": 691,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 2,
+                                "start_sound_id": 3230,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage11",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 70
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 93"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27012,
+                                "name_id": 7280,
+                                "description_id": 9011,
+                                "stage_icon_id": 258,
+                                "start_screen_icon_id": 692,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 2,
+                                "start_sound_id": 3231,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage12",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 50
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 170"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27013,
+                                "name_id": 7281,
+                                "description_id": 9012,
+                                "stage_icon_id": 259,
+                                "start_screen_icon_id": 693,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 2,
+                                "start_sound_id": 3232,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage13",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 51
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 144"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27014,
+                                "name_id": 7282,
+                                "description_id": 9013,
+                                "stage_icon_id": 260,
+                                "start_screen_icon_id": 694,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 2,
+                                "start_sound_id": 3233,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage14",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 52
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 147"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27015,
+                                "name_id": 7283,
+                                "description_id": 9014,
+                                "stage_icon_id": 261,
+                                "start_screen_icon_id": 695,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 2,
+                                "start_sound_id": 3234,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage15",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 18
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 237"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27016,
+                                "name_id": 7284,
+                                "description_id": 9015,
+                                "stage_icon_id": 262,
+                                "start_screen_icon_id": 696,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 2,
+                                "start_sound_id": 3235,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage16",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 33
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 144"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27017,
+                                "name_id": 7285,
+                                "description_id": 9016,
+                                "stage_icon_id": 263,
+                                "start_screen_icon_id": 697,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 2,
+                                "start_sound_id": 3236,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage17",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 53
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 141"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27018,
+                                "name_id": 8422,
+                                "description_id": 9017,
+                                "stage_icon_id": 264,
+                                "start_screen_icon_id": 698,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 2,
+                                "start_sound_id": 3237,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage18",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 136
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 159"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27019,
+                                "name_id": 7286,
+                                "description_id": 9018,
+                                "stage_icon_id": 265,
+                                "start_screen_icon_id": 672,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 3,
+                                "start_sound_id": 3238,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage19",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 27
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 140"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27020,
+                                "name_id": 7287,
+                                "description_id": 9019,
+                                "stage_icon_id": 266,
+                                "start_screen_icon_id": 673,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 3,
+                                "start_sound_id": 3239,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage20",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 49
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 191"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27021,
+                                "name_id": 7288,
+                                "description_id": 9020,
+                                "stage_icon_id": 267,
+                                "start_screen_icon_id": 674,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 3,
+                                "start_sound_id": 3240,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage21",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 36
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 116"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27022,
+                                "name_id": 7289,
+                                "description_id": 9021,
+                                "stage_icon_id": 268,
+                                "start_screen_icon_id": 675,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 3,
+                                "start_sound_id": 3241,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage22",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 38
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 289"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27023,
+                                "name_id": 7290,
+                                "description_id": 9022,
+                                "stage_icon_id": 269,
+                                "start_screen_icon_id": 676,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 3,
+                                "start_sound_id": 3242,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage23",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 22
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 214"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27024,
+                                "name_id": 7291,
+                                "description_id": 9023,
+                                "stage_icon_id": 270,
+                                "start_screen_icon_id": 677,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 3,
+                                "start_sound_id": 3243,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage24",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 45
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 594"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27025,
+                                "name_id": 7292,
+                                "description_id": 9024,
+                                "stage_icon_id": 271,
+                                "start_screen_icon_id": 678,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 3,
+                                "start_sound_id": 3244,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage25",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 46
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 432"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27026,
+                                "name_id": 7293,
+                                "description_id": 9025,
+                                "stage_icon_id": 272,
+                                "start_screen_icon_id": 679,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 3,
+                                "start_sound_id": 3245,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage26",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 15
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 144"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27027,
+                                "name_id": 8423,
+                                "description_id": 9026,
+                                "stage_icon_id": 273,
+                                "start_screen_icon_id": 680,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 3,
+                                "start_sound_id": 3246,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage27",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 139
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 173"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27028,
+                                "name_id": 7294,
+                                "description_id": 9027,
+                                "stage_icon_id": 274,
+                                "start_screen_icon_id": 681,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 4,
+                                "start_sound_id": 3247,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage28",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 28
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 110"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27029,
+                                "name_id": 7295,
+                                "description_id": 9028,
+                                "stage_icon_id": 275,
+                                "start_screen_icon_id": 682,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 4,
+                                "start_sound_id": 3248,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage29",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 41
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 153"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27030,
+                                "name_id": 7296,
+                                "description_id": 9029,
+                                "stage_icon_id": 276,
+                                "start_screen_icon_id": 683,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 4,
+                                "start_sound_id": 3249,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage30",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 40
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 244"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27031,
+                                "name_id": 7297,
+                                "description_id": 9030,
+                                "stage_icon_id": 277,
+                                "start_screen_icon_id": 684,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 4,
+                                "start_sound_id": 3250,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage31",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 141
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 221"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27032,
+                                "name_id": 7298,
+                                "description_id": 9032,
+                                "stage_icon_id": 278,
+                                "start_screen_icon_id": 685,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 4,
+                                "start_sound_id": 3251,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage32",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 42
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 170"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27033,
+                                "name_id": 7299,
+                                "description_id": 9031,
+                                "stage_icon_id": 279,
+                                "start_screen_icon_id": 686,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 4,
+                                "start_sound_id": 3252,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage33",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 43
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 147"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27034,
+                                "name_id": 7300,
+                                "description_id": 9033,
+                                "stage_icon_id": 280,
+                                "start_screen_icon_id": 687,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 4,
+                                "start_sound_id": 3253,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage34",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 47
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 126"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27035,
+                                "name_id": 7301,
+                                "description_id": 9034,
+                                "stage_icon_id": 281,
+                                "start_screen_icon_id": 688,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 4,
+                                "start_sound_id": 3254,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage35",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 140
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 152"
+                            }
+                        },
+                        {
+                            "Stage": {
+                                "guid": 27036,
+                                "name_id": 8424,
+                                "description_id": 9035,
+                                "stage_icon_id": 282,
+                                "start_screen_icon_id": 689,
+                                "min_players": 1,
+                                "max_players": 1,
+                                "difficulty": 4,
+                                "start_sound_id": 3255,
+                                "members_only": true,
+                                "require_previous_completed": false,
+                                "link_name": "stage",
+                                "short_name": "stage36",
+                                "minigame_type": {
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 48
+                                    }
+                                },
+                                "zone_template_guid": 200,
+                                "score_to_credits_expression": "x / 153"
+                            }
+                        }
+                    ]
+                }
+            },
             {
                 "guid": 16000,
                 "name_id": 5555,

--- a/config/minigames.json
+++ b/config/minigames.json
@@ -52,7 +52,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage01",
-                                "flash_game": "HasbroAttackShip.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "HasbroAttackShip.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 177"
                             }
@@ -72,7 +76,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage02",
-                                "flash_game": "HasbroAttackShip.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "HasbroAttackShip.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 208"
                             }
@@ -92,7 +100,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage03",
-                                "flash_game": "HasbroAttackShip.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "HasbroAttackShip.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 219"
                             }
@@ -101,7 +113,7 @@
                 }
             },
             {
-                "guid": 1004,
+                "guid": 10000,
                 "name_id": 7103,
                 "description_id": 9754,
                 "members_only": false,
@@ -115,7 +127,7 @@
                 "sort_order": 10000,
                 "tutorial_swf": "HowToStuntGungan.swf",
                 "stage_group": {
-                    "guid": 1004,
+                    "guid": 10000,
                     "name_id": 7103,
                     "description_id": 9754,
                     "icon_id": 542,
@@ -138,6 +150,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "StuntGungan.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 29"
                             }
@@ -183,7 +200,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage01",
-                                "flash_game": "CrisisZiro.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "CrisisZiro.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 160"
                             }
@@ -203,7 +224,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage02",
-                                "flash_game": "CrisisZiro.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "CrisisZiro.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 180"
                             }
@@ -223,7 +248,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage03",
-                                "flash_game": "CrisisZiro.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "CrisisZiro.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 180"
                             }
@@ -269,7 +298,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage01",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 15.25"
                             }
@@ -289,7 +322,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage02",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 14"
                             }
@@ -309,7 +346,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage03",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 14.45"
                             }
@@ -329,7 +370,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage04",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 19.4"
                             }
@@ -349,7 +394,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage05",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 13.9"
                             }
@@ -369,7 +418,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage06",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 14.7"
                             }
@@ -389,7 +442,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage07",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 19.8"
                             }
@@ -409,7 +466,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage08",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 11.55"
                             }
@@ -429,7 +490,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage09",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 12.55"
                             }
@@ -449,7 +514,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage10",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 22.7"
                             }
@@ -469,7 +538,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage11",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 17"
                             }
@@ -489,7 +562,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage12",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 17"
                             }
@@ -509,7 +586,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage13",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 11"
                             }
@@ -529,7 +610,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage14",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 17"
                             }
@@ -549,7 +634,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage15",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 18"
                             }
@@ -569,7 +658,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage16",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 25"
                             }
@@ -589,7 +682,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage17",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 17"
                             }
@@ -609,7 +706,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage18",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 39"
                             }
@@ -629,7 +730,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage19",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 18"
                             }
@@ -649,7 +754,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage20",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 24"
                             }
@@ -669,7 +778,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage21",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 20"
                             }
@@ -689,7 +802,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage22",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 22"
                             }
@@ -709,7 +826,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage23",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 12"
                             }
@@ -729,7 +850,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage24",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 18"
                             }
@@ -749,7 +874,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage25",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 18"
                             }
@@ -769,7 +898,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage26",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 15"
                             }
@@ -789,7 +922,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage27",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 19"
                             }
@@ -809,7 +946,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage28",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 21"
                             }
@@ -829,7 +970,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage29",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 15"
                             }
@@ -849,7 +994,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage30",
-                                "flash_game": "r2.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "r2.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 20"
                             }
@@ -895,7 +1044,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage01",
-                                "flash_game": "RepublicGunship.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "RepublicGunship.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 115"
                             }
@@ -915,7 +1068,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage02",
-                                "flash_game": "RepublicGunship.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "RepublicGunship.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 167"
                             }
@@ -935,7 +1092,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage03",
-                                "flash_game": "RepublicGunship.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "RepublicGunship.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 201"
                             }
@@ -981,7 +1142,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage01",
-                                "flash_game": "AquaticAssault.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "AquaticAssault.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 102.5"
                             }
@@ -1001,7 +1166,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage02",
-                                "flash_game": "AquaticAssault.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "AquaticAssault.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 108"
                             }
@@ -1021,7 +1190,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage03",
-                                "flash_game": "AquaticAssault.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "AquaticAssault.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 168"
                             }
@@ -1068,7 +1241,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage01",
-                                "flash_game": "BlasterTraining.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "BlasterTraining.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 180"
                             }
@@ -1088,7 +1265,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage02",
-                                "flash_game": "BlasterTraining.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "BlasterTraining.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 180"
                             }
@@ -1108,7 +1289,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage03",
-                                "flash_game": "BlasterTraining.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "BlasterTraining.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 180"
                             }
@@ -1154,7 +1339,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "",
-                                "flash_game": "TurretTactics.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "TurretTactics.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 69.5"
                             }
@@ -1209,7 +1398,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage01",
-                                "flash_game": "CrystalAttunement.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "CrystalAttunement.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 153"
                             }
@@ -1229,7 +1422,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage02",
-                                "flash_game": "CrystalAttunement.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "CrystalAttunement.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 153"
                             }
@@ -1249,7 +1446,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage03",
-                                "flash_game": "CrystalAttunement.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "CrystalAttunement.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 153"
                             }
@@ -1296,7 +1497,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage01",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 40"
                             }
@@ -1316,7 +1521,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage02",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 65"
                             }
@@ -1336,7 +1545,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage03",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 71"
                             }
@@ -1356,7 +1569,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage04",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 57"
                             }
@@ -1376,7 +1593,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage05",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 70"
                             }
@@ -1396,7 +1617,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage06",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 76"
                             }
@@ -1416,7 +1641,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage07",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 120"
                             }
@@ -1436,7 +1665,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage08",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 71"
                             }
@@ -1456,7 +1689,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage09",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 140"
                             }
@@ -1476,7 +1713,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage10",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 76"
                             }
@@ -1496,7 +1737,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage11",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 114"
                             }
@@ -1516,7 +1761,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage12",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 267"
                             }
@@ -1536,7 +1785,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage13",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 87"
                             }
@@ -1556,7 +1809,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage14",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 160"
                             }
@@ -1576,7 +1833,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage15",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 120"
                             }
@@ -1596,7 +1857,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage16",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 159"
                             }
@@ -1616,7 +1881,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage17",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 90"
                             }
@@ -1636,7 +1905,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage18",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 94"
                             }
@@ -1656,7 +1929,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage19",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 85"
                             }
@@ -1676,7 +1953,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage20",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 90.5"
                             }
@@ -1696,7 +1977,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage21",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 125"
                             }
@@ -1716,7 +2001,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage22",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 91"
                             }
@@ -1736,7 +2025,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage23",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 91"
                             }
@@ -1756,7 +2049,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage24",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 91"
                             }
@@ -1776,7 +2073,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage25",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 91"
                             }
@@ -1796,7 +2097,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage26",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 91"
                             }
@@ -1816,7 +2121,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage27",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 91"
                             }
@@ -1836,7 +2145,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage28",
-                                "flash_game": "Infiltration.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "Infiltration.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 91"
                             }
@@ -1882,7 +2195,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage01",
-                                "flash_game": "ForcePerception.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "ForcePerception.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 437"
                             }
@@ -1902,7 +2219,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage02",
-                                "flash_game": "ForcePerception.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "ForcePerception.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 439"
                             }
@@ -1922,7 +2243,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage03",
-                                "flash_game": "ForcePerception.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "ForcePerception.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 446"
                             }
@@ -1969,7 +2294,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage01",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 243"
                             }
@@ -1989,7 +2318,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage02",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 225"
                             }
@@ -2009,7 +2342,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage03",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 215"
                             }
@@ -2029,7 +2366,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage04",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 224"
                             }
@@ -2049,7 +2390,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage05",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 218"
                             }
@@ -2069,7 +2414,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage06",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 217"
                             }
@@ -2089,7 +2438,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage07",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 214"
                             }
@@ -2109,7 +2462,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage08",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 220"
                             }
@@ -2129,7 +2486,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage09",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 217"
                             }
@@ -2149,7 +2510,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage10",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 211.5"
                             }
@@ -2169,7 +2534,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage11",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 247"
                             }
@@ -2189,7 +2558,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage12",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 241"
                             }
@@ -2209,7 +2582,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage13",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 278"
                             }
@@ -2229,7 +2606,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage14",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 238"
                             }
@@ -2249,7 +2630,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage15",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 270"
                             }
@@ -2269,7 +2654,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage16",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 242"
                             }
@@ -2289,7 +2678,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage17",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 234"
                             }
@@ -2309,7 +2702,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage18",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 232"
                             }
@@ -2329,7 +2726,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage19",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 285"
                             }
@@ -2349,7 +2750,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage20",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 225"
                             }
@@ -2369,7 +2774,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage21",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 235"
                             }
@@ -2389,7 +2798,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage22",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 249"
                             }
@@ -2409,7 +2822,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage23",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 251"
                             }
@@ -2429,7 +2846,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage24",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 189"
                             }
@@ -2449,7 +2870,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage25",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 229"
                             }
@@ -2469,7 +2894,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage26",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 229"
                             }
@@ -2489,7 +2918,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage27",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 229"
                             }
@@ -2509,7 +2942,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage28",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 229"
                             }
@@ -2529,7 +2966,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage29",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 229"
                             }
@@ -2549,7 +2990,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage30",
-                                "flash_game": "DroidProgramming.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "DroidProgramming.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 229"
                             }
@@ -2595,7 +3040,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage01",
-                                "flash_game": "MineBuster.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "MineBuster.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 139"
                             }
@@ -2615,7 +3064,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage02",
-                                "flash_game": "MineBuster.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "MineBuster.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 169.25"
                             }
@@ -2635,7 +3088,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage03",
-                                "flash_game": "MineBuster.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "MineBuster.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 71.5"
                             }
@@ -2681,7 +3138,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage01",
-                                "flash_game": "HoloScramble.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "HoloScramble.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 200"
                             }
@@ -2701,7 +3162,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage02",
-                                "flash_game": "HoloScramble.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "HoloScramble.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 200"
                             }
@@ -2721,7 +3186,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage03",
-                                "flash_game": "HoloScramble.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "HoloScramble.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 200"
                             }
@@ -2767,7 +3236,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage01",
-                                "flash_game": "startyper.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "startyper.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 40.9"
                             }
@@ -2787,7 +3260,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage02",
-                                "flash_game": "startyper.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "startyper.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 80"
                             }
@@ -2807,7 +3284,11 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "stage03",
-                                "flash_game": "startyper.swf",
+                                "minigame_type": {
+                                    "Flash": {
+                                        "game_swf_name": "startyper.swf"
+                                    }
+                                },
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 81"
                             }

--- a/config/minigames.json
+++ b/config/minigames.json
@@ -125,7 +125,7 @@
                 "is_popular": true,
                 "is_game_of_day": false,
                 "sort_order": 10000,
-                "tutorial_swf": "HowToStuntGungan.swf",
+                "tutorial_swf": "HowtoStuntGungan.swf",
                 "stage_group": {
                     "guid": 10000,
                     "name_id": 7103,

--- a/config/minigames.json
+++ b/config/minigames.json
@@ -101,7 +101,7 @@
                 }
             },
             {
-                "guid": 10000,
+                "guid": 1004,
                 "name_id": 7103,
                 "description_id": 9754,
                 "members_only": false,
@@ -115,7 +115,7 @@
                 "sort_order": 10000,
                 "tutorial_swf": "HowToStuntGungan.swf",
                 "stage_group": {
-                    "guid": 10000,
+                    "guid": 1004,
                     "name_id": 7103,
                     "description_id": 9754,
                     "icon_id": 542,
@@ -138,7 +138,6 @@
                                 "require_previous_completed": false,
                                 "link_name": "stage",
                                 "short_name": "",
-                                "flash_game": "StuntGungan.swf",
                                 "zone_template_guid": 200,
                                 "score_to_credits_expression": "x / 29"
                             }

--- a/config/minigames.json
+++ b/config/minigames.json
@@ -113,7 +113,7 @@
                 }
             },
             {
-                "guid": 10000,
+                "guid": 1004,
                 "name_id": 7103,
                 "description_id": 9754,
                 "members_only": false,
@@ -124,10 +124,10 @@
                 "background_icon_id": 0,
                 "is_popular": true,
                 "is_game_of_day": false,
-                "sort_order": 10000,
+                "sort_order": 1004,
                 "tutorial_swf": "HowtoStuntGungan.swf",
                 "stage_group": {
-                    "guid": 10000,
+                    "guid": 13,
                     "name_id": 7103,
                     "description_id": 9754,
                     "icon_id": 542,
@@ -151,8 +151,8 @@
                                 "link_name": "stage",
                                 "short_name": "",
                                 "minigame_type": {
-                                    "Flash": {
-                                        "game_swf_name": "StuntGungan.swf"
+                                    "SaberStrike": {
+                                        "saber_strike_stage_id": 1
                                     }
                                 },
                                 "zone_template_guid": 200,

--- a/config/minigames.json
+++ b/config/minigames.json
@@ -113,7 +113,7 @@
                 }
             },
             {
-                "guid": 1004,
+                "guid": 10000,
                 "name_id": 7103,
                 "description_id": 9754,
                 "members_only": false,
@@ -124,10 +124,10 @@
                 "background_icon_id": 0,
                 "is_popular": true,
                 "is_game_of_day": false,
-                "sort_order": 1004,
+                "sort_order": 10000,
                 "tutorial_swf": "HowtoStuntGungan.swf",
                 "stage_group": {
-                    "guid": 13,
+                    "guid": 10000,
                     "name_id": 7103,
                     "description_id": 9754,
                     "icon_id": 542,
@@ -151,8 +151,8 @@
                                 "link_name": "stage",
                                 "short_name": "",
                                 "minigame_type": {
-                                    "SaberStrike": {
-                                        "saber_strike_stage_id": 1
+                                    "Flash": {
+                                        "game_swf_name": "StuntGungan.swf"
                                     }
                                 },
                                 "zone_template_guid": 200,

--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -37,7 +37,7 @@ use super::{
     housing::fixture_packets,
     inventory::wield_type_from_slot,
     lock_enforcer::CharacterReadGuard,
-    minigame::PlayerMinigameStats,
+    minigame::{MinigameTypeData, PlayerMinigameStats},
     mount::{spawn_mount_npc, MountConfig},
     unique_guid::{mount_guid, npc_guid, player_guid, shorten_player_guid},
     zone::teleport_within_zone,
@@ -984,6 +984,7 @@ pub struct MinigameStatus {
     pub total_score: i32,
     pub awarded_credits: u32,
     pub start_time: Instant,
+    pub type_data: MinigameTypeData,
 }
 
 #[derive(Clone)]

--- a/src/game_server/handlers/item.rs
+++ b/src/game_server/handlers/item.rs
@@ -2,6 +2,8 @@ use std::{collections::BTreeMap, fs::File, io::Error, path::Path};
 
 use crate::game_server::packets::item::ItemDefinition;
 
+pub const SABER_ITEM_TYPE: u32 = 25;
+
 pub fn load_item_definitions(config_dir: &Path) -> Result<BTreeMap<u32, ItemDefinition>, Error> {
     let mut file = File::open(config_dir.join("items.json"))?;
     let item_defs: Vec<ItemDefinition> = serde_json::from_reader(&mut file)?;

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -1167,7 +1167,7 @@ fn handle_request_start_active_minigame(
                                             stage_group_guid: minigame_status.stage_group_guid,
                                         },
                                         stage_id: 1,
-                                        disable_default_saber: true,
+                                        use_player_weapon: true,
                                     }
                                 })?,
                                 GamePacket::serialize(&TunneledPacket {

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -1166,8 +1166,8 @@ fn handle_request_start_active_minigame(
                                             sub_op_code: 1,
                                             stage_group_guid: minigame_status.stage_group_guid,
                                         },
-                                        unknown1: 1,
-                                        unknown2: true,
+                                        stage_id: 1,
+                                        disable_default_saber: true,
                                     }
                                 })?,
                                 GamePacket::serialize(&TunneledPacket {

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -31,6 +31,7 @@ use crate::{
                 ScoreType, ShowStageInstanceSelect, StartActiveMinigame,
                 UpdateActiveMinigameRewards,
             },
+            saber_strike::SaberStrikeInit,
             tunnel::TunneledPacket,
             GamePacket, RewardBundle,
         },
@@ -348,7 +349,7 @@ impl MinigameStageGroupConfig {
         CreateMinigameStageGroupInstance {
             header: MinigameHeader {
                 stage_guid: -1,
-                unknown2: -1,
+                sub_op_code: -1,
                 stage_group_guid: self.guid,
             },
             stage_group_guid: self.guid,
@@ -491,7 +492,7 @@ impl From<&[MinigamePortalCategoryConfig]> for MinigameDefinitions {
         MinigameDefinitions {
             header: MinigameHeader {
                 stage_guid: -1,
-                unknown2: -1,
+                sub_op_code: -1,
                 stage_group_guid: -1,
             },
             stages,
@@ -722,7 +723,7 @@ fn handle_request_stage_group_instance(
                                     inner: ShowStageInstanceSelect {
                                         header: MinigameHeader {
                                             stage_guid: -1,
-                                            unknown2: -1,
+                                            sub_op_code: -1,
                                             stage_group_guid: request.header.stage_group_guid,
                                         },
                                     },
@@ -953,7 +954,7 @@ pub fn remove_from_matchmaking(
         inner: ActiveMinigameCreationResult {
             header: MinigameHeader {
                 stage_guid,
-                unknown2: -1,
+                sub_op_code: -1,
                 stage_group_guid,
             },
             was_successful: false,
@@ -1159,10 +1160,22 @@ fn handle_request_start_active_minigame(
                             let mut packets = vec![
                                 GamePacket::serialize(&TunneledPacket {
                                     unknown1: true,
+                                    inner: SaberStrikeInit {
+                                        minigame_header: MinigameHeader {
+                                            stage_guid: minigame_status.stage_guid,
+                                            sub_op_code: 1,
+                                            stage_group_guid: minigame_status.stage_group_guid,
+                                        },
+                                        unknown1: 1,
+                                        unknown2: true,
+                                    }
+                                })?,
+                                GamePacket::serialize(&TunneledPacket {
+                                    unknown1: true,
                                     inner: StartActiveMinigame {
                                         header: MinigameHeader {
                                             stage_guid: minigame_status.stage_guid,
-                                            unknown2: -1,
+                                            sub_op_code: -1,
                                             stage_group_guid: minigame_status.stage_group_guid,
                                         },
                                     },
@@ -1385,7 +1398,7 @@ fn handle_flash_payload_win(
                         inner: FlashPayload {
                             header: MinigameHeader {
                                 stage_guid: minigame_status.stage_guid,
-                                unknown2: -1,
+                                sub_op_code: -1,
                                 stage_group_guid: minigame_status.stage_group_guid,
                             },
                             payload: format!(
@@ -1433,7 +1446,7 @@ fn handle_flash_payload(
                         inner: FlashPayload {
                             header: MinigameHeader {
                                 stage_guid: minigame_status.stage_guid,
-                                unknown2: -1,
+                                sub_op_code: -1,
                                 stage_group_guid: minigame_status.stage_group_guid,
                             },
                             payload: format!(
@@ -1504,7 +1517,7 @@ fn handle_flash_payload(
                             inner: FlashPayload {
                                 header: MinigameHeader {
                                     stage_guid: minigame_status.stage_guid,
-                                    unknown2: -1,
+                                    sub_op_code: -1,
                                     stage_group_guid: minigame_status.stage_group_guid,
                                 },
                                 payload: format!("OnShowEndRoundScreenMsg\t{}", awarded_credits),
@@ -1607,7 +1620,7 @@ pub fn create_active_minigame(
                     inner: ActiveMinigameCreationResult {
                         header: MinigameHeader {
                             stage_guid: minigame_status.stage_guid,
-                            unknown2: -1,
+                            sub_op_code: -1,
                             stage_group_guid: minigame_status.stage_group_guid,
                         },
                         was_successful: true,
@@ -1618,7 +1631,7 @@ pub fn create_active_minigame(
                     inner: CreateActiveMinigame {
                         header: MinigameHeader {
                             stage_guid: minigame_status.stage_guid,
-                            unknown2: -1,
+                            sub_op_code: -1,
                             stage_group_guid: minigame_status.stage_group_guid,
                         },
                         name_id: stage_config.name_id,
@@ -1740,7 +1753,7 @@ fn end_active_minigame(
                                     inner: FlashPayload {
                                         header: MinigameHeader {
                                             stage_guid: minigame_status.stage_guid,
-                                            unknown2: -1,
+                                            sub_op_code: -1,
                                             stage_group_guid: minigame_status.stage_group_guid,
                                         },
                                         payload: if minigame_status.game_won {
@@ -1755,7 +1768,7 @@ fn end_active_minigame(
                                     inner: ActiveMinigameEndScore {
                                         header: MinigameHeader {
                                             stage_guid,
-                                            unknown2: -1,
+                                            sub_op_code: -1,
                                             stage_group_guid: minigame_status.stage_group_guid,
                                         },
                                         scores: minigame_status.score_entries.clone(),
@@ -1767,7 +1780,7 @@ fn end_active_minigame(
                                     inner: UpdateActiveMinigameRewards {
                                         header: MinigameHeader {
                                             stage_guid: minigame_status.stage_guid,
-                                            unknown2: -1,
+                                            sub_op_code: -1,
                                             stage_group_guid: minigame_status.stage_group_guid,
                                         },
                                         reward_bundle1: RewardBundle {
@@ -1800,7 +1813,7 @@ fn end_active_minigame(
                                     inner: EndActiveMinigame {
                                         header: MinigameHeader {
                                             stage_guid: minigame_status.stage_guid,
-                                            unknown2: -1,
+                                            sub_op_code: -1,
                                             stage_group_guid: minigame_status.stage_group_guid,
                                         },
                                         won: minigame_status.game_won,
@@ -1814,7 +1827,7 @@ fn end_active_minigame(
                                     inner: LeaveActiveMinigame {
                                         header: MinigameHeader {
                                             stage_guid: minigame_status.stage_guid,
-                                            unknown2: -1,
+                                            sub_op_code: -1,
                                             stage_group_guid: minigame_status.stage_group_guid,
                                         },
                                     },

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -31,7 +31,7 @@ use crate::{
                 ScoreType, ShowStageInstanceSelect, StartActiveMinigame,
                 UpdateActiveMinigameRewards,
             },
-            saber_strike::SaberStrikeInit,
+            saber_strike::SaberStrikeStageData,
             tunnel::TunneledPacket,
             GamePacket, RewardBundle,
         },
@@ -1160,13 +1160,13 @@ fn handle_request_start_active_minigame(
                             let mut packets = vec![
                                 GamePacket::serialize(&TunneledPacket {
                                     unknown1: true,
-                                    inner: SaberStrikeInit {
+                                    inner: SaberStrikeStageData {
                                         minigame_header: MinigameHeader {
                                             stage_guid: minigame_status.stage_guid,
                                             sub_op_code: 1,
                                             stage_group_guid: minigame_status.stage_group_guid,
                                         },
-                                        stage_id: 1,
+                                        saber_strike_stage_id: 1,
                                         use_player_weapon: true,
                                     }
                                 })?,

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -1172,13 +1172,14 @@ fn handle_request_start_active_minigame(
                                 let mut stage_group_instance =
                                     game_server.minigames().stage_group_instance(minigame_status.stage_group_guid, player)?;
                                 stage_group_instance.header.stage_guid = minigame_status.stage_guid;
+                                // The default stage instance must be set for the how-to button the options menu to work
+                                stage_group_instance.default_stage_instance_guid = minigame_status.stage_guid;
 
                                 // Re-send the stage group instance to populate the stage data in the settings menu.
                                 // When we enter the Flash or 3D game HUD state, the current minigame group is cleared.
-                                // This removes the game name from the options menu and breaks the how-to button.
-                                // To avoid this, we need to send a script packet to transition the HUD to the
-                                // main state. Then we re-send the stage group instance data. Then we can load
-                                // the minigame.
+                                // This removes the game name from the options menu. To avoid this, we need to send a 
+                                // script packet to transition the HUD to the main state. Then we re-send the stage 
+                                // group instance data. Then we can load the minigame.
                                 packets.push(GamePacket::serialize(&TunneledPacket {
                                     unknown1: true,
                                     inner: ExecuteScriptWithParams {

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -106,6 +106,27 @@ pub enum MinigameType {
     SaberStrike { saber_strike_stage_id: u32 },
 }
 
+#[non_exhaustive]
+#[derive(Clone, Default)]
+pub enum MinigameTypeData {
+    #[default]
+    Empty,
+    SaberStrike {
+        obfuscated_score: i32,
+    },
+}
+
+impl From<&MinigameType> for MinigameTypeData {
+    fn from(value: &MinigameType) -> Self {
+        match value {
+            MinigameType::Flash { .. } => MinigameTypeData::default(),
+            MinigameType::SaberStrike { .. } => MinigameTypeData::SaberStrike {
+                obfuscated_score: 0,
+            },
+        }
+    }
+}
+
 #[derive(Deserialize)]
 pub struct MinigameStageConfig {
     pub guid: i32,
@@ -1056,6 +1077,7 @@ pub fn prepare_active_minigame_instance(
                                 total_score: 0,
                                 awarded_credits: 0,
                                 start_time: now,
+                                type_data: (&stage_config.stage_config.minigame_type).into(),
                             });
                             player.matchmaking_group = None;
                             Ok(())

--- a/src/game_server/handlers/mod.rs
+++ b/src/game_server/handlers/mod.rs
@@ -12,6 +12,7 @@ pub mod login;
 pub mod minigame;
 pub mod mount;
 pub mod reference_data;
+pub mod saber_strike;
 pub mod store;
 pub mod test_data;
 pub mod time;

--- a/src/game_server/handlers/saber_strike.rs
+++ b/src/game_server/handlers/saber_strike.rs
@@ -6,7 +6,9 @@ use crate::{
     game_server::{
         packets::{
             minigame::{MinigameHeader, ScoreEntry, ScoreType},
-            saber_strike::{SaberStrikeGameOver, SaberStrikeOpCode},
+            saber_strike::{
+                SaberStrikeGameOver, SaberStrikeOpCode, SaberStrikeSingleKill, SaberStrikeThrowKill,
+            },
         },
         Broadcast, GameServer, ProcessPacketError,
     },
@@ -26,6 +28,16 @@ pub fn process_saber_strike_packet(
             SaberStrikeOpCode::GameOver => {
                 let game_over = SaberStrikeGameOver::deserialize(cursor)?;
                 handle_saber_strike_game_over(&header, &game_over, sender, game_server)
+            }
+            SaberStrikeOpCode::SingleKill => {
+                let single_kill = SaberStrikeSingleKill::deserialize(cursor)?;
+                // TODO: update player achievement progress
+                Ok(Vec::new())
+            }
+            SaberStrikeOpCode::ThrowKill => {
+                let throw_kill = SaberStrikeThrowKill::deserialize(cursor)?;
+                // TODO: update player achievement progress
+                Ok(Vec::new())
             }
             _ => {
                 let mut buffer = Vec::new();

--- a/src/game_server/handlers/saber_strike.rs
+++ b/src/game_server/handlers/saber_strike.rs
@@ -1,0 +1,119 @@
+use std::io::{Cursor, Read};
+
+use packet_serialize::DeserializePacket;
+
+use crate::{
+    game_server::{
+        packets::{
+            minigame::{MinigameHeader, ScoreEntry, ScoreType},
+            saber_strike::{SaberStrikeGameOver, SaberStrikeOpCode},
+        },
+        Broadcast, GameServer, ProcessPacketError,
+    },
+    info,
+};
+
+use super::minigame::{end_active_minigame, handle_minigame_packet_write};
+
+pub fn process_saber_strike_packet(
+    cursor: &mut Cursor<&[u8]>,
+    sender: u32,
+    game_server: &GameServer,
+) -> Result<Vec<Broadcast>, ProcessPacketError> {
+    let header = MinigameHeader::deserialize(cursor)?;
+    match SaberStrikeOpCode::try_from(header.sub_op_code) {
+        Ok(op_code) => match op_code {
+            SaberStrikeOpCode::GameOver => {
+                let game_over = SaberStrikeGameOver::deserialize(cursor)?;
+                handle_minigame_packet_write(
+                    sender,
+                    game_server,
+                    &header,
+                    |minigame_status, minigame_stats, _, stage_config| {
+                        minigame_status.score_entries.push(ScoreEntry {
+                            entry_text: "lt_TotalTime".to_string(),
+                            icon_set_id: 0,
+                            score_type: ScoreType::Time,
+                            score_count: i32::try_from(game_over.duration_seconds.round() as i64)
+                                .unwrap_or_default(),
+                            score_max: 0,
+                            score_points: 0,
+                        });
+                        minigame_status.score_entries.push(ScoreEntry {
+                            entry_text: "lt_ThrowsRemaining".to_string(),
+                            icon_set_id: 0,
+                            score_type: ScoreType::Counter,
+                            score_count: game_over.remaining_sabers,
+                            score_max: 0,
+                            score_points: 0,
+                        });
+                        minigame_status.score_entries.push(ScoreEntry {
+                            entry_text: "lt_TotalDestroyed".to_string(),
+                            icon_set_id: 0,
+                            score_type: ScoreType::Counter,
+                            score_count: game_over.enemies_killed,
+                            score_max: 0,
+                            score_points: 0,
+                        });
+                        minigame_status.score_entries.push(ScoreEntry {
+                            entry_text: "lt_BestThrow".to_string(),
+                            icon_set_id: 0,
+                            score_type: ScoreType::Counter,
+                            score_count: game_over.best_throw,
+                            score_max: 0,
+                            score_points: 0,
+                        });
+                        minigame_status.score_entries.push(ScoreEntry {
+                            entry_text: "lt_TotalScore".to_string(),
+                            icon_set_id: 0,
+                            score_type: ScoreType::Total,
+                            score_count: game_over.score,
+                            score_max: 0,
+                            score_points: 0,
+                        });
+                        minigame_status.total_score = game_over.score;
+                        minigame_status.game_won = game_over.won;
+                        if game_over.won {
+                            minigame_stats
+                                .complete(stage_config.stage_config.guid, game_over.score);
+                        }
+                        Ok(())
+                    },
+                )?;
+
+                game_server.lock_enforcer().write_characters(
+                    |characters_table_write_handle, zones_lock_enforcer| {
+                        zones_lock_enforcer.write_zones(|zones_table_write_handle| {
+                            end_active_minigame(
+                                sender,
+                                characters_table_write_handle,
+                                zones_table_write_handle,
+                                header.stage_guid,
+                                false,
+                                game_server,
+                            )
+                        })
+                    },
+                )
+            }
+            _ => {
+                let mut buffer = Vec::new();
+                cursor.read_to_end(&mut buffer)?;
+                info!(
+                    "Unimplemented minigame op code: {:?} {:x?}",
+                    op_code, buffer
+                );
+                Ok(Vec::new())
+            }
+        },
+        Err(_) => {
+            let mut buffer = Vec::new();
+            cursor.read_to_end(&mut buffer)?;
+            info!(
+                "Unknown minigame packet: {}, {:x?}",
+                header.sub_op_code, buffer
+            );
+            Ok(Vec::new())
+        }
+    }
+}

--- a/src/game_server/handlers/saber_strike.rs
+++ b/src/game_server/handlers/saber_strike.rs
@@ -25,76 +25,7 @@ pub fn process_saber_strike_packet(
         Ok(op_code) => match op_code {
             SaberStrikeOpCode::GameOver => {
                 let game_over = SaberStrikeGameOver::deserialize(cursor)?;
-                handle_minigame_packet_write(
-                    sender,
-                    game_server,
-                    &header,
-                    |minigame_status, minigame_stats, _, stage_config| {
-                        minigame_status.score_entries.push(ScoreEntry {
-                            entry_text: "lt_TotalTime".to_string(),
-                            icon_set_id: 0,
-                            score_type: ScoreType::Time,
-                            score_count: i32::try_from(game_over.duration_seconds.round() as i64)
-                                .unwrap_or_default(),
-                            score_max: 0,
-                            score_points: 0,
-                        });
-                        minigame_status.score_entries.push(ScoreEntry {
-                            entry_text: "lt_ThrowsRemaining".to_string(),
-                            icon_set_id: 0,
-                            score_type: ScoreType::Counter,
-                            score_count: game_over.remaining_sabers,
-                            score_max: 0,
-                            score_points: 0,
-                        });
-                        minigame_status.score_entries.push(ScoreEntry {
-                            entry_text: "lt_TotalDestroyed".to_string(),
-                            icon_set_id: 0,
-                            score_type: ScoreType::Counter,
-                            score_count: game_over.enemies_killed,
-                            score_max: 0,
-                            score_points: 0,
-                        });
-                        minigame_status.score_entries.push(ScoreEntry {
-                            entry_text: "lt_BestThrow".to_string(),
-                            icon_set_id: 0,
-                            score_type: ScoreType::Counter,
-                            score_count: game_over.best_throw,
-                            score_max: 0,
-                            score_points: 0,
-                        });
-                        minigame_status.score_entries.push(ScoreEntry {
-                            entry_text: "lt_TotalScore".to_string(),
-                            icon_set_id: 0,
-                            score_type: ScoreType::Total,
-                            score_count: game_over.score,
-                            score_max: 0,
-                            score_points: 0,
-                        });
-                        minigame_status.total_score = game_over.score;
-                        minigame_status.game_won = game_over.won;
-                        if game_over.won {
-                            minigame_stats
-                                .complete(stage_config.stage_config.guid, game_over.score);
-                        }
-                        Ok(())
-                    },
-                )?;
-
-                game_server.lock_enforcer().write_characters(
-                    |characters_table_write_handle, zones_lock_enforcer| {
-                        zones_lock_enforcer.write_zones(|zones_table_write_handle| {
-                            end_active_minigame(
-                                sender,
-                                characters_table_write_handle,
-                                zones_table_write_handle,
-                                header.stage_guid,
-                                false,
-                                game_server,
-                            )
-                        })
-                    },
-                )
+                handle_saber_strike_game_over(&header, &game_over, sender, game_server)
             }
             _ => {
                 let mut buffer = Vec::new();
@@ -116,4 +47,81 @@ pub fn process_saber_strike_packet(
             Ok(Vec::new())
         }
     }
+}
+
+fn handle_saber_strike_game_over(
+    header: &MinigameHeader,
+    game_over: &SaberStrikeGameOver,
+    sender: u32,
+    game_server: &GameServer,
+) -> Result<Vec<Broadcast>, ProcessPacketError> {
+    handle_minigame_packet_write(
+        sender,
+        game_server,
+        header,
+        |minigame_status, minigame_stats, _, stage_config| {
+            minigame_status.score_entries.push(ScoreEntry {
+                entry_text: "lt_TotalTime".to_string(),
+                icon_set_id: 0,
+                score_type: ScoreType::Time,
+                score_count: i32::try_from(game_over.duration_seconds.round() as i64)
+                    .unwrap_or_default(),
+                score_max: 0,
+                score_points: 0,
+            });
+            minigame_status.score_entries.push(ScoreEntry {
+                entry_text: "lt_ThrowsRemaining".to_string(),
+                icon_set_id: 0,
+                score_type: ScoreType::Counter,
+                score_count: game_over.remaining_sabers,
+                score_max: 0,
+                score_points: 0,
+            });
+            minigame_status.score_entries.push(ScoreEntry {
+                entry_text: "lt_TotalDestroyed".to_string(),
+                icon_set_id: 0,
+                score_type: ScoreType::Counter,
+                score_count: game_over.enemies_killed,
+                score_max: 0,
+                score_points: 0,
+            });
+            minigame_status.score_entries.push(ScoreEntry {
+                entry_text: "lt_BestThrow".to_string(),
+                icon_set_id: 0,
+                score_type: ScoreType::Counter,
+                score_count: game_over.best_throw,
+                score_max: 0,
+                score_points: 0,
+            });
+            minigame_status.score_entries.push(ScoreEntry {
+                entry_text: "lt_TotalScore".to_string(),
+                icon_set_id: 0,
+                score_type: ScoreType::Total,
+                score_count: game_over.score,
+                score_max: 0,
+                score_points: 0,
+            });
+            minigame_status.total_score = game_over.score;
+            minigame_status.game_won = game_over.won;
+            if game_over.won {
+                minigame_stats.complete(stage_config.stage_config.guid, game_over.score);
+            }
+            Ok(())
+        },
+    )?;
+
+    game_server.lock_enforcer().write_characters(
+        |characters_table_write_handle, zones_lock_enforcer| {
+            zones_lock_enforcer.write_zones(|zones_table_write_handle| {
+                end_active_minigame(
+                    sender,
+                    characters_table_write_handle,
+                    zones_table_write_handle,
+                    header.stage_guid,
+                    false,
+                    game_server,
+                )
+            })
+        },
+    )
 }

--- a/src/game_server/packets/minigame.rs
+++ b/src/game_server/packets/minigame.rs
@@ -23,6 +23,7 @@ pub enum MinigameOpCode {
     RequestMinigameStageGroupInstance = 0x31,
     CreateMinigameStageGroupInstance = 0x33,
     ShowStageInstanceSelect = 0x34,
+    SaberStrike = 0x39,
     ActiveMinigameCreationResult = 0x44,
 }
 
@@ -37,7 +38,7 @@ impl SerializePacket for MinigameOpCode {
 #[derive(SerializePacket, DeserializePacket)]
 pub struct MinigameHeader {
     pub stage_guid: i32,
-    pub unknown2: i32,
+    pub sub_op_code: i32,
     pub stage_group_guid: i32,
 }
 

--- a/src/game_server/packets/mod.rs
+++ b/src/game_server/packets/mod.rs
@@ -12,6 +12,7 @@ pub mod player_data;
 pub mod player_update;
 pub mod purchase;
 pub mod reference_data;
+pub mod saber_strike;
 pub mod squad;
 pub mod store;
 pub mod time;

--- a/src/game_server/packets/saber_strike.rs
+++ b/src/game_server/packets/saber_strike.rs
@@ -39,11 +39,13 @@ pub struct SaberStrikeGameOver {
     pub remaining_sabers: i32,
 }
 
+#[allow(dead_code)]
 #[derive(DeserializePacket)]
 pub struct SaberStrikeSingleKill {
     pub enemy_type: u32,
 }
 
+#[allow(dead_code)]
 #[derive(DeserializePacket)]
 pub struct SaberStrikeThrowKill {
     pub enemies_killed: u32,

--- a/src/game_server/packets/saber_strike.rs
+++ b/src/game_server/packets/saber_strike.rs
@@ -32,7 +32,7 @@ impl GamePacket for SaberStrikeStageData {
 #[derive(DeserializePacket)]
 pub struct SaberStrikeGameOver {
     pub won: bool,
-    pub score: i32,
+    pub total_score: i32,
     pub best_throw: i32,
     pub enemies_killed: i32,
     pub duration_seconds: f32,
@@ -53,12 +53,12 @@ pub struct SaberStrikeThrowKill {
 
 #[derive(DeserializePacket)]
 pub struct SaberStrikeObfuscatedScore {
-    seed: u32,
-    obfuscated_score: u32,
+    seed: i32,
+    obfuscated_score: i32,
 }
 
 impl SaberStrikeObfuscatedScore {
-    pub fn score(&self) -> u32 {
+    pub fn score(&self) -> i32 {
         self.obfuscated_score ^ self.seed.rotate_right(1)
     }
 }
@@ -89,8 +89,8 @@ mod tests {
     fn test_large_score() {
         let obfuscated_score = SaberStrikeObfuscatedScore {
             seed: 0x113bf61a,
-            obfuscated_score: 0xf76204f2,
+            obfuscated_score: 0x776204f2,
         };
-        assert_eq!(obfuscated_score.score(), u32::MAX)
+        assert_eq!(obfuscated_score.score(), i32::MAX)
     }
 }

--- a/src/game_server/packets/saber_strike.rs
+++ b/src/game_server/packets/saber_strike.rs
@@ -13,6 +13,10 @@ pub enum SaberStrikeOpCode {
     GameOver = 0x2,
     SingleKill = 0x3,
     ThrowKill = 0x4,
+    ExtraSabersBoost = 0x5,
+    DemagnetizeWallsBoost = 0x6,
+    ReducedGoalBoost = 0x7,
+    EnableTrajectoryBoost = 0x8,
     ObfuscatedScore = 0x9,
 }
 
@@ -49,6 +53,28 @@ pub struct SaberStrikeSingleKill {
 #[derive(DeserializePacket)]
 pub struct SaberStrikeThrowKill {
     pub enemies_killed: u32,
+}
+
+#[derive(DeserializePacket)]
+pub struct ExtraSabersBoost {
+    pub minigame_header: MinigameHeader,
+    pub sabers: u32,
+}
+
+#[derive(DeserializePacket)]
+pub struct DemagnetizeWallsBoost {
+    pub minigame_header: MinigameHeader,
+}
+
+#[derive(DeserializePacket)]
+pub struct ReducedGoalBoost {
+    pub minigame_header: MinigameHeader,
+    pub goal_deduction: u32,
+}
+
+#[derive(DeserializePacket)]
+pub struct EnableTrajectoryBoost {
+    pub minigame_header: MinigameHeader,
 }
 
 #[derive(DeserializePacket)]

--- a/src/game_server/packets/saber_strike.rs
+++ b/src/game_server/packets/saber_strike.rs
@@ -31,6 +31,7 @@ impl GamePacket for SaberStrikeStageData {
 
 #[derive(SerializePacket, DeserializePacket)]
 pub struct SaberStrikeGameOver {
+    pub minigame_header: MinigameHeader,
     pub won: bool,
     pub score: u32,
     pub best_throw: u32,

--- a/src/game_server/packets/saber_strike.rs
+++ b/src/game_server/packets/saber_strike.rs
@@ -1,3 +1,4 @@
+use num_enum::TryFromPrimitive;
 use packet_serialize::{DeserializePacket, SerializePacket};
 
 use super::{
@@ -5,14 +6,20 @@ use super::{
     GamePacket,
 };
 
+#[derive(Copy, Clone, Debug, TryFromPrimitive)]
+#[repr(i32)]
+pub enum SaberStrikeOpCode {
+    StageData = 0x1,
+}
+
 #[derive(SerializePacket, DeserializePacket)]
-pub struct SaberStrikeInit {
+pub struct SaberStrikeStageData {
     pub minigame_header: MinigameHeader,
-    pub stage_id: u32,
+    pub saber_strike_stage_id: u32,
     pub use_player_weapon: bool,
 }
 
-impl GamePacket for SaberStrikeInit {
+impl GamePacket for SaberStrikeStageData {
     type Header = MinigameOpCode;
 
     const HEADER: Self::Header = MinigameOpCode::SaberStrike;

--- a/src/game_server/packets/saber_strike.rs
+++ b/src/game_server/packets/saber_strike.rs
@@ -64,6 +64,6 @@ impl GamePacket for SaberStrikeObfuscatedScore {
 
 impl SaberStrikeObfuscatedScore {
     pub fn score(&self) -> u32 {
-        self.obfuscated_score ^ self.seed - ror(self.seed, 1)
+        (self.obfuscated_score ^ self.seed) - ror(self.seed, 1)
     }
 }

--- a/src/game_server/packets/saber_strike.rs
+++ b/src/game_server/packets/saber_strike.rs
@@ -60,7 +60,7 @@ impl GamePacket for SaberStrikeSingleKill {
 #[derive(SerializePacket, DeserializePacket)]
 pub struct SaberStrikeThrowKill {
     pub minigame_header: MinigameHeader,
-    pub enemy_count: u32,
+    pub enemies_killed: u32,
 }
 
 impl GamePacket for SaberStrikeThrowKill {

--- a/src/game_server/packets/saber_strike.rs
+++ b/src/game_server/packets/saber_strike.rs
@@ -11,6 +11,8 @@ use super::{
 pub enum SaberStrikeOpCode {
     StageData = 0x1,
     GameOver = 0x2,
+    SingleKill = 0x3,
+    ThrowKill = 0x4,
     ObfuscatedScore = 0x9,
 }
 
@@ -38,6 +40,30 @@ pub struct SaberStrikeGameOver {
 }
 
 impl GamePacket for SaberStrikeGameOver {
+    type Header = MinigameOpCode;
+
+    const HEADER: Self::Header = MinigameOpCode::SaberStrike;
+}
+
+#[derive(SerializePacket, DeserializePacket)]
+pub struct SaberStrikeSingleKill {
+    pub minigame_header: MinigameHeader,
+    pub enemy_type: u32,
+}
+
+impl GamePacket for SaberStrikeSingleKill {
+    type Header = MinigameOpCode;
+
+    const HEADER: Self::Header = MinigameOpCode::SaberStrike;
+}
+
+#[derive(SerializePacket, DeserializePacket)]
+pub struct SaberStrikeThrowKill {
+    pub minigame_header: MinigameHeader,
+    pub enemy_count: u32,
+}
+
+impl GamePacket for SaberStrikeThrowKill {
     type Header = MinigameOpCode;
 
     const HEADER: Self::Header = MinigameOpCode::SaberStrike;

--- a/src/game_server/packets/saber_strike.rs
+++ b/src/game_server/packets/saber_strike.rs
@@ -64,6 +64,6 @@ impl GamePacket for SaberStrikeObfuscatedScore {
 
 impl SaberStrikeObfuscatedScore {
     pub fn score(&self) -> u32 {
-        (self.obfuscated_score ^ self.seed) - ror(self.seed, 1)
+        self.obfuscated_score ^ ror(self.seed, 1)
     }
 }

--- a/src/game_server/packets/saber_strike.rs
+++ b/src/game_server/packets/saber_strike.rs
@@ -9,7 +9,7 @@ use super::{
 pub struct SaberStrikeInit {
     pub minigame_header: MinigameHeader,
     pub stage_id: u32,
-    pub disable_default_saber: bool,
+    pub use_player_weapon: bool,
 }
 
 impl GamePacket for SaberStrikeInit {

--- a/src/game_server/packets/saber_strike.rs
+++ b/src/game_server/packets/saber_strike.rs
@@ -8,8 +8,8 @@ use super::{
 #[derive(SerializePacket, DeserializePacket)]
 pub struct SaberStrikeInit {
     pub minigame_header: MinigameHeader,
-    pub unknown1: u32,
-    pub unknown2: bool,
+    pub stage_id: u32,
+    pub disable_default_saber: bool,
 }
 
 impl GamePacket for SaberStrikeInit {

--- a/src/game_server/packets/saber_strike.rs
+++ b/src/game_server/packets/saber_strike.rs
@@ -32,11 +32,11 @@ impl GamePacket for SaberStrikeStageData {
 #[derive(DeserializePacket)]
 pub struct SaberStrikeGameOver {
     pub won: bool,
-    pub score: u32,
-    pub best_throw: u32,
-    pub enemies_killed: u32,
+    pub score: i32,
+    pub best_throw: i32,
+    pub enemies_killed: i32,
     pub duration_seconds: f32,
-    pub remaining_sabers: u32,
+    pub remaining_sabers: i32,
 }
 
 #[derive(DeserializePacket)]

--- a/src/game_server/packets/saber_strike.rs
+++ b/src/game_server/packets/saber_strike.rs
@@ -55,26 +55,50 @@ pub struct SaberStrikeThrowKill {
     pub enemies_killed: u32,
 }
 
-#[derive(DeserializePacket)]
+#[derive(SerializePacket, DeserializePacket)]
 pub struct ExtraSabersBoost {
     pub minigame_header: MinigameHeader,
     pub sabers: u32,
 }
 
-#[derive(DeserializePacket)]
+impl GamePacket for ExtraSabersBoost {
+    type Header = MinigameOpCode;
+
+    const HEADER: Self::Header = MinigameOpCode::SaberStrike;
+}
+
+#[derive(SerializePacket, DeserializePacket)]
 pub struct DemagnetizeWallsBoost {
     pub minigame_header: MinigameHeader,
 }
 
-#[derive(DeserializePacket)]
+impl GamePacket for DemagnetizeWallsBoost {
+    type Header = MinigameOpCode;
+
+    const HEADER: Self::Header = MinigameOpCode::SaberStrike;
+}
+
+#[derive(SerializePacket, DeserializePacket)]
 pub struct ReducedGoalBoost {
     pub minigame_header: MinigameHeader,
     pub goal_deduction: u32,
 }
 
-#[derive(DeserializePacket)]
+impl GamePacket for ReducedGoalBoost {
+    type Header = MinigameOpCode;
+
+    const HEADER: Self::Header = MinigameOpCode::SaberStrike;
+}
+
+#[derive(SerializePacket, DeserializePacket)]
 pub struct EnableTrajectoryBoost {
     pub minigame_header: MinigameHeader,
+}
+
+impl GamePacket for EnableTrajectoryBoost {
+    type Header = MinigameOpCode;
+
+    const HEADER: Self::Header = MinigameOpCode::SaberStrike;
 }
 
 #[derive(DeserializePacket)]

--- a/src/game_server/packets/saber_strike.rs
+++ b/src/game_server/packets/saber_strike.rs
@@ -1,0 +1,19 @@
+use packet_serialize::{DeserializePacket, SerializePacket};
+
+use super::{
+    minigame::{MinigameHeader, MinigameOpCode},
+    GamePacket,
+};
+
+#[derive(SerializePacket, DeserializePacket)]
+pub struct SaberStrikeInit {
+    pub minigame_header: MinigameHeader,
+    pub unknown1: u32,
+    pub unknown2: bool,
+}
+
+impl GamePacket for SaberStrikeInit {
+    type Header = MinigameOpCode;
+
+    const HEADER: Self::Header = MinigameOpCode::SaberStrike;
+}

--- a/src/game_server/packets/saber_strike.rs
+++ b/src/game_server/packets/saber_strike.rs
@@ -10,6 +10,8 @@ use super::{
 #[repr(i32)]
 pub enum SaberStrikeOpCode {
     StageData = 0x1,
+    GameOver = 0x2,
+    ObfuscatedScore = 0x9,
 }
 
 #[derive(SerializePacket, DeserializePacket)]
@@ -23,4 +25,45 @@ impl GamePacket for SaberStrikeStageData {
     type Header = MinigameOpCode;
 
     const HEADER: Self::Header = MinigameOpCode::SaberStrike;
+}
+
+#[derive(SerializePacket, DeserializePacket)]
+pub struct SaberStrikeGameOver {
+    pub won: bool,
+    pub score: u32,
+    pub best_throw: u32,
+    pub enemies_killed: u32,
+    pub duration_seconds: f32,
+    pub remaining_sabers: u32,
+}
+
+impl GamePacket for SaberStrikeGameOver {
+    type Header = MinigameOpCode;
+
+    const HEADER: Self::Header = MinigameOpCode::SaberStrike;
+}
+
+fn ror(x: u32, bits: u8) -> u32 {
+    let right_shift = (bits as u32) % u32::BITS;
+    let left_shift = 32 - right_shift;
+    (x >> right_shift) | (x << left_shift)
+}
+
+#[derive(SerializePacket, DeserializePacket)]
+pub struct SaberStrikeObfuscatedScore {
+    pub minigame_header: MinigameHeader,
+    seed: u32,
+    obfuscated_score: u32,
+}
+
+impl GamePacket for SaberStrikeObfuscatedScore {
+    type Header = MinigameOpCode;
+
+    const HEADER: Self::Header = MinigameOpCode::SaberStrike;
+}
+
+impl SaberStrikeObfuscatedScore {
+    pub fn score(&self) -> u32 {
+        self.obfuscated_score ^ self.seed - ror(self.seed, 1)
+    }
 }

--- a/src/game_server/packets/saber_strike.rs
+++ b/src/game_server/packets/saber_strike.rs
@@ -29,9 +29,8 @@ impl GamePacket for SaberStrikeStageData {
     const HEADER: Self::Header = MinigameOpCode::SaberStrike;
 }
 
-#[derive(SerializePacket, DeserializePacket)]
+#[derive(DeserializePacket)]
 pub struct SaberStrikeGameOver {
-    pub minigame_header: MinigameHeader,
     pub won: bool,
     pub score: u32,
     pub best_throw: u32,
@@ -40,47 +39,20 @@ pub struct SaberStrikeGameOver {
     pub remaining_sabers: u32,
 }
 
-impl GamePacket for SaberStrikeGameOver {
-    type Header = MinigameOpCode;
-
-    const HEADER: Self::Header = MinigameOpCode::SaberStrike;
-}
-
-#[derive(SerializePacket, DeserializePacket)]
+#[derive(DeserializePacket)]
 pub struct SaberStrikeSingleKill {
-    pub minigame_header: MinigameHeader,
     pub enemy_type: u32,
 }
 
-impl GamePacket for SaberStrikeSingleKill {
-    type Header = MinigameOpCode;
-
-    const HEADER: Self::Header = MinigameOpCode::SaberStrike;
-}
-
-#[derive(SerializePacket, DeserializePacket)]
+#[derive(DeserializePacket)]
 pub struct SaberStrikeThrowKill {
-    pub minigame_header: MinigameHeader,
     pub enemies_killed: u32,
 }
 
-impl GamePacket for SaberStrikeThrowKill {
-    type Header = MinigameOpCode;
-
-    const HEADER: Self::Header = MinigameOpCode::SaberStrike;
-}
-
-#[derive(SerializePacket, DeserializePacket)]
+#[derive(DeserializePacket)]
 pub struct SaberStrikeObfuscatedScore {
-    pub minigame_header: MinigameHeader,
     seed: u32,
     obfuscated_score: u32,
-}
-
-impl GamePacket for SaberStrikeObfuscatedScore {
-    type Header = MinigameOpCode;
-
-    const HEADER: Self::Header = MinigameOpCode::SaberStrike;
 }
 
 impl SaberStrikeObfuscatedScore {
@@ -96,11 +68,6 @@ mod tests {
     #[test]
     fn test_score_zero() {
         let obfuscated_score = SaberStrikeObfuscatedScore {
-            minigame_header: MinigameHeader {
-                stage_guid: -1,
-                sub_op_code: -1,
-                stage_group_guid: -1,
-            },
             seed: 0x113bf61a,
             obfuscated_score: 0x89dfb0d,
         };
@@ -110,11 +77,6 @@ mod tests {
     #[test]
     fn test_small_score() {
         let obfuscated_score = SaberStrikeObfuscatedScore {
-            minigame_header: MinigameHeader {
-                stage_guid: -1,
-                sub_op_code: -1,
-                stage_group_guid: -1,
-            },
             seed: 0x113bf61a,
             obfuscated_score: 0x89de5f7,
         };
@@ -124,11 +86,6 @@ mod tests {
     #[test]
     fn test_large_score() {
         let obfuscated_score = SaberStrikeObfuscatedScore {
-            minigame_header: MinigameHeader {
-                stage_guid: -1,
-                sub_op_code: -1,
-                stage_group_guid: -1,
-            },
             seed: 0x113bf61a,
             obfuscated_score: 0xf76204f2,
         };


### PR DESCRIPTION
* Add all levels of Saber Strike.
* Implement a rudimentary anticheat for Saber Strike only. The server compares the obfuscated score to the actual score sent in the `GameOver` packet.
  * This isn't particularly effective because clients can just modify the obfuscated packet, but we believe this anticheat mechanism existed in the OG and can prevent some basic cheating attempts.
* Add support for minigame-specific data in config and at runtime.
* Marked Saber Strike as a popular game and unmarked Rocket Rescue as popular.