### PR TITLE
Don't disconnect on `ProcessPacketError`, reduce log spam

### DIFF
--- a/src/game_server/handlers/chat.rs
+++ b/src/game_server/handlers/chat.rs
@@ -3,16 +3,13 @@ use std::io::{Cursor, Read};
 use byteorder::{LittleEndian, ReadBytesExt};
 use packet_serialize::DeserializePacket;
 
-use crate::{
-    game_server::{
-        packets::{
-            chat::{ChatOpCode, MessageTypeData, SendMessage},
-            tunnel::TunneledPacket,
-            GamePacket,
-        },
-        Broadcast, GameServer, ProcessPacketError, ProcessPacketErrorType,
+use crate::game_server::{
+    packets::{
+        chat::{ChatOpCode, MessageTypeData, SendMessage},
+        tunnel::TunneledPacket,
+        GamePacket,
     },
-    info,
+    Broadcast, GameServer, ProcessPacketError, ProcessPacketErrorType,
 };
 
 use super::{
@@ -157,8 +154,10 @@ pub fn process_chat_packet(
             _ => {
                 let mut buffer = Vec::new();
                 cursor.read_to_end(&mut buffer)?;
-                info!("Unimplemented: {:?}, {:x?}", op_code, buffer);
-                Ok(Vec::new())
+                Err(ProcessPacketError::new(
+                    ProcessPacketErrorType::UnknownOpCode,
+                    format!("Unimplemented chat op code: {:?}, {:x?}", op_code, buffer),
+                ))
             }
         },
         Err(_) => Err(ProcessPacketError::new(

--- a/src/game_server/handlers/command.rs
+++ b/src/game_server/handlers/command.rs
@@ -3,12 +3,9 @@ use std::io::Cursor;
 use byteorder::{LittleEndian, ReadBytesExt};
 use packet_serialize::DeserializePacket;
 
-use crate::{
-    game_server::{
-        packets::command::{CommandOpCode, SelectPlayer},
-        Broadcast, GameServer, ProcessPacketError,
-    },
-    info,
+use crate::game_server::{
+    packets::command::{CommandOpCode, SelectPlayer},
+    Broadcast, GameServer, ProcessPacketError, ProcessPacketErrorType,
 };
 
 use super::zone::interact_with_character;
@@ -24,14 +21,14 @@ pub fn process_command(
                 let req = SelectPlayer::deserialize(cursor)?;
                 interact_with_character(req, game_server)
             }
-            _ => {
-                info!("Unimplemented command: {:?}", op_code);
-                Ok(Vec::new())
-            }
+            _ => Err(ProcessPacketError::new(
+                ProcessPacketErrorType::UnknownOpCode,
+                format!("Unimplemented command: {:?}", op_code),
+            )),
         },
-        Err(_) => {
-            info!("Unknown command: {}", raw_op_code);
-            Ok(Vec::new())
-        }
+        Err(_) => Err(ProcessPacketError::new(
+            ProcessPacketErrorType::UnknownOpCode,
+            format!("Unknown command: {}", raw_op_code),
+        )),
     }
 }

--- a/src/game_server/handlers/housing.rs
+++ b/src/game_server/handlers/housing.rs
@@ -468,15 +468,19 @@ pub fn process_housing_packet(
             _ => {
                 let mut buffer = Vec::new();
                 cursor.read_to_end(&mut buffer)?;
-                info!("Unimplemented housing packet: {:?}, {:x?}", op_code, buffer);
-                Ok(Vec::new())
+                Err(ProcessPacketError::new(
+                    ProcessPacketErrorType::UnknownOpCode,
+                    format!("Unimplemented housing packet: {:?}, {:x?}", op_code, buffer),
+                ))
             }
         },
         Err(_) => {
             let mut buffer = Vec::new();
             cursor.read_to_end(&mut buffer)?;
-            info!("Unknown housing packet: {}, {:x?}", raw_op_code, buffer);
-            Ok(Vec::new())
+            Err(ProcessPacketError::new(
+                ProcessPacketErrorType::UnknownOpCode,
+                format!("Unknown housing packet: {}, {:x?}", raw_op_code, buffer),
+            ))
         }
     }
 }

--- a/src/game_server/handlers/inventory.rs
+++ b/src/game_server/handlers/inventory.rs
@@ -93,10 +93,10 @@ pub fn process_inventory_packet(
                 process_equip_customization(game_server, cursor, sender)
             }
         },
