### PR TITLE
Update matchmaking status when leaving

### DIFF
--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -1293,6 +1293,7 @@ impl NpcTemplate {
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum MatchmakingGroupStatus {
+    Closed,
     OpenToAll,
     OpenToFriends,
 }


### PR DESCRIPTION
* Introduce a new `Closed` status for matchmaking groups. This will be used to track players in the same minigame group who have already started the game.
* Update the matchmaking group when leaving the game.
  * Checking the minimum players requirement will be implemented in a separate PR.