### PR TITLE
Fix gunship radius

### DIFF
--- a/config/zones.yaml
+++ b/config/zones.yaml
@@ -23,7 +23,6 @@
   jump_height_multiplier: 1
   gravity_multiplier: 1
   seconds_per_day: 10800
-  interact_radius: 7
   door_auto_interact_radius: 0
   doors: []
   transports:
@@ -71,7 +70,6 @@
   gravity_multiplier: 1
   seconds_per_day: 10800
   map_id: 115
-  interact_radius: 7
   door_auto_interact_radius: 0
   doors: []
   transports:
@@ -173,7 +171,6 @@
   gravity_multiplier: 1
   seconds_per_day: 10800
   map_id: 104
-  interact_radius: 7
   door_auto_interact_radius: 0
   doors: []
   transports:
@@ -232,7 +229,7 @@
       name_offset_y: 0
       name_offset_z: 5
       cursor: 54
-      interact_radius_override: 15
+      interact_radius: 15
       show_name: false
       show_icon: true
       large_icon: true
@@ -263,7 +260,6 @@
   gravity_multiplier: 1
   seconds_per_day: 10800
   map_id: 113
-  interact_radius: 7
   door_auto_interact_radius: 0
   doors: []
   transports:
@@ -330,7 +326,6 @@
   gravity_multiplier: 1
   seconds_per_day: 10800
   map_id: 128
-  interact_radius: 7
   door_auto_interact_radius: 0
   doors: []
   transports:
@@ -391,7 +386,6 @@
   jump_height_multiplier: 1
   gravity_multiplier: 1
   seconds_per_day: 10800
-  interact_radius: 7
   door_auto_interact_radius: 1.5
   doors:
     - comment: Veranda -> Archives
@@ -1189,7 +1183,6 @@
   jump_height_multiplier: 1
   gravity_multiplier: 1
   seconds_per_day: 10800
-  interact_radius: 7
   door_auto_interact_radius: 1.5
   doors:
     - comment: Construction Chamber -> Veranda
@@ -1259,7 +1252,6 @@
   gravity_multiplier: 1
   seconds_per_day: 10800
   update_previous_location_on_leave: false
-  interact_radius: 7
   door_auto_interact_radius: 0
   doors: []
   transports:
@@ -1308,7 +1300,6 @@
   gravity_multiplier: 1
   seconds_per_day: 10800
   update_previous_location_on_leave: false
-  interact_radius: 7
   door_auto_interact_radius: 0
   doors: []
   transports: []

--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -54,6 +54,10 @@ const fn default_fade_millis() -> u32 {
     1000
 }
 
+const fn default_interact_radius() -> f32 {
+    7.0
+}
+
 const fn default_removal_delay_millis() -> u32 {
     5000
 }
@@ -142,10 +146,9 @@ pub struct BaseNpcConfig {
     pub cursor: Option<u8>,
     #[serde(default = "default_true")]
     pub enable_interact_popup: bool,
-    #[serde(default)]
-    pub interact_radius_override: f32,
-    #[serde(default)]
-    pub interact_popup_radius_override: f32,
+    #[serde(default = "default_interact_radius")]
+    pub interact_radius: f32,
+    pub interact_popup_radius: Option<f32>,
     #[serde(default = "default_true")]
     pub show_name: bool,
     #[serde(default = "default_true")]
@@ -176,7 +179,8 @@ pub struct BaseNpc {
     pub name_offset_y: f32,
     pub name_offset_z: f32,
     pub enable_interact_popup: bool,
-    pub interact_popup_radius_override: f32,
+    pub interact_radius: f32,
+    pub interact_popup_radius: Option<f32>,
     pub show_name: bool,
     pub visible: bool,
     pub bounce_area_id: i32,
@@ -261,11 +265,9 @@ impl BaseNpc {
                 collision: true,
                 rider_guid: 0,
                 npc_type: self.npc_type,
-                interact_popup_radius: if self.interact_popup_radius_override > 0.0 {
-                    self.interact_popup_radius_override
-                } else {
-                    character.interact_radius
-                },
+                interact_popup_radius: self
+                    .interact_popup_radius
+                    .unwrap_or(character.interact_radius),
                 target: Target::default(),
                 variables: vec![],
                 rail_id: 0,
@@ -315,7 +317,8 @@ impl From<BaseNpcConfig> for BaseNpc {
             name_offset_y: value.name_offset_y,
             name_offset_z: value.name_offset_z,
             enable_interact_popup: value.enable_interact_popup,
-            interact_popup_radius_override: value.interact_popup_radius_override,
+            interact_radius: value.interact_radius,
+            interact_popup_radius: value.interact_popup_radius,
             show_name: value.show_name,
             visible: value.visible,
             bounce_area_id: value.bounce_area_id,

--- a/src/game_server/handlers/zone.rs
+++ b/src/game_server/handlers/zone.rs
@@ -92,7 +92,6 @@ struct ZoneConfig {
     jump_height_multiplier: f32,
     gravity_multiplier: f32,
     doors: Vec<DoorConfig>,
-    interact_radius: f32,
     door_auto_interact_radius: f32,
     transports: Vec<TransportConfig>,
     ambient_npcs: Vec<AmbientNpcConfig>,
@@ -179,11 +178,7 @@ impl From<ZoneConfig> for ZoneTemplate {
                     synchronize_with: ambient_npc.base_npc.synchronize_with.clone(),
                     animation_id: ambient_npc.base_npc.active_animation_slot,
                     cursor: ambient_npc.base_npc.cursor,
-                    interact_radius: if ambient_npc.base_npc.interact_radius_override > 0.0 {
-                        ambient_npc.base_npc.interact_radius_override
-                    } else {
-                        value.interact_radius
-                    },
+                    interact_radius: ambient_npc.base_npc.interact_radius,
                     is_spawned: ambient_npc.base_npc.is_spawned,
                     character_type: CharacterType::AmbientNpc(ambient_npc.into()),
                     mount_id: None,
@@ -206,11 +201,7 @@ impl From<ZoneConfig> for ZoneTemplate {
                     synchronize_with: door.base_npc.synchronize_with.clone(),
                     animation_id: door.base_npc.active_animation_slot,
                     cursor: door.base_npc.cursor,
-                    interact_radius: if door.base_npc.interact_radius_override > 0.0 {
-                        door.base_npc.interact_radius_override
-                    } else {
-                        value.interact_radius
-                    },
+                    interact_radius: door.base_npc.interact_radius,
                     is_spawned: door.base_npc.is_spawned,
                     character_type: CharacterType::Door(door.into()),
                     mount_id: None,
@@ -233,11 +224,7 @@ impl From<ZoneConfig> for ZoneTemplate {
                     synchronize_with: transport.base_npc.synchronize_with.clone(),
                     animation_id: transport.base_npc.active_animation_slot,
                     cursor: transport.base_npc.cursor,
-                    interact_radius: if transport.base_npc.interact_radius_override > 0.0 {
-                        transport.base_npc.interact_radius_override
-                    } else {
-                        value.interact_radius
-                    },
+                    interact_radius: transport.base_npc.interact_radius,
                     is_spawned: transport.base_npc.is_spawned,
                     character_type: CharacterType::Transport(transport.into()),
                     mount_id: None,


### PR DESCRIPTION
- Add `interact_popup_radius` and move `interact_radius` to `BaseNpc` as storing it per zone has become redundant.
- Increases the Gunship’s interact radius on Umbara to match [Live Footage](https://m.youtube.com/watch?v=mRsuVhHF-2k&t=44s)