-        Err(_) => {
-            info!("Unknown inventory packet: {}, {:x?}", raw_op_code, cursor);
-            Ok(Vec::new())
-        }
+        Err(_) => Err(ProcessPacketError::new(
+            ProcessPacketErrorType::UnknownOpCode,
+            format!("Unknown inventory packet: {}, {:x?}", raw_op_code, cursor),
+        )),
     }
 }
 
@@ -462,7 +462,7 @@ fn process_equip_customization(
                         };
 
                         if cost > player.credits {
-                            return Ok(vec![]);
+                            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} tried to purchase customization {} for {} but only has {} credits", sender, equip_customization.item_guid, cost, player.credits)));
                         }
                         player.credits -= cost;
                         let new_credits = player.credits;

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -1597,12 +1597,10 @@ pub fn handle_minigame_packet_write<T: Default>(
                                 Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to process Flash payload for {}'s active minigame with stage config {} (stage group {}) that does not exist", sender, minigame_status.stage_guid, minigame_status.stage_group_guid)))
                             }
                         } else {
-                            info!("Tried to process packet for {}'s active minigame (stage {}), but they're in a different minigame (stage group {}, stage {})", sender, header.stage_guid, minigame_status.stage_group_guid, minigame_status.stage_guid);
-                            Ok(T::default())
+                            Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to process packet for {}'s active minigame (stage {}), but they're in a different minigame (stage group {}, stage {})", sender, header.stage_guid, minigame_status.stage_group_guid, minigame_status.stage_guid)))
                         }
                     } else {
-                        info!("Tried to process packet for {}'s active minigame (stage {}), but they aren't in an active minigame", sender, header.stage_guid);
-                        Ok(T::default())
+                        Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to process packet for {}'s active minigame (stage {}), but they aren't in an active minigame", sender, header.stage_guid)))
                     }
                 } else {
                     Err(ProcessPacketError::new(
@@ -1648,12 +1646,10 @@ fn handle_flash_payload_read_only<T: Default>(
                                 Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to process Flash payload for {}'s active minigame with stage config {} (stage group {}) that does not exist", sender, minigame_status.stage_guid, minigame_status.stage_group_guid)))
                             }
                         } else {
-                            info!("Tried to process Flash payload for {}'s active minigame (stage {}), but they're in a different minigame (stage group {}, stage {})", sender, header.stage_guid, minigame_status.stage_group_guid, minigame_status.stage_guid);
-                            Ok(T::default())
+                            Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to process Flash payload for {}'s active minigame (stage {}), but they're in a different minigame (stage group {}, stage {})", sender, header.stage_guid, minigame_status.stage_group_guid, minigame_status.stage_guid)))
                         }
                     } else {
-                        info!("Tried to process Flash payload for {}'s active minigame (stage {}), but they aren't in an active minigame", sender, header.stage_guid);
-                        Ok(T::default())
+                        Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to process Flash payload for {}'s active minigame (stage {}), but they aren't in an active minigame", sender, header.stage_guid)))
                     }
                 } else {
                     Err(ProcessPacketError::new(

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -962,18 +962,22 @@ pub fn process_minigame_packet(
             _ => {
                 let mut buffer = Vec::new();
                 cursor.read_to_end(&mut buffer)?;
-                info!(
-                    "Unimplemented minigame op code: {:?} {:x?}",
-                    op_code, buffer
-                );
-                Ok(Vec::new())
+                Err(ProcessPacketError::new(
+                    ProcessPacketErrorType::UnknownOpCode,
+                    format!(
+                        "Unimplemented minigame op code: {:?} {:x?}",
+                        op_code, buffer
+                    ),
+                ))
             }
         },
         Err(_) => {
             let mut buffer = Vec::new();
             cursor.read_to_end(&mut buffer)?;
-            info!("Unknown minigame packet: {}, {:x?}", raw_op_code, buffer);
-            Ok(Vec::new())
+            Err(ProcessPacketError::new(
+                ProcessPacketErrorType::UnknownOpCode,
+                format!("Unknown minigame packet: {}, {:x?}", raw_op_code, buffer),
+            ))
         }
     }
 }
@@ -1526,12 +1530,10 @@ fn handle_request_start_active_minigame(
                                 Broadcast::Single(sender, packets)
                             ])
                         } else {
-                            info!("Player {} requested to start an active minigame (stage {}), but they're in a different minigame (stage group {}, stage {})", sender, request.header.stage_guid, minigame_status.stage_group_guid, minigame_status.stage_guid);
-                            Ok(vec![])
+                            Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} requested to start an active minigame (stage {}), but they're in a different minigame (stage group {}, stage {})", sender, request.header.stage_guid, minigame_status.stage_group_guid, minigame_status.stage_guid)))
                         }
                     } else {
-                        info!("Player {} requested to start an active minigame (stage {}), but they aren't in an active minigame", sender, request.header.stage_guid);
-                        Ok(vec![])
+                        Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} requested to start an active minigame (stage {}), but they aren't in an active minigame", sender, request.header.stage_guid)))
                     }
                 } else {
                     Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} requested to start an active minigame, but their character isn't a player", sender)))
