### PR TITLE
Properly handle player house list request

### DIFF
--- a/src/game_server/handlers/housing.rs
+++ b/src/game_server/handlers/housing.rs
@@ -9,8 +9,9 @@ use crate::{
         packets::{
             housing::{
                 BuildArea, EnterRequest, FixtureAssetData, FixtureUpdate, HouseDescription,
-                HouseInfo, HouseInstanceData, HouseItemList, HouseZoneData, HousingOpCode,
-                InnerInstanceData, PlacedFixture, RoomInstances, SetEditMode, Unknown1,
+                HouseInfo, HouseInstanceData, HouseInstanceEntry, HouseInstanceList, HouseItemList,
+                HouseZoneData, HousingOpCode, InnerInstanceData, PlacedFixture,
+                RequestPlayerHouseList, RoomInstances, SetEditMode, Unknown1,
             },
             item::{BaseAttachmentGroup, WieldType},
             player_update::{AddNpc, Hostility, Icon},
@@ -26,7 +27,9 @@ use super::{
     character::{Character, CurrentFixture, PreviousFixture},
     guid::{GuidTableIndexer, IndexedGuid},
     lock_enforcer::{CharacterLockRequest, ZoneLockRequest},
-    unique_guid::{npc_guid, player_guid, zone_template_guid, FIXTURE_DISCRIMINANT},
+    unique_guid::{
+        npc_guid, player_guid, zone_instance_guid, zone_template_guid, FIXTURE_DISCRIMINANT,
+    },
     zone::{House, ZoneInstance},
 };
 
@@ -410,6 +413,41 @@ pub fn process_housing_packet(
                         Ok(vec![Broadcast::Single(sender, packets)])
                     },
                 })
+            }
+            HousingOpCode::RequestPlayerHouseList => {
+                let request = RequestPlayerHouseList::deserialize(cursor)?;
+                Ok(vec![Broadcast::Single(
+                    sender,
+                    vec![GamePacket::serialize(&TunneledPacket {
+                        unknown1: true,
+                        inner: HouseInstanceList {
+                            instances: vec![HouseInstanceEntry {
+                                description: HouseDescription {
+                                    owner_guid: request.player_guid,
+                                    house_guid: zone_instance_guid(0, 100),
+                                    house_name: 1987,
+                                    player_given_name: "Blaster's Mustafar Lot".to_string(),
+                                    owner_name: "BLASTER NICESHOT".to_string(),
+                                    icon_id: 4209,
+                                    unknown5: true,
+                                    fixture_count: 1,
+                                    unknown7: 0,
+                                    furniture_score: 3,
+                                    is_locked: false,
+                                    unknown10: "".to_string(),
+                                    unknown11: "".to_string(),
+                                    rating: 4.5,
+                                    total_votes: 5,
+                                    is_published: false,
+                                    is_rateable: false,
+                                    unknown16: 0,
+                                    unknown17: 0,
+                                },
+                                unknown1: request.player_guid,
+                            }],
+                        },
+                    })?],
+                )])
             }
             HousingOpCode::EnterRequest => {
                 let enter_request: EnterRequest = DeserializePacket::deserialize(cursor)?;

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -41,7 +41,6 @@ use handlers::unique_guid::{
 };
 use handlers::zone::{load_zones, teleport_within_zone, ZoneInstance, ZoneTemplate};
 use packets::client_update::{Health, Power, PreloadCharactersDone, Stat, StatId, Stats};
-use packets::housing::{HouseDescription, HouseInstanceEntry, HouseInstanceList};
 use packets::item::ItemDefinition;
 use packets::login::{LoginRequest, WelcomeScreen, ZoneDetailsDone};
 use packets::player_update::{Customization, InitCustomizations, QueueAnimation, UpdateWieldType};
@@ -658,38 +657,6 @@ impl GameServer {
                 }
                 OpCode::Housing => {
                     broadcasts.append(&mut process_housing_packet(sender, self, &mut cursor)?);
-                    broadcasts.push(Broadcast::Single(
-                        sender,
-                        vec![GamePacket::serialize(&TunneledPacket {
-                            unknown1: true,
-                            inner: HouseInstanceList {
-                                instances: vec![HouseInstanceEntry {
-                                    description: HouseDescription {
-                                        owner_guid: player_guid(sender),
-                                        house_guid: zone_instance_guid(0, 100),
-                                        house_name: 1987,
-                                        player_given_name: "Blaster's Mustafar Lot".to_string(),
-                                        owner_name: "BLASTER NICESHOT".to_string(),
-                                        icon_id: 4209,
-                                        unknown5: true,
-                                        fixture_count: 1,
-                                        unknown7: 0,
-                                        furniture_score: 3,
-                                        is_locked: false,
-                                        unknown10: "".to_string(),
-                                        unknown11: "".to_string(),
-                                        rating: 4.5,
-                                        total_votes: 5,
-                                        is_published: false,
-                                        is_rateable: false,
-                                        unknown16: 0,
-                                        unknown17: 0,
-                                    },
-                                    unknown1: player_guid(sender),
-                                }],
-                            },
-                        })?],
-                    ));
                 }
                 OpCode::Chat => {
                     broadcasts.append(&mut process_chat_packet(&mut cursor, sender, self)?);

--- a/src/game_server/packets/housing.rs
+++ b/src/game_server/packets/housing.rs
@@ -10,6 +10,7 @@ use super::{item::BaseAttachmentGroup, GamePacket, OpCode, Pos};
 #[repr(u16)]
 pub enum HousingOpCode {
     SetEditMode = 0x6,
+    RequestPlayerHouseList = 0xb,
     EnterRequest = 0x10,
     InstanceData = 0x18,
     InstanceList = 0x26,
@@ -37,6 +38,16 @@ pub struct SetEditMode {
 impl GamePacket for SetEditMode {
     type Header = HousingOpCode;
     const HEADER: Self::Header = HousingOpCode::SetEditMode;
+}
+
+#[derive(SerializePacket, DeserializePacket)]
+pub struct RequestPlayerHouseList {
+    pub player_guid: u64,
+}
+
+impl GamePacket for RequestPlayerHouseList {
+    type Header = HousingOpCode;
+    const HEADER: Self::Header = HousingOpCode::RequestPlayerHouseList;
 }
 
 #[derive(SerializePacket, DeserializePacket)]


### PR DESCRIPTION
#133 broke the player house list because we now return an error on unknown housing op codes. Previously, we always returned an `Ok` result on unknown op codes, so the house instance list would be added to the broadcast list on every housing packet received. This PR moves the house list broadcast to the `RequestPlayerHouseList` handler, rather than the hacky and now-broken solution of sending it on every housing packet.