### PR TITLE
Refactor miscellaneous `if let` statements to use `let else`

### DIFF
--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -1218,16 +1218,7 @@ impl Player {
         if let Some(mount_id) = character.mount_id {
             let short_rider_guid = shorten_player_guid(Guid::guid(character))?;
             player_mount_guid = mount_guid(short_rider_guid, mount_id);
-            if let Some(mount_config) = mount_configs.get(&mount_id) {
-                mount_packets.append(&mut spawn_mount_npc(
-                    player_mount_guid,
-                    Guid::guid(character),
-                    mount_config,
-                    character.pos,
-                    character.rot,
-                    false,
-                )?);
-            } else {
+            let Some(mount_config) = mount_configs.get(&mount_id) else {
                 return Err(ProcessPacketError::new(
                     ProcessPacketErrorType::ConstraintViolated,
                     format!(
@@ -1236,7 +1227,16 @@ impl Player {
                         mount_id
                     ),
                 ));
-            }
+            };
+
+            mount_packets.append(&mut spawn_mount_npc(
+                player_mount_guid,
+                Guid::guid(character),
+                mount_config,
+                character.pos,
+                character.rot,
+                false,
+            )?);
         }
 
         let attachments: Vec<Attachment> = self

--- a/src/game_server/handlers/saber_strike.rs
+++ b/src/game_server/handlers/saber_strike.rs
@@ -94,22 +94,23 @@ fn handle_saber_strike_game_over(
         game_server,
         header,
         |minigame_status, minigame_stats, _, stage_config| {
-            if let MinigameTypeData::SaberStrike { obfuscated_score } = minigame_status.type_data {
-                if obfuscated_score != game_over.total_score {
-                    return Err(ProcessPacketError::new(
-                        ProcessPacketErrorType::ConstraintViolated,
-                        format!(
-                            "Player {} sent a Saber Strike game over packet with score {}, but their obfuscated score was {}",
-                            sender,
-                            game_over.total_score,
-                            obfuscated_score,
-                        )
-                    ));
-                }
-            } else {
+            let MinigameTypeData::SaberStrike { obfuscated_score } = minigame_status.type_data
+            else {
                 return Err(ProcessPacketError::new(
                     ProcessPacketErrorType::ConstraintViolated,
                     format!("Player {} sent a Saber Strike game over packet, but they have no Saber Strike game data", sender)
+                ));
+            };
+
+            if obfuscated_score != game_over.total_score {
+                return Err(ProcessPacketError::new(
+                    ProcessPacketErrorType::ConstraintViolated,
+                    format!(
+                        "Player {} sent a Saber Strike game over packet with score {}, but their obfuscated score was {}",
+                        sender,
+                        game_over.total_score,
+                        obfuscated_score,
+                    )
                 ));
             }
 


### PR DESCRIPTION
We currently use a number of nested `if let` statements that have become a bit unwieldly. I'm refactoring many of these to use a `let else` pattern to reduce the amount of nesting. This PR refactors `if let statements` in miscellaneous files where there aren't many `if let`s used. I'll refactor the other statements in separate PRs.