@@ -1898,13 +1900,13 @@ fn handle_flash_payload(
                 }
             },
         ),
-        _ => {
-            info!(
+        _ => Err(ProcessPacketError::new(
+            ProcessPacketErrorType::ConstraintViolated,
+            format!(
                 "Received unknown Flash payload {} in stage {}, stage group {} from player {}",
                 payload.payload, payload.header.stage_guid, payload.header.stage_group_guid, sender
-            );
-            Ok(vec![])
-        }
+            ),
+        )),
     }
 }
 
@@ -2162,12 +2164,10 @@ pub fn end_active_minigame(
                             Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to end player {}'s active minigame with stage config {} (stage group {}) that does not exist", sender, minigame_status.stage_guid, minigame_status.stage_group_guid)))
                         }
                     } else {
-                        info!("Tried to end player {}'s active minigame (stage {}), but they're in a different minigame (stage group {}, stage {})", sender, stage_guid, minigame_status.stage_group_guid, minigame_status.stage_guid);
-                        Ok((vec![], previous_location, true))
+                        Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to end player {}'s active minigame (stage {}), but they're in a different minigame (stage group {}, stage {})", sender, stage_guid, minigame_status.stage_group_guid, minigame_status.stage_guid)))
                     }
                 } else {
-                    info!("Tried to end player {}'s active minigame (stage {}), but they aren't in an active minigame", sender, stage_guid);
-                    Ok((vec![], previous_location, true))
+                    Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to end player {}'s active minigame (stage {}), but they aren't in an active minigame", sender, stage_guid)))
                 }
             } else {
                 Err(ProcessPacketError::new(

--- a/src/game_server/handlers/mount.rs
+++ b/src/game_server/handlers/mount.rs
@@ -329,10 +329,10 @@ pub fn process_mount_packet(
         Ok(op_code) => match op_code {
             MountOpCode::DismountRequest => process_dismount(sender, game_server),
             MountOpCode::MountSpawn => process_mount_spawn(cursor, sender, game_server),
-            _ => {
-                info!("Unimplemented mount op code: {:?}", op_code);
-                Ok(Vec::new())
-            }
+            _ => Err(ProcessPacketError::new(
+                ProcessPacketErrorType::UnknownOpCode,
+                format!("Unimplemented mount op code: {:?}", op_code),
+            )),
         },
         Err(_) => Err(ProcessPacketError::new(
             ProcessPacketErrorType::UnknownOpCode,

--- a/src/game_server/handlers/mount.rs
+++ b/src/game_server/handlers/mount.rs
@@ -10,19 +10,16 @@ use packet_serialize::DeserializePacket;
 use parking_lot::{RwLockReadGuard, RwLockWriteGuard};
 use serde::Deserialize;
 
-use crate::{
-    game_server::{
-        packets::{
-            client_update::{Stat, StatId, Stats},
-            item::{BaseAttachmentGroup, WieldType},
-            mount::{DismountReply, MountOpCode, MountReply, MountSpawn},
-            player_update::{AddNpc, Hostility, Icon, RemoveGracefully, UpdateSpeed},
-            tunnel::TunneledPacket,
-            Effect, GamePacket, Pos, Target,
-        },
-        Broadcast, GameServer, ProcessPacketError, ProcessPacketErrorType,
+use crate::game_server::{
+    packets::{
+        client_update::{Stat, StatId, Stats},
+        item::{BaseAttachmentGroup, WieldType},
+        mount::{DismountReply, MountOpCode, MountReply, MountSpawn},
+        player_update::{AddNpc, Hostility, Icon, RemoveGracefully, UpdateSpeed},
+        tunnel::TunneledPacket,
+        Effect, GamePacket, Pos, Target,
     },
-    info,
+    Broadcast, GameServer, ProcessPacketError, ProcessPacketErrorType,
 };
 
 use super::{

--- a/src/game_server/handlers/saber_strike.rs
+++ b/src/game_server/handlers/saber_strike.rs
@@ -2,18 +2,15 @@ use std::io::{Cursor, Read};
 
 use packet_serialize::DeserializePacket;
 
-use crate::{
-    game_server::{
-        packets::{
-            minigame::{MinigameHeader, ScoreEntry, ScoreType},
-            saber_strike::{
-                SaberStrikeGameOver, SaberStrikeObfuscatedScore, SaberStrikeOpCode,
-                SaberStrikeSingleKill, SaberStrikeThrowKill,
-            },
+use crate::game_server::{
+    packets::{
+        minigame::{MinigameHeader, ScoreEntry, ScoreType},
+        saber_strike::{
+            SaberStrikeGameOver, SaberStrikeObfuscatedScore, SaberStrikeOpCode,
+            SaberStrikeSingleKill, SaberStrikeThrowKill,
         },
-        Broadcast, GameServer, ProcessPacketError, ProcessPacketErrorType,
     },
-    info,
+    Broadcast, GameServer, ProcessPacketError, ProcessPacketErrorType,
 };
 
 use super::minigame::{end_active_minigame, handle_minigame_packet_write, MinigameTypeData};

--- a/src/game_server/handlers/saber_strike.rs
+++ b/src/game_server/handlers/saber_strike.rs
@@ -63,21 +63,25 @@ pub fn process_saber_strike_packet(
             _ => {
                 let mut buffer = Vec::new();
                 cursor.read_to_end(&mut buffer)?;
-                info!(
-                    "Unimplemented minigame op code: {:?} {:x?}",
-                    op_code, buffer
-                );
-                Ok(Vec::new())
+                Err(ProcessPacketError::new(
+                    ProcessPacketErrorType::UnknownOpCode,
+                    format!(
+                        "Unimplemented minigame op code: {:?} {:x?}",
+                        op_code, buffer
+                    ),
+                ))
             }
         },
         Err(_) => {
             let mut buffer = Vec::new();
             cursor.read_to_end(&mut buffer)?;
-            info!(
-                "Unknown minigame packet: {}, {:x?}",
-                header.sub_op_code, buffer
-            );
-            Ok(Vec::new())
+            Err(ProcessPacketError::new(
+                ProcessPacketErrorType::UnknownOpCode,
+                format!(
+                    "Unknown minigame packet: {}, {:x?}",
+                    header.sub_op_code, buffer
+                ),
+            ))
         }
     }
 }

--- a/src/game_server/handlers/zone.rs
+++ b/src/game_server/handlers/zone.rs
@@ -9,22 +9,19 @@ use packet_serialize::SerializePacketError;
 use parking_lot::RwLockReadGuard;
 use serde::Deserialize;
 
-use crate::{
-    game_server::{
-        packets::{
-            client_update::Position,
-            command::SelectPlayer,
-            housing::BuildArea,
-            item::{ItemDefinition, WieldType},
-            login::{ClientBeginZoning, ZoneDetails},
-            player_update::Customization,
-            tunnel::TunneledPacket,
-            ui::ExecuteScriptWithParams,
-            GamePacket, Pos,
-        },
-        Broadcast, GameServer, ProcessPacketError,
+use crate::game_server::{
+    packets::{
+        client_update::Position,
+        command::SelectPlayer,
+        housing::BuildArea,
+        item::{ItemDefinition, WieldType},
+        login::{ClientBeginZoning, ZoneDetails},
+        player_update::Customization,
+        tunnel::TunneledPacket,
+        ui::ExecuteScriptWithParams,
+        GamePacket, Pos,
     },
-    info,
+    Broadcast, GameServer, ProcessPacketError, ProcessPacketErrorType,
 };
 
 use super::{
@@ -1166,11 +1163,13 @@ pub fn interact_with_character(
 
                         target_read_handle.interact(requester, source_zone_guid)
                     } else {
-                        info!(
-                            "Received request to interact with unknown NPC {} from {}",
-                            request.target, request.requester
-                        );
-                        coerce_to_broadcast_supplier(|_| Ok(Vec::new()))
+                        Err(ProcessPacketError::new(
+                            ProcessPacketErrorType::ConstraintViolated,
+                            format!(
+                                "Received request to interact with unknown NPC {} from {}",
+                                request.target, request.requester
+                            ),
+                        ))
                     }
                 },
             }

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -739,6 +739,9 @@ impl GameServer {
                 OpCode::Minigame => {
                     broadcasts.append(&mut process_minigame_packet(&mut cursor, sender, self)?);
                 }
+                OpCode::LobbyGame => {}
+                OpCode::UiInteractions => {}
+                OpCode::ClientLog => {}
                 _ => {
                     return Err(ProcessPacketError::new(
                         ProcessPacketErrorType::UnknownOpCode,

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -739,9 +739,19 @@ impl GameServer {
                 OpCode::Minigame => {
                     broadcasts.append(&mut process_minigame_packet(&mut cursor, sender, self)?);
                 }
-                _ => info!("Unimplemented: {:?}, {:x?}", op_code, data),
+                _ => {
+                    return Err(ProcessPacketError::new(
+                        ProcessPacketErrorType::UnknownOpCode,
+                        format!("Unimplemented: {:?}, {:x?}", op_code, data),
+                    ))
+                }
             },
-            Err(_) => info!("Unknown op code: {}, {:x?}", raw_op_code, data),
+            Err(_) => {
+                return Err(ProcessPacketError::new(
+                    ProcessPacketErrorType::UnknownOpCode,
+                    format!("Unknown op code: {}, {:x?}", raw_op_code, data),
+                ))
+            }
         }
 
         Ok(broadcasts)

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -741,6 +741,7 @@ impl GameServer {
                 }
                 OpCode::LobbyGame => {}
                 OpCode::UiInteractions => {}
+                OpCode::ClientMetrics => {}
                 OpCode::ClientLog => {}
                 _ => {
                     return Err(ProcessPacketError::new(

--- a/src/game_server/packets/mod.rs
+++ b/src/game_server/packets/mod.rs
@@ -58,6 +58,8 @@ pub enum OpCode {
     QuickChat = 0x43,
     ZoneTeleportRequest = 0x5a,
     WelcomeScreen = 0x5d,
+    LobbyGame = 0x66,
+    ClientLog = 0x6d,
     TeleportToSafety = 0x7a,
     UpdatePlayerPosition = 0x7d,
     UpdatePlayerCamera = 0x7e,
@@ -71,6 +73,7 @@ pub enum OpCode {
     Store = 0xa4,
     DeploymentEnv = 0xa5,
     BrandishHolster = 0xb4,
+    UiInteractions = 0xbd,
 }
 
 impl SerializePacket for OpCode {

--- a/src/game_server/packets/mod.rs
+++ b/src/game_server/packets/mod.rs
@@ -59,6 +59,7 @@ pub enum OpCode {
     ZoneTeleportRequest = 0x5a,
     WelcomeScreen = 0x5d,
     LobbyGame = 0x66,
+    ClientMetrics = 0x69,
     ClientLog = 0x6d,
     TeleportToSafety = 0x7a,
     UpdatePlayerPosition = 0x7d,

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,12 +67,12 @@ async fn main() {
         Path::new("config/custom_assets"),
         PathBuf::from(".asset_cache"),
     ));
-    info!("Hello, world!");
     let socket = UdpSocket::bind(SocketAddr::new(
         server_options.bind_ip,
         server_options.udp_port,
     ))
     .expect("couldn't bind to socket");
+    info!("Hello, world!");
 
     let channel_manager = RwLock::new(ChannelManager::new(server_options.max_sessions));
     let game_server = GameServer::new(config_dir).unwrap();

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -10,7 +10,7 @@ use crate::protocol::reliable_data_ops::{
     fragment_data, unbundle_reliable_data, DataPacket, FragmentState,
 };
 use crate::protocol::serialize::{serialize_packets, SerializeError};
-use crate::{info, ServerOptions};
+use crate::{debug, info, ServerOptions};
 
 mod deserialize;
 mod hash;
@@ -562,7 +562,7 @@ impl Channel {
     }
 
     fn process_packet(&mut self, packet: &Packet, server_options: &ServerOptions) {
-        info!("Received packet op code {:?}", packet.op_code());
+        debug!("Received packet op code {:?}", packet.op_code());
         match packet {
             Packet::SessionRequest(protocol_version, session_id, buffer_size, protocol) => self
                 .process_session_request(


### PR DESCRIPTION
Currently, we disconnect players whenever we have a `ProcessPacketError`. This is a bit awkward because we tend to treat some errors as OK when we don't want to disconnect the player, and we also can only disconnect the player who sent the packet. (In contrast, we can send packets to any other players via `Broadcast`.)

I don't think disconnecting players on these errors provides much value, so I've disabled the disconnection (except during login). Since this makes the "unimplemented packet" log statements a bit longer, I've marked a few op codes we don't use as ignored to reduce log spam. I've also introduced a `debug!` macro for debug logging that isn't enabled by default. This macro is used for the "received packet op code" messages that are also quite spammy.