### PR TITLE
Add GUID table for shared minigame data

### DIFF
--- a/src/game_server/handlers/housing.rs
+++ b/src/game_server/handlers/housing.rs
@@ -369,7 +369,7 @@ pub fn process_housing_packet(
                             zones_lock_enforcer.read_zones(|_| ZoneLockRequest {
                                 read_guids: vec![instance_guid],
                                 write_guids: Vec::new(),
-                                zone_consumer: |_, zones_read, _| {
+                                zone_consumer: |_, zones_read, _, _| {
                                     if let Some(zone_read_handle) = zones_read.get(&instance_guid){
                                         if let Some(house) = &zone_read_handle.house_data {
                                             if house.owner == sender {

--- a/src/game_server/handlers/housing.rs
+++ b/src/game_server/handlers/housing.rs
@@ -25,7 +25,7 @@ use crate::{
 use super::{
     character::{Character, CurrentFixture, PreviousFixture},
     guid::{GuidTableIndexer, IndexedGuid},
-    lock_enforcer::{CharacterLockRequest, ZoneLockRequest},
+    lock_enforcer::{CharacterLockRequest, ZoneLockEnforcer, ZoneLockRequest},
     unique_guid::{
         npc_guid, player_guid, zone_instance_guid, zone_template_guid, FIXTURE_DISCRIMINANT,
     },
@@ -364,12 +364,13 @@ pub fn process_housing_packet(
                 game_server.lock_enforcer().read_characters(|_| CharacterLockRequest {
                     read_guids: Vec::new(),
                     write_guids: Vec::new(),
-                    character_consumer: |characters_table_read_handle, _, _, zones_lock_enforcer| {
+                    character_consumer: |characters_table_read_handle, _, _, minigame_data_lock_enforcer| {
                         let packets = if let Some((_, instance_guid, _)) = characters_table_read_handle.index1(player_guid(sender)) {
+                            let zones_lock_enforcer: ZoneLockEnforcer = minigame_data_lock_enforcer.into();
                             zones_lock_enforcer.read_zones(|_| ZoneLockRequest {
                                 read_guids: vec![instance_guid],
                                 write_guids: Vec::new(),
-                                zone_consumer: |_, zones_read, _, _| {
+                                zone_consumer: |_, zones_read, _| {
                                     if let Some(zone_read_handle) = zones_read.get(&instance_guid){
                                         if let Some(house) = &zone_read_handle.house_data {
                                             if house.owner == sender {

--- a/src/game_server/handlers/lock_enforcer.rs
+++ b/src/game_server/handlers/lock_enforcer.rs
@@ -378,7 +378,7 @@ pub struct CharacterLockRequest<
         &CharacterTableReadHandle<'_>,
         BTreeMap<u64, CharacterReadGuard<'_>>,
         BTreeMap<u64, CharacterWriteGuard<'_>>,
-        &ZoneLockEnforcer,
+        ZoneLockEnforcer,
     ) -> R,
 > {
     pub read_guids: Vec<u64>,
@@ -407,7 +407,7 @@ impl CharacterLockEnforcer<'_> {
             &CharacterTableReadHandle<'_>,
             BTreeMap<u64, CharacterReadGuard<'_>>,
             BTreeMap<u64, CharacterWriteGuard<'_>>,
-            &ZoneLockEnforcer,
+            ZoneLockEnforcer,
         ) -> R,
         T: FnOnce(&CharacterTableReadHandle<'_>) -> CharacterLockRequest<R, C>,
     >(
@@ -428,7 +428,7 @@ impl CharacterLockEnforcer<'_> {
                         table_read_handle,
                         characters_read,
                         characters_write,
-                        &zones_enforcer,
+                        zones_enforcer,
                     )
                 },
             }

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -45,7 +45,7 @@ use crate::{
 
 use super::{
     character::{CharacterMatchmakingGroupIndex, CharacterType, MatchmakingGroupStatus, Player},
-    guid::GuidTableIndexer,
+    guid::{Guid, GuidTableIndexer},
     item::SABER_ITEM_TYPE,
     lock_enforcer::{CharacterLockRequest, CharacterTableWriteHandle, ZoneTableWriteHandle},
     saber_strike::process_saber_strike_packet,
@@ -131,6 +131,22 @@ impl From<&MinigameType> for MinigameTypeData {
         }
     }
 }
+
+#[derive(Clone)]
+pub struct SharedMinigameData {
+    pub guid: CharacterMatchmakingGroupIndex,
+    pub data: SharedMinigameTypeData,
+}
+
+impl Guid<CharacterMatchmakingGroupIndex> for SharedMinigameData {
+    fn guid(&self) -> CharacterMatchmakingGroupIndex {
+        self.guid
+    }
+}
+
+#[non_exhaustive]
+#[derive(Clone)]
+pub enum SharedMinigameTypeData {}
 
 const CHALLENGE_LINK_NAME: &str = "challenge";
 const GROUP_LINK_NAME: &str = "group";

--- a/src/game_server/handlers/mount.rs
+++ b/src/game_server/handlers/mount.rs
@@ -187,7 +187,7 @@ fn process_dismount(
                     zones_lock_enforcer.read_zones(|_| ZoneLockRequest {
                         read_guids: vec![character_write_handle.stats.instance_guid],
                         write_guids: Vec::new(),
-                        zone_consumer: |_, zones_read, _| {
+                        zone_consumer: |_, zones_read, _, _| {
                             if let Some(zone_read_handle) =
                                 zones_read.get(&character_write_handle.stats.instance_guid)
                             {
@@ -233,7 +233,7 @@ fn process_mount_spawn(
                     zones_lock_enforcer.read_zones(|_| ZoneLockRequest {
                         read_guids: vec![character_write_handle.stats.instance_guid],
                         write_guids: Vec::new(),
-                        zone_consumer: |_, zones_read, _| {
+                        zone_consumer: |_, zones_read, _, _| {
                             if let Some(zone_read_handle) = zones_read.get(&character_write_handle.stats.instance_guid) {
                                 character_write_handle.stats.speed.mount_multiplier = mount.speed_multiplier;
                                 character_write_handle.stats.jump_height_multiplier.mount_multiplier = mount.jump_height_multiplier;

--- a/src/game_server/handlers/mount.rs
+++ b/src/game_server/handlers/mount.rs
@@ -26,7 +26,7 @@ use super::{
         CharacterSquadIndex,
     },
     guid::{Guid, GuidTableIndexer, IndexedGuid},
-    lock_enforcer::{CharacterLockRequest, ZoneLockRequest},
+    lock_enforcer::{CharacterLockRequest, ZoneLockEnforcer, ZoneLockRequest},
     unique_guid::{mount_guid, player_guid},
     zone::ZoneInstance,
 };
@@ -181,13 +181,14 @@ fn process_dismount(
             character_consumer: |characters_table_read_handle,
                                  _,
                                  mut characters_write,
-                                 zones_lock_enforcer| {
+                                 minigame_data_lock_enforcer| {
                 if let Some(character_write_handle) = characters_write.get_mut(&player_guid(sender))
                 {
+                    let zones_lock_enforcer: ZoneLockEnforcer = minigame_data_lock_enforcer.into();
                     zones_lock_enforcer.read_zones(|_| ZoneLockRequest {
                         read_guids: vec![character_write_handle.stats.instance_guid],
                         write_guids: Vec::new(),
-                        zone_consumer: |_, zones_read, _, _| {
+                        zone_consumer: |_, zones_read, _| {
                             if let Some(zone_read_handle) =
                                 zones_read.get(&character_write_handle.stats.instance_guid)
                             {
@@ -228,12 +229,13 @@ fn process_mount_spawn(
         game_server.lock_enforcer().read_characters(|_| CharacterLockRequest {
             read_guids: Vec::new(),
             write_guids: vec![player_guid(sender)],
-            character_consumer: |characters_table_read_handle, _, mut characters_write, zones_lock_enforcer| {
+            character_consumer: |characters_table_read_handle, _, mut characters_write, minigame_data_lock_enforcer| {
                 if let Some(character_write_handle) = characters_write.get_mut(&player_guid(sender)) {
+                    let zones_lock_enforcer: ZoneLockEnforcer = minigame_data_lock_enforcer.into();
                     zones_lock_enforcer.read_zones(|_| ZoneLockRequest {
                         read_guids: vec![character_write_handle.stats.instance_guid],
                         write_guids: Vec::new(),
-                        zone_consumer: |_, zones_read, _, _| {
+                        zone_consumer: |_, zones_read, _| {
                             if let Some(zone_read_handle) = zones_read.get(&character_write_handle.stats.instance_guid) {
                                 character_write_handle.stats.speed.mount_multiplier = mount.speed_multiplier;
                                 character_write_handle.stats.jump_height_multiplier.mount_multiplier = mount.jump_height_multiplier;

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -164,7 +164,7 @@ impl GameServer {
             customizations: load_customizations(config_dir)?,
             customization_item_mappings: load_customization_item_mappings(config_dir)?,
             default_sabers: load_default_sabers(config_dir)?,
-            lock_enforcer_source: LockEnforcerSource::from(characters, zones),
+            lock_enforcer_source: LockEnforcerSource::from(characters, zones, GuidTable::new()),
             items: item_definitions,
             item_classes: load_item_classes(config_dir)?,
             item_groups: ItemGroupDefinitions {

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -21,7 +21,7 @@ use handlers::inventory::{
 };
 use handlers::item::load_item_definitions;
 use handlers::lock_enforcer::{
-    CharacterLockRequest, CharacterTableWriteHandle, LockEnforcer, LockEnforcerSource,
+    CharacterLockEnforcer, CharacterLockRequest, CharacterTableWriteHandle, LockEnforcerSource,
     ZoneLockRequest, ZoneTableWriteHandle,
 };
 use handlers::login::{log_in, log_out, send_points_of_interest};
@@ -759,7 +759,7 @@ impl GameServer {
         self.start_time
     }
 
-    pub fn lock_enforcer(&self) -> LockEnforcer {
+    pub fn lock_enforcer(&self) -> CharacterLockEnforcer {
         self.lock_enforcer_source.lock_enforcer()
     }
 

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -368,7 +368,7 @@ impl GameServer {
                                     zones_lock_enforcer.read_zones(|_| ZoneLockRequest {
                                         read_guids: vec![instance_guid],
                                         write_guids: Vec::new(),
-                                        zone_consumer: |_, zones_read, _| {
+                                        zone_consumer: |_, zones_read, _, _| {
                                             if let Some(zone) = zones_read.get(&instance_guid) {
                                                 let mut sender_only_character_packets = Vec::new();
                                                 sender_only_character_packets.append(&mut zone.send_self_on_client_ready()?);
@@ -523,7 +523,7 @@ impl GameServer {
                                         zones_lock_enforcer.read_zones(|_| ZoneLockRequest {
                                             read_guids: vec![instance_guid],
                                             write_guids: vec![],
-                                            zone_consumer: |_, zones_read, _| {
+                                            zone_consumer: |_, zones_read, _, _| {
                                                 if let Some(zone_read_handle) =
                                                     zones_read.get(&instance_guid)
                                                 {
@@ -620,7 +620,7 @@ impl GameServer {
                                     zones_lock_enforcer.read_zones(|_| ZoneLockRequest {
                                         read_guids: vec![instance_guid],
                                         write_guids: Vec::new(),
-                                        zone_consumer: |_, zones_read, _| {
+                                        zone_consumer: |_, zones_read, _, _| {
                                             if let Some(zone) = zones_read.get(&instance_guid) {
                                                 let spawn_pos = zone.default_spawn_pos;
                                                 let spawn_rot = zone.default_spawn_rot;


### PR DESCRIPTION
* Add GUID table for shared minigame data (currently unused). This can be accessed after the characters table but before the zones table.
* Refactor lock enforcers to reduce duplication