### PR TITLE
Allow simultaneous minigame data and zones table write access

### DIFF
--- a/src/game_server/handlers/housing.rs
+++ b/src/game_server/handlers/housing.rs
@@ -453,7 +453,9 @@ pub fn process_housing_packet(
                 let enter_request: EnterRequest = DeserializePacket::deserialize(cursor)?;
 
                 game_server.lock_enforcer().write_characters(
-                    |characters_table_write_handle, zones_lock_enforcer| {
+                    |characters_table_write_handle, minigame_data_lock_enforcer| {
+                        let zones_lock_enforcer: ZoneLockEnforcer<'_> =
+                            minigame_data_lock_enforcer.into();
                         zones_lock_enforcer.write_zones(|zones_table_write_handle| {
                             // Create the house instance if it does not already exist
                             if zones_table_write_handle

--- a/src/game_server/handlers/zone.rs
+++ b/src/game_server/handlers/zone.rs
@@ -38,7 +38,7 @@ use super::{
     housing::prepare_init_house_packets,
     lock_enforcer::{
         CharacterLockRequest, CharacterReadGuard, CharacterTableWriteHandle, CharacterWriteGuard,
-        ZoneTableWriteHandle,
+        ZoneLockEnforcer, ZoneTableWriteHandle,
     },
     mount::MountConfig,
     unique_guid::{
@@ -1202,7 +1202,8 @@ pub fn teleport_anywhere(
 ) -> WriteLockingBroadcastSupplier {
     coerce_to_broadcast_supplier(move |game_server| {
         game_server.lock_enforcer().write_characters(
-            |characters_table_write_handle, zones_lock_enforcer| {
+            |characters_table_write_handle, minigame_data_lock_enforcer| {
+                let zones_lock_enforcer: ZoneLockEnforcer<'_> = minigame_data_lock_enforcer.into();
                 zones_lock_enforcer.write_zones(|zones_table_write_handle| {
                     let source_zone_guid =
                         match characters_table_write_handle.get(player_guid(requester)) {

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -1012,7 +1012,8 @@ impl GameServer {
     fn tick_minigame_groups(&self) -> Result<Vec<Broadcast>, ProcessPacketError> {
         let now = Instant::now();
         self.lock_enforcer().write_characters(
-            |characters_table_write_handle, zones_lock_enforcer| {
+            |characters_table_write_handle, minigame_data_lock_enforcer| {
+                let zones_lock_enforcer: ZoneLockEnforcer<'_> = minigame_data_lock_enforcer.into();
                 let mut broadcasts = Vec::new();
 
                 // Iterate over timed-out groups for every stage, since the number of stages remains


### PR DESCRIPTION
Refactor `leave_active_minigame` to take the minigame data table write handle as a parameter (currently unused). Allow write access to minigame data and zone data simultaneously.