### PR TITLE
Remove error return option from `SerializePacket::serialize`

### DIFF
--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -438,7 +438,7 @@ impl TickableStep {
                     model_id,
                     guid: Guid::guid(character),
                 },
-            })?);
+            }));
         }
 
         if let Some(composite_effect_id) = self.composite_effect_id {
@@ -457,7 +457,7 @@ impl TickableStep {
                         w: 0.0,
                     },
                 },
-            })?);
+            }));
         }
 
         if let Some(rail_id) = self.rail_id {
@@ -474,7 +474,7 @@ impl TickableStep {
                         w: 0.0,
                     },
                 },
-            })?);
+            }));
         }
 
         if let Some(speed) = self.speed {
@@ -485,7 +485,7 @@ impl TickableStep {
                     guid: Guid::guid(character),
                     speed,
                 },
-            })?);
+            }));
         }
 
         let new_pos = self.new_pos(character.pos);
@@ -503,7 +503,7 @@ impl TickableStep {
                 character_state: 1,
                 unknown: 0,
             },
-        })?);
+        }));
 
         if let Some(animation_id) = self.animation_id {
             character.animation_id = animation_id;
@@ -515,7 +515,7 @@ impl TickableStep {
                     animation_group_id: -1,
                     override_animation: true,
                 },
-            })?);
+            }));
         }
 
         if let Some(animation_id) = self.one_shot_animation_id {
@@ -528,7 +528,7 @@ impl TickableStep {
                     delay_seconds: 0.0,
                     duration_seconds: self.duration_millis as f32 / 1000.0,
                 },
-            })?);
+            }));
         }
 
         if let Some(sound_id) = self.sound_id {
@@ -541,7 +541,7 @@ impl TickableStep {
                         guid: Guid::guid(character),
                     }),
                 },
-            })?);
+            }));
         }
 
         if self.cursor != CursorUpdate::Keep {
@@ -562,7 +562,7 @@ impl TickableStep {
                         unknown1: false,
                     }],
                 },
-            })?);
+            }));
         }
 
         let mut broadcasts = vec![Broadcast::Multi(
@@ -584,7 +584,7 @@ impl TickableStep {
                     owner_guid: 0,
                     unknown7: 0,
                 },
-            })?];
+            })];
 
             let recipients = nearby_player_guids
                 .iter()
@@ -938,13 +938,13 @@ impl AmbientNpc {
             GamePacket::serialize(&TunneledPacket {
                 unknown1: true,
                 inner: add_npc,
-            })?,
+            }),
             GamePacket::serialize(&TunneledPacket {
                 unknown1: true,
                 inner: NpcRelevance {
                     new_states: vec![enable_interaction],
                 },
-            })?,
+            }),
         ];
 
         Ok(packets)
@@ -1025,13 +1025,13 @@ impl Door {
             GamePacket::serialize(&TunneledPacket {
                 unknown1: true,
                 inner: add_npc,
-            })?,
+            }),
             GamePacket::serialize(&TunneledPacket {
                 unknown1: true,
                 inner: NpcRelevance {
                     new_states: vec![enable_interaction],
                 },
-            })?,
+            }),
         ];
 
         Ok(packets)
@@ -1099,13 +1099,13 @@ impl Transport {
             GamePacket::serialize(&TunneledPacket {
                 unknown1: true,
                 inner: add_npc,
-            })?,
+            }),
             GamePacket::serialize(&TunneledPacket {
                 unknown1: true,
                 inner: NpcRelevance {
                     new_states: vec![enable_interaction],
                 },
-            })?,
+            }),
             GamePacket::serialize(&TunneledPacket {
                 unknown1: true,
                 inner: AddNotifications {
@@ -1124,7 +1124,7 @@ impl Transport {
                         unknown2: false,
                     }],
                 },
-            })?,
+            }),
         ];
 
         Ok(packets)
@@ -1140,7 +1140,7 @@ impl Transport {
                         script_name: "UIGlobal.ShowGalaxyMap".to_string(),
                         params: vec![],
                     },
-                })?],
+                })],
             )])
         })
     }
@@ -1357,7 +1357,7 @@ impl Player {
                     self.active_battle_class,
                 ),
             },
-        })?];
+        })];
 
         packets.append(&mut mount_packets);
 
@@ -1558,7 +1558,7 @@ impl CharacterStats {
                 self.pos,
                 self.rot,
                 self.scale,
-            )?,
+            ),
         };
 
         Ok(packets)
@@ -1571,7 +1571,7 @@ impl CharacterStats {
                 inner: RemoveStandard {
                     guid: Guid::guid(self),
                 },
-            })?,
+            }),
             RemovalMode::Graceful {
                 enable_death_animation,
                 removal_delay_millis,
@@ -1588,7 +1588,7 @@ impl CharacterStats {
                     composite_effect: removal_composite_effect_id,
                     fade_duration_millis,
                 },
-            })?,
+            }),
         }];
 
         if let Some(mount_id) = self.mount_id {
@@ -1598,7 +1598,7 @@ impl CharacterStats {
                     inner: RemoveStandard {
                         guid: mount_guid(shorten_player_guid(Guid::guid(self))?, mount_id),
                     },
-                })?,
+                }),
                 RemovalMode::Graceful {
                     enable_death_animation,
                     removal_delay_millis,
@@ -1615,7 +1615,7 @@ impl CharacterStats {
                         composite_effect: removal_composite_effect_id,
                         fade_duration_millis,
                     },
-                })?,
+                }),
             });
         }
         Ok(packets)

--- a/src/game_server/handlers/chat.rs
+++ b/src/game_server/handlers/chat.rs
@@ -70,7 +70,7 @@ pub fn process_chat_packet(
                                         vec![GamePacket::serialize(&TunneledPacket {
                                             unknown1: true,
                                             inner: message,
-                                        })?],
+                                        })],
                                     )])
                                 }
                                 MessageTypeData::Whisper => {
@@ -84,7 +84,7 @@ pub fn process_chat_packet(
                                         GamePacket::serialize(&TunneledPacket {
                                             unknown1: true,
                                             inner: message.clone(),
-                                        })?;
+                                        });
                                     let mut broadcasts: Vec<Broadcast> =
                                         characters_table_read_handle
                                             .keys_by_index2(&message.payload.target_name.first_name)
@@ -116,7 +116,7 @@ pub fn process_chat_packet(
                                         GamePacket::serialize(&TunneledPacket {
                                             unknown1: true,
                                             inner: message,
-                                        })?;
+                                        });
                                     broadcasts.push(Broadcast::Single(
                                         sender,
                                         vec![message_packet_for_sender],
@@ -140,7 +140,7 @@ pub fn process_chat_packet(
                                             vec![GamePacket::serialize(&TunneledPacket {
                                                 unknown1: true,
                                                 inner: message,
-                                            })?],
+                                            })],
                                         )])
                                     } else {
                                         Ok(Vec::new())

--- a/src/game_server/handlers/housing.rs
+++ b/src/game_server/handlers/housing.rs
@@ -1,7 +1,7 @@
 use std::io::{Cursor, Read};
 
 use byteorder::{LittleEndian, ReadBytesExt};
-use packet_serialize::{DeserializePacket, SerializePacketError};
+use packet_serialize::DeserializePacket;
 
 use crate::{
     game_server::{
@@ -73,10 +73,7 @@ fn placed_fixture(
     }
 }
 
-fn fixture_item_list(
-    fixtures: &[PreviousFixture],
-    house_guid: u64,
-) -> Result<Vec<u8>, SerializePacketError> {
+fn fixture_item_list(fixtures: &[PreviousFixture], house_guid: u64) -> Vec<u8> {
     let mut unknown1 = Vec::new();
     let mut unknown2 = Vec::new();
 
@@ -119,8 +116,8 @@ pub fn fixture_packets(
     pos: Pos,
     rot: Pos,
     scale: f32,
-) -> Result<Vec<Vec<u8>>, SerializePacketError> {
-    Ok(vec![
+) -> Vec<Vec<u8>> {
+    vec![
         GamePacket::serialize(&TunneledPacket {
             unknown1: true,
             inner: FixtureUpdate {
@@ -153,7 +150,7 @@ pub fn fixture_packets(
                 unknown5: 0,
                 unknown6: 0,
             },
-        })?,
+        }),
         GamePacket::serialize(&TunneledPacket {
             unknown1: true,
             inner: AddNpc {
@@ -253,8 +250,8 @@ pub fn fixture_packets(
                 unknown71: 0,
                 icon_id: Icon::None,
             },
-        })?,
-    ])
+        }),
+    ]
 }
 
 pub fn prepare_init_house_packets(
@@ -301,7 +298,7 @@ pub fn prepare_init_house_packets(
                     unknown17: 0,
                 },
             },
-        })?,
+        }),
         GamePacket::serialize(&TunneledPacket {
             unknown1: true,
             inner: HouseInstanceData {
@@ -335,7 +332,7 @@ pub fn prepare_init_house_packets(
                     unknown2: vec![],
                 },
             },
-        })?,
+        }),
         GamePacket::serialize(&TunneledPacket {
             unknown1: true,
             inner: HouseInfo {
@@ -347,7 +344,7 @@ pub fn prepare_init_house_packets(
                 unknown6: 0,
                 unknown7: 0,
             },
-        })?,
+        }),
     ])
 }
 
@@ -406,7 +403,7 @@ pub fn process_housing_packet(
                                         unknown6: 0,
                                         unknown7: 0,
                                     },
-                                })?])
+                                })])
                             },
                         })?;
 
@@ -446,7 +443,7 @@ pub fn process_housing_packet(
                                 unknown1: request.player_guid,
                             }],
                         },
-                    })?],
+                    })],
                 )])
             }
             HousingOpCode::EnterRequest => {

--- a/src/game_server/handlers/inventory.rs
+++ b/src/game_server/handlers/inventory.rs
@@ -215,7 +215,7 @@ fn process_unequip_slot(
                                 slot: unequip_slot.slot,
                                 battle_class: unequip_slot.battle_class
                             }
-                        })?
+                        })
                     ])
                 ];
 
@@ -229,7 +229,7 @@ fn process_unequip_slot(
                             guid: player_guid(sender),
                             wield_type,
                         }
-                    })?);
+                    }));
                 }
 
                 all_player_packets.push(
@@ -249,7 +249,7 @@ fn process_unequip_slot(
                             battle_class: unequip_slot.battle_class,
                             wield_type: character_write_handle.stats.wield_type()
                         }
-                    })?
+                    })
                 );
 
                 let (_, instance_guid, chunk) = character_write_handle.index1();
@@ -424,7 +424,7 @@ fn process_preview_customization(
                     game_server.customization_item_mappings(),
                 )?,
             },
-        })?],
+        })],
     )])
 }
 
@@ -506,7 +506,7 @@ fn process_equip_customization(
                                 is_preview: false,
                                 customizations: customizations_to_apply,
                             },
-                        })?],
+                        })],
                     ),
                     Broadcast::Single(
                         sender,
@@ -514,7 +514,7 @@ fn process_equip_customization(
                             GamePacket::serialize(&TunneledPacket {
                                 unknown1: true,
                                 inner: UpdateCredits { new_credits },
-                            })?,
+                            }),
                             // Fix UI not updating the equipped customization item ID properly
                             GamePacket::serialize(&TunneledPacket {
                                 unknown1: true,
@@ -525,7 +525,7 @@ fn process_equip_customization(
                                     params: vec!["BaseClient.CustomizationItemDataSource"
                                         .to_string()],
                                 },
-                            })?,
+                            }),
                         ],
                     ),
                 ])
@@ -586,7 +586,7 @@ pub fn update_saber_tints<'a>(
                     item_class: primary_shape_def.item_class,
                     equip: true,
                 },
-            })?);
+            }));
             nearby_player_packets.push(GamePacket::serialize(&TunneledPacket {
                 unknown1: true,
                 inner: UpdateEquippedItem {
@@ -603,7 +603,7 @@ pub fn update_saber_tints<'a>(
                     battle_class,
                     wield_type,
                 },
-            })?);
+            }));
         }
     }
 
@@ -629,7 +629,7 @@ pub fn update_saber_tints<'a>(
                     item_class: secondary_shape_def.item_class,
                     equip: true,
                 },
-            })?);
+            }));
             nearby_player_packets.push(GamePacket::serialize(&TunneledPacket {
                 unknown1: true,
                 inner: UpdateEquippedItem {
@@ -646,7 +646,7 @@ pub fn update_saber_tints<'a>(
                     battle_class,
                     wield_type,
                 },
-            })?);
+            }));
         }
     }
 
@@ -757,7 +757,7 @@ fn equip_item_in_slot<'a>(
             item_class: item_def.item_class,
             equip: true,
         },
-    })?];
+    })];
     let mut other_player_packets = vec![GamePacket::serialize(&TunneledPacket {
         unknown1: true,
         inner: UpdateEquippedItem {
@@ -774,7 +774,7 @@ fn equip_item_in_slot<'a>(
             battle_class: equip_guid.battle_class,
             wield_type: current_wield_type,
         },
-    })?];
+    })];
 
     if let Some(item_class) = game_server
         .item_classes()
@@ -794,7 +794,7 @@ fn equip_item_in_slot<'a>(
                         slot: other_weapon_slot,
                         battle_class: equip_guid.battle_class,
                     },
-                })?);
+                }));
                 other_player_packets.push(GamePacket::serialize(&TunneledPacket {
                     unknown1: true,
                     inner: UpdateEquippedItem {
@@ -811,7 +811,7 @@ fn equip_item_in_slot<'a>(
                         battle_class: equip_guid.battle_class,
                         wield_type: current_wield_type,
                     },
-                })?);
+                }));
                 battle_class.items.remove(&other_weapon_slot);
             }
 
@@ -878,7 +878,7 @@ fn equip_item_in_slot<'a>(
                     guid: player_guid(sender),
                     wield_type,
                 },
-            })?],
+            })],
         ));
     }
 

--- a/src/game_server/handlers/login.rs
+++ b/src/game_server/handlers/login.rs
@@ -1,4 +1,4 @@
-use packet_serialize::{NullTerminatedString, SerializePacketError};
+use packet_serialize::NullTerminatedString;
 
 use crate::game_server::{
     packets::{
@@ -33,7 +33,7 @@ pub fn log_in(sender: u32, game_server: &GameServer) -> Result<Vec<Broadcast>, P
                 unknown1: true,
                 inner: LoginReply { logged_in: true },
             };
-            packets.push(GamePacket::serialize(&login_reply)?);
+            packets.push(GamePacket::serialize(&login_reply));
 
             let deployment_env = TunneledPacket {
                 unknown1: true,
@@ -41,7 +41,7 @@ pub fn log_in(sender: u32, game_server: &GameServer) -> Result<Vec<Broadcast>, P
                     environment: NullTerminatedString("prod".to_string()),
                 },
             };
-            packets.push(GamePacket::serialize(&deployment_env)?);
+            packets.push(GamePacket::serialize(&deployment_env));
 
             let (instance_guid, mut zone_packets) =
                 zones_lock_enforcer.write_zones(|zones_table_write_handle| {
@@ -70,7 +70,7 @@ pub fn log_in(sender: u32, game_server: &GameServer) -> Result<Vec<Broadcast>, P
                     time_scale: 1.0,
                 },
             };
-            packets.push(GamePacket::serialize(&settings)?);
+            packets.push(GamePacket::serialize(&settings));
 
             let item_defs = TunneledPacket {
                 unknown1: true,
@@ -78,13 +78,13 @@ pub fn log_in(sender: u32, game_server: &GameServer) -> Result<Vec<Broadcast>, P
                     definitions: game_server.items(),
                 },
             };
-            packets.push(GamePacket::serialize(&item_defs)?);
+            packets.push(GamePacket::serialize(&item_defs));
 
             let player = TunneledPacket {
                 unknown1: true,
                 inner: make_test_player(sender, game_server.mounts(), game_server.items()),
             };
-            packets.push(GamePacket::serialize(&player)?);
+            packets.push(GamePacket::serialize(&player));
 
             characters_table_write_handle.insert(Character::from_player(
                 sender,
@@ -172,16 +172,14 @@ pub fn log_out(
     )
 }
 
-pub fn send_points_of_interest(
-    game_server: &GameServer,
-) -> Result<Vec<Vec<u8>>, SerializePacketError> {
+pub fn send_points_of_interest(game_server: &GameServer) -> Vec<Vec<u8>> {
     let mut points = Vec::new();
     for point_of_interest in game_server.points_of_interest().values() {
         points.push(point_of_interest.into());
     }
 
-    Ok(vec![GamePacket::serialize(&TunneledPacket {
+    vec![GamePacket::serialize(&TunneledPacket {
         unknown1: true,
         inner: DefinePointsOfInterest { points },
-    })?])
+    })]
 }

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -1060,7 +1060,7 @@ fn handle_request_stage_group_instance(
                             inner: game_server
                                 .minigames()
                                 .stage_group_instance(request.header.stage_group_guid, player)?,
-                        })?,
+                        }),
                         GamePacket::serialize(&TunneledPacket {
                             unknown1: true,
                             inner: ShowStageInstanceSelect {
@@ -1070,7 +1070,7 @@ fn handle_request_stage_group_instance(
                                     stage_group_guid: request.header.stage_group_guid,
                                 },
                             },
-                        })?,
+                        }),
                     ],
                 )])
             },
@@ -1163,7 +1163,7 @@ fn handle_request_create_active_minigame(
                                 owner_guid: 0,
                                 unknown7: 0,
                             },
-                        })?],
+                        })],
                     )];
                     let required_space = 1;
                     let (open_group, space_left) = find_matchmaking_group(
@@ -1286,7 +1286,7 @@ pub fn remove_from_matchmaking(
             },
             was_successful: false,
         },
-    })?];
+    })];
     if let Some(message) = message_id {
         result_packets.push(GamePacket::serialize(&TunneledPacket {
             unknown1: true,
@@ -1301,7 +1301,7 @@ pub fn remove_from_matchmaking(
                 owner_guid: 0,
                 unknown7: 0,
             },
-        })?);
+        }));
     }
     broadcasts.push(Broadcast::Single(player, result_packets));
 
@@ -1390,32 +1390,23 @@ pub fn prepare_active_minigame_instance(
             })?;
 
             if let Some(message) = message_id {
-                let string_id_packet_result = GamePacket::serialize(&TunneledPacket {
-                    unknown1: true,
-                    inner: SendStringId {
-                        sender_guid: player_guid(*member_guid),
-                        message_id: message,
-                        is_anonymous: true,
-                        unknown2: false,
-                        is_action_bar_message: true,
-                        action_bar_text_color: ActionBarTextColor::Yellow,
-                        target_guid: 0,
-                        owner_guid: 0,
-                        unknown7: 0,
-                    },
-                });
-
-                match string_id_packet_result {
-                    Ok(packet) => {
-                        teleport_broadcasts.push(Broadcast::Single(*member_guid, vec![packet]))
-                    }
-                    Err(err) => info!(
-                        "Couldn't serialize send string packet: {} (stage group {}, stage {})",
-                        ProcessPacketError::from(err),
-                        stage_group_guid,
-                        stage_guid
-                    ),
-                }
+                teleport_broadcasts.push(Broadcast::Single(
+                    *member_guid,
+                    vec![GamePacket::serialize(&TunneledPacket {
+                        unknown1: true,
+                        inner: SendStringId {
+                            sender_guid: player_guid(*member_guid),
+                            message_id: message,
+                            is_anonymous: true,
+                            unknown2: false,
+                            is_action_bar_message: true,
+                            action_bar_text_color: ActionBarTextColor::Yellow,
+                            target_guid: 0,
+                            owner_guid: 0,
+                            unknown7: 0,
+                        },
+                    })],
+                ));
             }
 
             let result: Result<Vec<Broadcast>, ProcessPacketError> = teleport_to_zone!(
@@ -1522,11 +1513,11 @@ fn handle_request_start_active_minigame(
                     script_name: "UIGlobal.SetStateMain".to_string(),
                     params: vec![],
                 },
-            })?);
+            }));
             packets.push(GamePacket::serialize(&TunneledPacket {
                 unknown1: true,
                 inner: stage_group_instance,
-            })?);
+            }));
 
             match stage_config.minigame_type() {
                 MinigameType::Flash { game_swf_name } => {
@@ -1538,7 +1529,7 @@ fn handle_request_start_active_minigame(
                                 game_swf_name: game_swf_name.clone(),
                                 is_micro: false,
                             },
-                        })?
+                        })
                     );
                 },
                 MinigameType::SaberStrike { saber_strike_stage_id } => {
@@ -1558,7 +1549,7 @@ fn handle_request_start_active_minigame(
                                     .map(|item| item.item_type == SABER_ITEM_TYPE)
                                     .unwrap_or(false),
                             }
-                        })?,
+                        }),
                     );
                 },
             }
@@ -1573,7 +1564,7 @@ fn handle_request_start_active_minigame(
                             stage_group_guid: minigame_status.stage_group_guid,
                         },
                     },
-                })?,
+                }),
             );
 
             Ok(vec![
@@ -1750,7 +1741,7 @@ fn handle_flash_payload_win(
                                     .as_millis()
                             ),
                         },
-                    })?],
+                    })],
                 )])
             } else {
                 Err(ProcessPacketError::new(
@@ -1796,7 +1787,7 @@ fn handle_flash_payload(
                                 stage_config_ref.stage_number
                             ),
                         },
-                    })?],
+                    })],
                 )])
             },
         ),
@@ -1864,7 +1855,7 @@ fn handle_flash_payload(
                                 },
                                 payload: format!("OnShowEndRoundScreenMsg\t{}", awarded_credits),
                             },
-                        })?],
+                        })],
                     ));
 
                     Ok(broadcasts)
@@ -1976,7 +1967,7 @@ pub fn create_active_minigame(
                     },
                     was_successful: true,
                 },
-            })?,
+            }),
             GamePacket::serialize(&TunneledPacket {
                 unknown1: true,
                 inner: CreateActiveMinigame {
@@ -2013,7 +2004,7 @@ pub fn create_active_minigame(
                     unknown26: 0,
                     unknown27: 0,
                 },
-            })?,
+            }),
         ],
     )])
 }
@@ -2041,7 +2032,7 @@ fn award_credits(
         vec![GamePacket::serialize(&TunneledPacket {
             unknown1: true,
             inner: UpdateCredits { new_credits },
-        })?],
+        })],
     )];
 
     Ok((broadcasts, awarded_credits))
@@ -2131,7 +2122,7 @@ pub fn leave_active_minigame_if_any(
                             "OnGameLostMsg".to_string()
                         },
                     },
-                })?,
+                }),
                 GamePacket::serialize(&TunneledPacket {
                     unknown1: true,
                     inner: ActiveMinigameEndScore {
@@ -2143,7 +2134,7 @@ pub fn leave_active_minigame_if_any(
                         scores: minigame_status.score_entries.clone(),
                         unknown2: true,
                     },
-                })?,
+                }),
                 GamePacket::serialize(&TunneledPacket {
                     unknown1: true,
                     inner: UpdateActiveMinigameRewards {
@@ -2176,7 +2167,7 @@ pub fn leave_active_minigame_if_any(
                         reward_bundle2: RewardBundle::default(),
                         earned_trophies: vec![],
                     },
-                })?,
+                }),
                 GamePacket::serialize(&TunneledPacket {
                     unknown1: true,
                     inner: EndActiveMinigame {
@@ -2190,7 +2181,7 @@ pub fn leave_active_minigame_if_any(
                         unknown3: 0,
                         unknown4: 0,
                     },
-                })?,
+                }),
                 GamePacket::serialize(&TunneledPacket {
                     unknown1: true,
                     inner: LeaveActiveMinigame {
@@ -2200,7 +2191,7 @@ pub fn leave_active_minigame_if_any(
                             stage_group_guid: minigame_status.stage_group_guid,
                         },
                     },
-                })?,
+                }),
             ],
         );
 
@@ -2212,7 +2203,7 @@ pub fn leave_active_minigame_if_any(
                     minigame_status.stage_group_guid,
                     player,
                 )?,
-            })?],
+            })],
         ));
         broadcasts.push(last_broadcast);
 

--- a/src/game_server/handlers/mount.rs
+++ b/src/game_server/handlers/mount.rs
@@ -117,7 +117,7 @@ pub fn reply_dismount<'a>(
                         rider_guid: player_guid(sender),
                         composite_effect: mount.dismount_composite_effect,
                     },
-                })?,
+                }),
                 GamePacket::serialize(&TunneledPacket {
                     unknown1: true,
                     inner: RemoveGracefully {
@@ -128,14 +128,14 @@ pub fn reply_dismount<'a>(
                         composite_effect: 0,
                         fade_duration_millis: 1000,
                     },
-                })?,
+                }),
                 GamePacket::serialize(&TunneledPacket {
                     unknown1: true,
                     inner: UpdateSpeed {
                         guid: player_guid(sender),
                         speed: character.stats.speed.total(),
                     },
-                })?,
+                }),
             ],
         ),
         Broadcast::Single(
@@ -164,7 +164,7 @@ pub fn reply_dismount<'a>(
                         },
                     ],
                 },
-            })?],
+            })],
         ),
     ])
 }
@@ -292,7 +292,7 @@ fn process_mount_spawn(
                                 guid: player_guid(sender),
                                 speed: character_write_handle.stats.speed.total(),
                             },
-                        })?);
+                        }));
 
                         if let Some(mount_id) = character_write_handle.stats.mount_id {
                             return Err(ProcessPacketError::new(
@@ -343,7 +343,7 @@ fn process_mount_spawn(
                                             },
                                         ],
                                     },
-                                })?],
+                                })],
                             ),
                         ])
                     },
@@ -507,7 +507,7 @@ pub fn spawn_mount_npc(
                 unknown71: 0,
                 icon_id: Icon::None,
             },
-        })?,
+        }),
         GamePacket::serialize(&TunneledPacket {
             unknown1: true,
             inner: MountReply {
@@ -519,6 +519,6 @@ pub fn spawn_mount_npc(
                 composite_effect: 0,
                 unknown5: 0,
             },
-        })?,
+        }),
     ])
 }

--- a/src/game_server/handlers/test_data.rs
+++ b/src/game_server/handlers/test_data.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use packet_serialize::{LengthlessVec, SerializePacketError};
+use packet_serialize::LengthlessVec;
 
 use crate::game_server::packets::{
     item::{EquipmentSlot, Item, ItemDefinition, MarketData},
@@ -372,12 +372,12 @@ pub fn make_test_customizations() -> BTreeMap<CustomizationSlot, u32> {
     customizations
 }
 
-pub fn make_test_nameplate_image(guid: u32) -> Result<Vec<Vec<u8>>, SerializePacketError> {
-    Ok(vec![GamePacket::serialize(&TunneledPacket {
+pub fn make_test_nameplate_image(guid: u32) -> Vec<Vec<u8>> {
+    vec![GamePacket::serialize(&TunneledPacket {
         unknown1: true,
         inner: NameplateImageId {
             image_id: NameplateImage::Trooper,
             guid: player_guid(guid),
         },
-    })?])
+    })]
 }

--- a/src/game_server/handlers/zone.rs
+++ b/src/game_server/handlers/zone.rs
@@ -436,7 +436,7 @@ impl ZoneInstance {
                 unknown7: 0,
                 unknown8: 0,
             },
-        })?];
+        })];
 
         if let Some(house) = &self.house_data {
             packets.append(&mut prepare_init_house_packets(sender, self, house)?);
@@ -453,7 +453,7 @@ impl ZoneInstance {
                     script_name: "UIGlobal.AtlasLoadZone".to_string(),
                     params: vec![self.map_id as i32],
                 },
-            })?,
+            }),
             GamePacket::serialize(&TunneledPacket {
                 unknown1: true,
                 inner: ExecuteScriptWithStringParams {
@@ -463,7 +463,7 @@ impl ZoneInstance {
                     ),
                     params: vec![],
                 },
-            })?,
+            }),
         ])
     }
 
@@ -786,7 +786,7 @@ impl ZoneInstance {
                                 vec![GamePacket::serialize(&TunneledPacket {
                                     unknown1: true,
                                     inner: full_update_packet,
-                                })?],
+                                })],
                             ));
                             Ok::<(bool, bool, Vec<Broadcast>, Vec<u64>), ProcessPacketError>((
                                 true,
@@ -900,7 +900,7 @@ impl ZoneInstance {
                             new_chunk_packets.push(GamePacket::serialize(&TunneledPacket {
                                 unknown1: true,
                                 inner: full_update_packet,
-                            })?);
+                            }));
                             broadcasts
                                 .push(Broadcast::Multi(other_players_nearby, new_chunk_packets));
 
@@ -930,7 +930,7 @@ impl ZoneInstance {
                             is_teleport: true,
                             unknown2: true,
                         },
-                    })?],
+                    })],
                 ));
             }
         }
@@ -1075,7 +1075,7 @@ fn prepare_init_zone_packets(
             unknown6: false,
             unknown7: false,
         },
-    })?);
+    }));
 
     packets.append(&mut destination.send_self(player)?);
 
@@ -1319,7 +1319,7 @@ pub fn interact_with_character(
                                     destination,
                                     target,
                                 },
-                            })?],
+                            })],
                         ));
                         return coerce_to_broadcast_supplier(|_| Ok(broadcasts));
                     }
@@ -1347,6 +1347,6 @@ pub fn teleport_within_zone(
                 is_teleport: true,
                 unknown2: true,
             },
-        })?],
+        })],
     )])
 }

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -54,7 +54,7 @@ use packets::{GamePacket, OpCode};
 use rand::Rng;
 
 use crate::{info, ConfigError};
-use packet_serialize::{DeserializePacket, DeserializePacketError, SerializePacketError};
+use packet_serialize::{DeserializePacket, DeserializePacketError};
 
 mod handlers;
 mod packets;
@@ -113,15 +113,6 @@ impl From<DeserializePacketError> for ProcessPacketError {
         ProcessPacketError::new(
             ProcessPacketErrorType::DeserializeError,
             format!("Deserialize Error: {:?}", err),
-        )
-    }
-}
-
-impl From<SerializePacketError> for ProcessPacketError {
-    fn from(err: SerializePacketError) -> Self {
-        ProcessPacketError::new(
-            ProcessPacketErrorType::SerializeError,
-            format!("Serialize Error: {:?}", err),
         )
     }
 }
@@ -313,16 +304,16 @@ impl GameServer {
                                             },
                                         };
                                         sender_only_packets
-                                            .push(GamePacket::serialize(&welcome_screen)?);
+                                            .push(GamePacket::serialize(&welcome_screen));
 
                                         let minigame_definitions = TunneledPacket {
                                             unknown1: true,
                                             inner: GamePacket::serialize(
                                                 &self.minigames.definitions(),
-                                            )?,
+                                            ),
                                         };
                                         sender_only_packets
-                                            .push(GamePacket::serialize(&minigame_definitions)?);
+                                            .push(GamePacket::serialize(&minigame_definitions));
                                     }
 
                                     player.ready = true;
@@ -332,25 +323,25 @@ impl GameServer {
                             )
                         })?;
 
-                    sender_only_packets.append(&mut send_points_of_interest(self)?);
+                    sender_only_packets.append(&mut send_points_of_interest(self));
 
                     let categories = TunneledPacket {
                         unknown1: true,
-                        inner: GamePacket::serialize(&self.categories)?,
+                        inner: GamePacket::serialize(&self.categories),
                     };
-                    sender_only_packets.push(GamePacket::serialize(&categories)?);
+                    sender_only_packets.push(GamePacket::serialize(&categories));
 
                     let item_groups = TunneledPacket {
                         unknown1: true,
-                        inner: GamePacket::serialize(&self.item_groups)?,
+                        inner: GamePacket::serialize(&self.item_groups),
                     };
-                    sender_only_packets.push(GamePacket::serialize(&item_groups)?);
+                    sender_only_packets.push(GamePacket::serialize(&item_groups));
 
                     let store_items = TunneledPacket {
                         unknown1: true,
-                        inner: GamePacket::serialize(&StoreItemList::from(&self.costs))?,
+                        inner: GamePacket::serialize(&StoreItemList::from(&self.costs)),
                     };
-                    sender_only_packets.push(GamePacket::serialize(&store_items)?);
+                    sender_only_packets.push(GamePacket::serialize(&store_items));
 
                     let mut character_broadcasts = self.lock_enforcer().read_characters(|characters_table_read_handle| {
                         let possible_index = characters_table_read_handle.index1(player_guid(sender));
@@ -422,7 +413,7 @@ impl GameServer {
                                                 ],
                                             },
                                         };
-                                        sender_only_character_packets.push(GamePacket::serialize(&stats)?);
+                                        sender_only_character_packets.push(GamePacket::serialize(&stats));
 
                                         let health = TunneledPacket {
                                             unknown1: true,
@@ -431,7 +422,7 @@ impl GameServer {
                                                 max: 25000,
                                             },
                                         };
-                                        sender_only_character_packets.push(GamePacket::serialize(&health)?);
+                                        sender_only_character_packets.push(GamePacket::serialize(&health));
 
                                         let power = TunneledPacket {
                                             unknown1: true,
@@ -440,7 +431,7 @@ impl GameServer {
                                                 max: 300,
                                             },
                                         };
-                                        sender_only_character_packets.push(GamePacket::serialize(&power)?);
+                                        sender_only_character_packets.push(GamePacket::serialize(&power));
 
                                         let mut character_broadcasts = Vec::new();
 
@@ -459,7 +450,7 @@ impl GameServer {
                                                 wield_type: character_write_handle.stats.wield_type(),
                                             },
                                         };
-                                        global_packets.push(GamePacket::serialize(&wield_type)?);
+                                        global_packets.push(GamePacket::serialize(&wield_type));
 
                                         if let CharacterType::Player(player) = &character_write_handle.stats.character_type {
                                             sender_only_character_packets.push(GamePacket::serialize(&TunneledPacket {
@@ -467,7 +458,7 @@ impl GameServer {
                                                 inner: InitCustomizations {
                                                     customizations: customizations_from_guids(player.customizations.values().cloned(), self.customizations()),
                                                 },
-                                            })?);
+                                            }));
 
                                             if let Some(battle_class) = player.battle_classes.get(&player.active_battle_class) {
                                                 character_broadcasts.append(&mut update_saber_tints(
@@ -497,19 +488,19 @@ impl GameServer {
                     })?;
                     broadcasts.append(&mut character_broadcasts);
 
-                    sender_only_packets.append(&mut make_test_nameplate_image(sender)?);
+                    sender_only_packets.append(&mut make_test_nameplate_image(sender));
 
                     let zone_details_done = TunneledPacket {
                         unknown1: true,
                         inner: ZoneDetailsDone {},
                     };
-                    sender_only_packets.push(GamePacket::serialize(&zone_details_done)?);
+                    sender_only_packets.push(GamePacket::serialize(&zone_details_done));
 
                     let preload_characters_done = TunneledPacket {
                         unknown1: true,
                         inner: PreloadCharactersDone { unknown1: false },
                     };
-                    sender_only_packets.push(GamePacket::serialize(&preload_characters_done)?);
+                    sender_only_packets.push(GamePacket::serialize(&preload_characters_done));
 
                     broadcasts.push(Broadcast::Single(sender, sender_only_packets));
                 }
@@ -552,7 +543,7 @@ impl GameServer {
 
                                             broadcasts.push(Broadcast::Single(
                                                 sender,
-                                                vec![GamePacket::serialize(&game_time_sync)?],
+                                                vec![GamePacket::serialize(&game_time_sync)],
                                             ));
 
                                             Ok::<(), ProcessPacketError>(())
@@ -684,14 +675,14 @@ impl GameServer {
                                         delay_seconds: 0.0,
                                         duration_seconds: 2.0,
                                     }
-                                })?,
+                                }),
                                 GamePacket::serialize(&TunneledPacket {
                                     unknown1: true,
                                     inner: UpdateWieldType {
                                         guid: player_guid(sender),
                                         wield_type: character_write_handle.stats.wield_type()
                                     }
-                                })?,
+                                }),
                             ]));
                             Ok(())
                         }

--- a/src/game_server/packets/chat.rs
+++ b/src/game_server/packets/chat.rs
@@ -1,11 +1,9 @@
 use std::io::Cursor;
 
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use byteorder::{LittleEndian, ReadBytesExt};
 use num_enum::TryFromPrimitive;
 
-use packet_serialize::{
-    DeserializePacket, DeserializePacketError, SerializePacket, SerializePacketError,
-};
+use packet_serialize::{DeserializePacket, DeserializePacketError, SerializePacket};
 
 use super::{GamePacket, Name, OpCode, Pos};
 
@@ -17,10 +15,9 @@ pub enum ChatOpCode {
 }
 
 impl SerializePacket for ChatOpCode {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        OpCode::Chat.serialize(buffer)?;
-        buffer.write_u16::<LittleEndian>(*self as u16)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        OpCode::Chat.serialize(buffer);
+        (*self as u16).serialize(buffer);
     }
 }
 
@@ -92,16 +89,12 @@ pub struct SendMessage {
 }
 
 impl SerializePacket for SendMessage {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_u16::<LittleEndian>(self.message_type_data.message_type() as u16)?;
-        self.payload.serialize(buffer)?;
-        match self.message_type_data {
-            MessageTypeData::Area(area_id) => {
-                Ok::<(), SerializePacketError>(buffer.write_u32::<LittleEndian>(area_id)?)
-            }
-            _ => Ok(()),
-        }?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        (self.message_type_data.message_type() as u16).serialize(buffer);
+        self.payload.serialize(buffer);
+        if let MessageTypeData::Area(area_id) = self.message_type_data {
+            area_id.serialize(buffer);
+        }
     }
 }
 
@@ -155,9 +148,8 @@ pub enum ActionBarTextColor {
 }
 
 impl SerializePacket for ActionBarTextColor {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_u32::<LittleEndian>(*self as u32)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        (*self as u32).serialize(buffer);
     }
 }
 

--- a/src/game_server/packets/client_update.rs
+++ b/src/game_server/packets/client_update.rs
@@ -1,8 +1,4 @@
-use std::io::Write;
-
-use byteorder::{LittleEndian, WriteBytesExt};
-
-use packet_serialize::{DeserializePacket, SerializePacket, SerializePacketError};
+use packet_serialize::{DeserializePacket, SerializePacket};
 
 use super::{
     item::{Attachment, EquipmentSlot, Item, ItemDefinition},
@@ -23,10 +19,9 @@ pub enum ClientUpdateOpCode {
 }
 
 impl SerializePacket for ClientUpdateOpCode {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        OpCode::ClientUpdate.serialize(buffer)?;
-        buffer.write_u16::<LittleEndian>(*self as u16)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        OpCode::ClientUpdate.serialize(buffer);
+        (*self as u16).serialize(buffer);
     }
 }
 
@@ -54,12 +49,11 @@ pub struct AddItems {
 }
 
 impl SerializePacket for AddItems {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
+    fn serialize(&self, buffer: &mut Vec<u8>) {
         let mut inner_buffer = Vec::new();
-        self.data.serialize(&mut inner_buffer)?;
-        buffer.write_u32::<LittleEndian>(inner_buffer.len() as u32)?;
-        buffer.write_all(&inner_buffer)?;
-        Ok(())
+        self.data.serialize(&mut inner_buffer);
+        (inner_buffer.len() as u32).serialize(buffer);
+        inner_buffer.serialize(buffer);
     }
 }
 
@@ -157,9 +151,8 @@ pub enum StatId {
 }
 
 impl SerializePacket for StatId {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_u32::<LittleEndian>(*self as u32)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        (*self as u32).serialize(buffer);
     }
 }
 

--- a/src/game_server/packets/client_update.rs
+++ b/src/game_server/packets/client_update.rs
@@ -52,7 +52,6 @@ impl SerializePacket for AddItems {
     fn serialize(&self, buffer: &mut Vec<u8>) {
         let mut inner_buffer = Vec::new();
         self.data.serialize(&mut inner_buffer);
-        (inner_buffer.len() as u32).serialize(buffer);
         inner_buffer.serialize(buffer);
     }
 }

--- a/src/game_server/packets/combat.rs
+++ b/src/game_server/packets/combat.rs
@@ -1,5 +1,4 @@
-use byteorder::{LittleEndian, WriteBytesExt};
-use packet_serialize::{DeserializePacket, SerializePacket, SerializePacketError};
+use packet_serialize::{DeserializePacket, SerializePacket};
 
 use super::{GamePacket, OpCode};
 
@@ -9,10 +8,9 @@ pub enum CombatOpCode {
 }
 
 impl SerializePacket for CombatOpCode {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        OpCode::Combat.serialize(buffer)?;
-        buffer.write_u16::<LittleEndian>(*self as u16)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        OpCode::Combat.serialize(buffer);
+        (*self as u16).serialize(buffer);
     }
 }
 

--- a/src/game_server/packets/command.rs
+++ b/src/game_server/packets/command.rs
@@ -1,6 +1,5 @@
-use byteorder::{LittleEndian, WriteBytesExt};
 use num_enum::TryFromPrimitive;
-use packet_serialize::{DeserializePacket, SerializePacket, SerializePacketError};
+use packet_serialize::{DeserializePacket, SerializePacket};
 
 use super::{GamePacket, OpCode, Pos, Rgba, Target};
 
@@ -22,10 +21,9 @@ pub enum CommandOpCode {
 }
 
 impl SerializePacket for CommandOpCode {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        OpCode::Command.serialize(buffer)?;
-        buffer.write_u16::<LittleEndian>(*self as u16)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        OpCode::Command.serialize(buffer);
+        (*self as u16).serialize(buffer);
     }
 }
 

--- a/src/game_server/packets/housing.rs
+++ b/src/game_server/packets/housing.rs
@@ -1,8 +1,5 @@
-use std::io::Write;
-
-use byteorder::{LittleEndian, WriteBytesExt};
 use num_enum::TryFromPrimitive;
-use packet_serialize::{DeserializePacket, SerializePacket, SerializePacketError};
+use packet_serialize::{DeserializePacket, SerializePacket};
 
 use super::{item::BaseAttachmentGroup, GamePacket, OpCode, Pos};
 
@@ -23,10 +20,9 @@ pub enum HousingOpCode {
 }
 
 impl SerializePacket for HousingOpCode {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        OpCode::Housing.serialize(buffer)?;
-        buffer.write_u16::<LittleEndian>(*self as u16)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        OpCode::Housing.serialize(buffer);
+        (*self as u16).serialize(buffer);
     }
 }
 
@@ -243,13 +239,12 @@ pub struct HouseInstanceData {
 }
 
 impl SerializePacket for HouseInstanceData {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
+    fn serialize(&self, buffer: &mut Vec<u8>) {
         let mut inner = Vec::new();
-        self.inner.serialize(&mut inner)?;
-        buffer.write_u32::<LittleEndian>(inner.len() as u32)?;
-        buffer.write_all(&inner)?;
-        self.rooms.serialize(buffer)?;
-        Ok(())
+        self.inner.serialize(&mut inner);
+        (inner.len() as u32).serialize(buffer);
+        inner.serialize(buffer);
+        self.rooms.serialize(buffer);
     }
 }
 

--- a/src/game_server/packets/housing.rs
+++ b/src/game_server/packets/housing.rs
@@ -242,7 +242,6 @@ impl SerializePacket for HouseInstanceData {
     fn serialize(&self, buffer: &mut Vec<u8>) {
         let mut inner = Vec::new();
         self.inner.serialize(&mut inner);
-        (inner.len() as u32).serialize(buffer);
         inner.serialize(buffer);
         self.rooms.serialize(buffer);
     }

--- a/src/game_server/packets/inventory.rs
+++ b/src/game_server/packets/inventory.rs
@@ -1,6 +1,5 @@
-use byteorder::{LittleEndian, WriteBytesExt};
 use num_enum::TryFromPrimitive;
-use packet_serialize::{DeserializePacket, SerializePacket, SerializePacketError};
+use packet_serialize::{DeserializePacket, SerializePacket};
 
 use super::{item::EquipmentSlot, OpCode};
 
@@ -15,10 +14,9 @@ pub enum InventoryOpCode {
 }
 
 impl SerializePacket for InventoryOpCode {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        OpCode::Inventory.serialize(buffer)?;
-        buffer.write_u16::<LittleEndian>(*self as u16)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        OpCode::Inventory.serialize(buffer);
+        (*self as u16).serialize(buffer);
     }
 }
 

--- a/src/game_server/packets/item.rs
+++ b/src/game_server/packets/item.rs
@@ -1,8 +1,6 @@
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use byteorder::{LittleEndian, ReadBytesExt};
 use num_enum::TryFromPrimitive;
-use packet_serialize::{
-    DeserializePacket, DeserializePacketError, SerializePacket, SerializePacketError,
-};
+use packet_serialize::{DeserializePacket, DeserializePacketError, SerializePacket};
 use serde::{de::IgnoredAny, Deserialize};
 
 use super::{player_update::CustomizationSlot, GamePacket, OpCode};
@@ -49,9 +47,8 @@ impl EquipmentSlot {
 }
 
 impl SerializePacket for EquipmentSlot {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_u32::<LittleEndian>(*self as u32)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        (*self as u32).serialize(buffer);
     }
 }
 
@@ -93,9 +90,8 @@ pub enum WieldType {
 }
 
 impl SerializePacket for WieldType {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_u32::<LittleEndian>(*self as u32)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        (*self as u32).serialize(buffer);
     }
 }
 

--- a/src/game_server/packets/login.rs
+++ b/src/game_server/packets/login.rs
@@ -171,7 +171,6 @@ impl SerializePacket for DefinePointsOfInterest {
         }
         0u8.serialize(&mut inner_buffer);
 
-        (inner_buffer.len() as u32).serialize(buffer);
         inner_buffer.serialize(buffer);
     }
 }

--- a/src/game_server/packets/login.rs
+++ b/src/game_server/packets/login.rs
@@ -166,10 +166,10 @@ impl SerializePacket for DefinePointsOfInterest {
         let mut inner_buffer = Vec::new();
 
         for point in self.points.iter() {
-            1u8.serialize(&mut inner_buffer);
+            true.serialize(&mut inner_buffer);
             point.serialize(&mut inner_buffer);
         }
-        0u8.serialize(&mut inner_buffer);
+        false.serialize(&mut inner_buffer);
 
         inner_buffer.serialize(buffer);
     }

--- a/src/game_server/packets/login.rs
+++ b/src/game_server/packets/login.rs
@@ -1,9 +1,4 @@
-use std::io::Write;
-
-use byteorder::{LittleEndian, WriteBytesExt};
-use packet_serialize::{
-    DeserializePacket, NullTerminatedString, SerializePacket, SerializePacketError,
-};
+use packet_serialize::{DeserializePacket, NullTerminatedString, SerializePacket};
 
 use crate::game_server::handlers::zone::PointOfInterestConfig;
 
@@ -167,19 +162,17 @@ pub struct DefinePointsOfInterest {
 }
 
 impl SerializePacket for DefinePointsOfInterest {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
+    fn serialize(&self, buffer: &mut Vec<u8>) {
         let mut inner_buffer = Vec::new();
 
         for point in self.points.iter() {
-            inner_buffer.write_u8(1)?;
-            SerializePacket::serialize(point, &mut inner_buffer)?;
+            1u8.serialize(&mut inner_buffer);
+            point.serialize(&mut inner_buffer);
         }
-        inner_buffer.write_u8(0)?;
+        0u8.serialize(&mut inner_buffer);
 
-        buffer.write_u32::<LittleEndian>(inner_buffer.len() as u32)?;
-        buffer.write_all(&inner_buffer)?;
-
-        Ok(())
+        (inner_buffer.len() as u32).serialize(buffer);
+        inner_buffer.serialize(buffer);
     }
 }
 

--- a/src/game_server/packets/minigame.rs
+++ b/src/game_server/packets/minigame.rs
@@ -1,5 +1,5 @@
 use num_enum::TryFromPrimitive;
-use packet_serialize::{DeserializePacket, SerializePacket};
+use packet_serialize::{DeserializePacket, LengthlessSlice, SerializePacket};
 
 use super::{GamePacket, OpCode, RewardBundle};
 
@@ -133,7 +133,6 @@ impl SerializePacket for MinigameDefinitions {
         self.portal_categories.serialize(&mut inner_buffer);
 
         self.header.serialize(buffer);
-        SerializePacket::serialize(&(inner_buffer.len() as u32), buffer);
         SerializePacket::serialize(&inner_buffer, buffer);
     }
 }
@@ -186,7 +185,7 @@ impl SerializePacket for FlashPayload {
     fn serialize(&self, buffer: &mut Vec<u8>) {
         self.header.serialize(buffer);
         SerializePacket::serialize(&(self.payload.len().saturating_add(1) as u32), buffer);
-        SerializePacket::serialize(&self.payload.as_bytes(), buffer);
+        SerializePacket::serialize(&LengthlessSlice(self.payload.as_bytes()), buffer);
         SerializePacket::serialize(&0u8, buffer);
     }
 }

--- a/src/game_server/packets/minigame.rs
+++ b/src/game_server/packets/minigame.rs
@@ -1,8 +1,5 @@
-use std::io::Write;
-
-use byteorder::{LittleEndian, WriteBytesExt};
 use num_enum::TryFromPrimitive;
-use packet_serialize::{DeserializePacket, SerializePacket, SerializePacketError};
+use packet_serialize::{DeserializePacket, SerializePacket};
 
 use super::{GamePacket, OpCode, RewardBundle};
 
@@ -28,10 +25,9 @@ pub enum MinigameOpCode {
 }
 
 impl SerializePacket for MinigameOpCode {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        OpCode::Minigame.serialize(buffer)?;
-        buffer.write_u8(*self as u8)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        OpCode::Minigame.serialize(buffer);
+        SerializePacket::serialize(&(*self as u8), buffer);
     }
 }
 
@@ -129,17 +125,16 @@ pub struct MinigameDefinitions {
 }
 
 impl SerializePacket for MinigameDefinitions {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
+    fn serialize(&self, buffer: &mut Vec<u8>) {
         let mut inner_buffer = Vec::new();
-        SerializePacket::serialize(&self.stages, &mut inner_buffer)?;
-        SerializePacket::serialize(&self.stage_groups, &mut inner_buffer)?;
-        SerializePacket::serialize(&self.portal_entries, &mut inner_buffer)?;
-        SerializePacket::serialize(&self.portal_categories, &mut inner_buffer)?;
+        self.stages.serialize(&mut inner_buffer);
+        self.stage_groups.serialize(&mut inner_buffer);
+        self.portal_entries.serialize(&mut inner_buffer);
+        self.portal_categories.serialize(&mut inner_buffer);
 
-        SerializePacket::serialize(&self.header, buffer)?;
-        buffer.write_u32::<LittleEndian>(inner_buffer.len() as u32)?;
-        buffer.write_all(&inner_buffer)?;
-        Ok(())
+        self.header.serialize(buffer);
+        SerializePacket::serialize(&(inner_buffer.len() as u32), buffer);
+        SerializePacket::serialize(&inner_buffer, buffer);
     }
 }
 
@@ -188,12 +183,11 @@ pub struct FlashPayload {
 }
 
 impl SerializePacket for FlashPayload {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        self.header.serialize(buffer)?;
-        buffer.write_u32::<LittleEndian>(self.payload.len().saturating_add(1) as u32)?;
-        buffer.write_all(self.payload.as_bytes())?;
-        buffer.write_u8(0)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        self.header.serialize(buffer);
+        SerializePacket::serialize(&(self.payload.len().saturating_add(1) as u32), buffer);
+        SerializePacket::serialize(&self.payload.as_bytes(), buffer);
+        SerializePacket::serialize(&0u8, buffer);
     }
 }
 
@@ -342,9 +336,8 @@ pub enum ScoreType {
 }
 
 impl SerializePacket for ScoreType {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_i32::<LittleEndian>(*self as i32)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        SerializePacket::serialize(&(*self as i32), buffer);
     }
 }
 

--- a/src/game_server/packets/mod.rs
+++ b/src/game_server/packets/mod.rs
@@ -23,9 +23,8 @@ pub mod zone;
 
 use std::fmt::Display;
 
-use byteorder::{LittleEndian, WriteBytesExt};
 use num_enum::TryFromPrimitive;
-use packet_serialize::{DeserializePacket, SerializePacket, SerializePacketError};
+use packet_serialize::{DeserializePacket, SerializePacket};
 use serde::Deserialize;
 
 #[derive(Copy, Clone, Debug, TryFromPrimitive)]
@@ -78,9 +77,8 @@ pub enum OpCode {
 }
 
 impl SerializePacket for OpCode {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_u16::<LittleEndian>(*self as u16)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        (*self as u16).serialize(buffer);
     }
 }
 
@@ -88,11 +86,11 @@ pub trait GamePacket: SerializePacket {
     type Header: SerializePacket;
     const HEADER: Self::Header;
 
-    fn serialize(&self) -> Result<Vec<u8>, SerializePacketError> {
+    fn serialize(&self) -> Vec<u8> {
         let mut buffer = Vec::new();
-        SerializePacket::serialize(&Self::HEADER, &mut buffer)?;
-        SerializePacket::serialize(self, &mut buffer)?;
-        Ok(buffer)
+        SerializePacket::serialize(&Self::HEADER, &mut buffer);
+        SerializePacket::serialize(self, &mut buffer);
+        buffer
     }
 }
 
@@ -219,38 +217,36 @@ pub enum Target {
 }
 
 impl SerializePacket for Target {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
+    fn serialize(&self, buffer: &mut Vec<u8>) {
         match self {
             Target::None => {
-                buffer.write_u32::<LittleEndian>(0)?;
+                0u32.serialize(buffer);
             }
             Target::Guid(guid_target) => {
-                buffer.write_u32::<LittleEndian>(1)?;
-                guid_target.serialize(buffer)?;
+                1u32.serialize(buffer);
+                guid_target.serialize(buffer);
             }
             Target::BoundingBox(bounding_box_target) => {
-                buffer.write_u32::<LittleEndian>(2)?;
-                bounding_box_target.serialize(buffer)?;
+                2u32.serialize(buffer);
+                bounding_box_target.serialize(buffer);
             }
             Target::CharacterBone(character_bone_name_target) => {
-                buffer.write_u32::<LittleEndian>(3)?;
-                character_bone_name_target.serialize(buffer)?;
+                3u32.serialize(buffer);
+                character_bone_name_target.serialize(buffer);
             }
             Target::CharacterBoneId(character_bone_id_target) => {
-                buffer.write_u32::<LittleEndian>(4)?;
-                character_bone_id_target.serialize(buffer)?;
+                4u32.serialize(buffer);
+                character_bone_id_target.serialize(buffer);
             }
             Target::ActorBoneName(actor_bone_name_target) => {
-                buffer.write_u32::<LittleEndian>(5)?;
-                actor_bone_name_target.serialize(buffer)?;
+                5u32.serialize(buffer);
+                actor_bone_name_target.serialize(buffer);
             }
             Target::ActorBoneId(actor_bone_id_target) => {
-                buffer.write_u32::<LittleEndian>(1)?;
-                actor_bone_id_target.serialize(buffer)?;
+                6u32.serialize(buffer);
+                actor_bone_id_target.serialize(buffer);
             }
         }
-
-        Ok(())
     }
 }
 
@@ -274,12 +270,11 @@ pub struct NewItemRewardEntry {
 }
 
 impl SerializePacket for NewItemRewardEntry {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        self.base.serialize(buffer)?;
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        self.base.serialize(buffer);
         if let Some(value) = self.unknown1 {
-            value.serialize(buffer)?;
+            value.serialize(buffer);
         }
-        Ok(())
     }
 }
 
@@ -368,66 +363,66 @@ pub enum RewardEntry {
 }
 
 impl SerializePacket for RewardEntry {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
+    fn serialize(&self, buffer: &mut Vec<u8>) {
         match self {
             RewardEntry::NewItem(item_reward_entry) => {
-                buffer.write_u32::<LittleEndian>(1)?;
+                1u32.serialize(buffer);
                 item_reward_entry.serialize(buffer)
             }
             RewardEntry::Xp(xp_reward_entry) => {
-                buffer.write_u32::<LittleEndian>(3)?;
+                3u32.serialize(buffer);
                 xp_reward_entry.serialize(buffer)
             }
             RewardEntry::NewQuest(new_quest_reward_entry) => {
-                buffer.write_u32::<LittleEndian>(6)?;
+                6u32.serialize(buffer);
                 new_quest_reward_entry.serialize(buffer)
             }
             RewardEntry::NewBattleClass(new_battle_class_reward_entry) => {
-                buffer.write_u32::<LittleEndian>(7)?;
+                7u32.serialize(buffer);
                 new_battle_class_reward_entry.serialize(buffer)
             }
             RewardEntry::NewAbility(new_ability_reward_entry) => {
-                buffer.write_u32::<LittleEndian>(8)?;
+                8u32.serialize(buffer);
                 new_ability_reward_entry.serialize(buffer)
             }
             RewardEntry::NewCollection(new_collection_reward_entry) => {
-                buffer.write_u32::<LittleEndian>(10)?;
+                10u32.serialize(buffer);
                 new_collection_reward_entry.serialize(buffer)
             }
             RewardEntry::NewCollectionItem(new_collection_item_reward_entry) => {
-                buffer.write_u32::<LittleEndian>(11)?;
+                11u32.serialize(buffer);
                 new_collection_item_reward_entry.serialize(buffer)
             }
             RewardEntry::Token(token_reward_entry) => {
-                buffer.write_u32::<LittleEndian>(12)?;
+                12u32.serialize(buffer);
                 token_reward_entry.serialize(buffer)
             }
             RewardEntry::PetTrickXp(pet_trick_xp_entry) => {
-                buffer.write_u32::<LittleEndian>(13)?;
+                13u32.serialize(buffer);
                 pet_trick_xp_entry.serialize(buffer)
             }
             RewardEntry::NewRecipe(new_recipe_entry) => {
-                buffer.write_u32::<LittleEndian>(14)?;
+                14u32.serialize(buffer);
                 new_recipe_entry.serialize(buffer)
             }
             RewardEntry::ZoneFlag(zone_flag_entry) => {
-                buffer.write_u32::<LittleEndian>(15)?;
+                15u32.serialize(buffer);
                 zone_flag_entry.serialize(buffer)
             }
             RewardEntry::CharacterFlag(character_flag_entry) => {
-                buffer.write_u32::<LittleEndian>(17)?;
+                17u32.serialize(buffer);
                 character_flag_entry.serialize(buffer)
             }
             RewardEntry::WheelSpin(wheel_spin_entry) => {
-                buffer.write_u32::<LittleEndian>(18)?;
+                18u32.serialize(buffer);
                 wheel_spin_entry.serialize(buffer)
             }
             RewardEntry::NewTrophy(new_trophy_entry) => {
-                buffer.write_u32::<LittleEndian>(19)?;
+                19u32.serialize(buffer);
                 new_trophy_entry.serialize(buffer)
             }
             RewardEntry::ClientExitUrl(client_exit_url_entry) => {
-                buffer.write_u32::<LittleEndian>(20)?;
+                20u32.serialize(buffer);
                 client_exit_url_entry.serialize(buffer)
             }
         }

--- a/src/game_server/packets/mount.rs
+++ b/src/game_server/packets/mount.rs
@@ -1,6 +1,5 @@
-use byteorder::WriteBytesExt;
 use num_enum::TryFromPrimitive;
-use packet_serialize::{DeserializePacket, SerializePacket, SerializePacketError};
+use packet_serialize::{DeserializePacket, SerializePacket};
 
 use super::{GamePacket, OpCode};
 
@@ -19,10 +18,9 @@ pub enum MountOpCode {
 }
 
 impl SerializePacket for MountOpCode {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        OpCode::Mount.serialize(buffer)?;
-        buffer.write_u8(*self as u8)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        OpCode::Mount.serialize(buffer);
+        (*self as u8).serialize(buffer);
     }
 }
 

--- a/src/game_server/packets/player_data.rs
+++ b/src/game_server/packets/player_data.rs
@@ -459,7 +459,6 @@ impl SerializePacket for Player {
     fn serialize(&self, buffer: &mut Vec<u8>) {
         let mut data_buffer = Vec::new();
         self.data.serialize(&mut data_buffer);
-        (data_buffer.len() as u32).serialize(buffer);
         data_buffer.serialize(buffer);
     }
 }

--- a/src/game_server/packets/player_data.rs
+++ b/src/game_server/packets/player_data.rs
@@ -1,7 +1,6 @@
-use std::{collections::BTreeMap, io::Write};
+use std::collections::BTreeMap;
 
-use byteorder::{LittleEndian, WriteBytesExt};
-use packet_serialize::{LengthlessVec, SerializePacket, SerializePacketError};
+use packet_serialize::{LengthlessVec, SerializePacket};
 
 use super::{
     item::{EquipmentSlot, Item, MarketData},
@@ -39,9 +38,9 @@ pub enum Ability {
 }
 
 impl SerializePacket for Ability {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
+    fn serialize(&self, buffer: &mut Vec<u8>) {
         match self {
-            Ability::Empty => Ok(buffer.write_u32::<LittleEndian>(0)?),
+            Ability::Empty => 0u32.serialize(buffer),
             Ability::Type1(
                 unknown2,
                 unknown3,
@@ -54,14 +53,13 @@ impl SerializePacket for Ability {
                 unknown11,
                 unknown12,
             ) => {
-                buffer.write_u32::<LittleEndian>(1)?;
-                buffer.write_u32::<LittleEndian>(*unknown2)?;
-                buffer.write_u32::<LittleEndian>(*unknown3)?;
+                1u32.serialize(buffer);
+                unknown2.serialize(buffer);
+                unknown3.serialize(buffer);
                 write_ability_end(
                     *unknown5, *unknown6, *unknown7, *unknown8, *unknown9, *unknown10, *unknown11,
                     *unknown12, buffer,
-                )?;
-                Ok(())
+                );
             }
             Ability::Type2(
                 unknown4,
@@ -74,13 +72,12 @@ impl SerializePacket for Ability {
                 unknown11,
                 unknown12,
             ) => {
-                buffer.write_u32::<LittleEndian>(2)?;
-                buffer.write_u32::<LittleEndian>(*unknown4)?;
+                2u32.serialize(buffer);
+                unknown4.serialize(buffer);
                 write_ability_end(
                     *unknown5, *unknown6, *unknown7, *unknown8, *unknown9, *unknown10, *unknown11,
                     *unknown12, buffer,
-                )?;
-                Ok(())
+                );
             }
             Ability::Type3(
                 unknown2,
@@ -94,14 +91,13 @@ impl SerializePacket for Ability {
                 unknown11,
                 unknown12,
             ) => {
-                buffer.write_u32::<LittleEndian>(3)?;
-                buffer.write_u32::<LittleEndian>(*unknown2)?;
-                buffer.write_u32::<LittleEndian>(*unknown3)?;
+                3u32.serialize(buffer);
+                unknown2.serialize(buffer);
+                unknown3.serialize(buffer);
                 write_ability_end(
                     *unknown5, *unknown6, *unknown7, *unknown8, *unknown9, *unknown10, *unknown11,
                     *unknown12, buffer,
-                )?;
-                Ok(())
+                );
             }
             Ability::OtherType(
                 unknown1,
@@ -114,12 +110,11 @@ impl SerializePacket for Ability {
                 unknown11,
                 unknown12,
             ) => {
-                buffer.write_u32::<LittleEndian>(*unknown1)?;
+                unknown1.serialize(buffer);
                 write_ability_end(
                     *unknown5, *unknown6, *unknown7, *unknown8, *unknown9, *unknown10, *unknown11,
                     *unknown12, buffer,
-                )?;
-                Ok(())
+                );
             }
         }
     }
@@ -135,16 +130,15 @@ fn write_ability_end(
     unknown11: u32,
     unknown12: bool,
     buffer: &mut Vec<u8>,
-) -> Result<(), SerializePacketError> {
-    buffer.write_u32::<LittleEndian>(unknown5)?;
-    buffer.write_u32::<LittleEndian>(unknown6)?;
-    buffer.write_u32::<LittleEndian>(unknown7)?;
-    buffer.write_u32::<LittleEndian>(unknown8)?;
-    buffer.write_u32::<LittleEndian>(unknown9)?;
-    buffer.write_u32::<LittleEndian>(unknown10)?;
-    buffer.write_u32::<LittleEndian>(unknown11)?;
-    buffer.write_u8(unknown12 as u8)?;
-    Ok(())
+) {
+    unknown5.serialize(buffer);
+    unknown6.serialize(buffer);
+    unknown7.serialize(buffer);
+    unknown8.serialize(buffer);
+    unknown9.serialize(buffer);
+    unknown10.serialize(buffer);
+    unknown11.serialize(buffer);
+    unknown12.serialize(buffer);
 }
 
 #[derive(Clone)]
@@ -154,9 +148,9 @@ pub enum BattleClassUnknown10 {
 }
 
 impl SerializePacket for BattleClassUnknown10 {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
+    fn serialize(&self, buffer: &mut Vec<u8>) {
         match self {
-            BattleClassUnknown10::None => Ok(buffer.write_u32::<LittleEndian>(0)?),
+            BattleClassUnknown10::None => 0u32.serialize(buffer),
             BattleClassUnknown10::Some(
                 unknown1,
                 unknown2,
@@ -169,17 +163,16 @@ impl SerializePacket for BattleClassUnknown10 {
                 unknown9,
                 unknown10,
             ) => {
-                buffer.write_u32::<LittleEndian>(*unknown1)?;
-                buffer.write_u8(*unknown2 as u8)?;
-                buffer.write_u32::<LittleEndian>(*unknown3)?;
-                buffer.write_u32::<LittleEndian>(*unknown4)?;
-                buffer.write_u32::<LittleEndian>(*unknown5)?;
-                buffer.write_u32::<LittleEndian>(*unknown6)?;
-                buffer.write_u32::<LittleEndian>(*unknown7)?;
-                buffer.write_u32::<LittleEndian>(*unknown8)?;
-                buffer.write_u32::<LittleEndian>(*unknown9)?;
-                buffer.write_u32::<LittleEndian>(*unknown10)?;
-                Ok(())
+                unknown1.serialize(buffer);
+                unknown2.serialize(buffer);
+                unknown3.serialize(buffer);
+                unknown4.serialize(buffer);
+                unknown5.serialize(buffer);
+                unknown6.serialize(buffer);
+                unknown7.serialize(buffer);
+                unknown8.serialize(buffer);
+                unknown9.serialize(buffer);
+                unknown10.serialize(buffer);
             }
         }
     }
@@ -224,16 +217,15 @@ pub struct Unknown {
 pub struct SocialInfo {}
 
 impl SerializePacket for MarketData {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
+    fn serialize(&self, buffer: &mut Vec<u8>) {
         if let MarketData::Some(expiration, upsells, bundle_id) = &self {
-            buffer.write_u8(true as u8)?;
-            buffer.write_u64::<LittleEndian>(*expiration)?;
-            buffer.write_u32::<LittleEndian>(*upsells)?;
-            buffer.write_u32::<LittleEndian>(*bundle_id)?;
+            true.serialize(buffer);
+            expiration.serialize(buffer);
+            upsells.serialize(buffer);
+            bundle_id.serialize(buffer);
         } else {
-            buffer.write_u8(false as u8)?;
+            false.serialize(buffer);
         }
-        Ok(())
     }
 }
 
@@ -464,12 +456,11 @@ pub struct Player {
 }
 
 impl SerializePacket for Player {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
+    fn serialize(&self, buffer: &mut Vec<u8>) {
         let mut data_buffer = Vec::new();
-        SerializePacket::serialize(&self.data, &mut data_buffer)?;
-        buffer.write_u32::<LittleEndian>(data_buffer.len() as u32)?;
-        buffer.write_all(&data_buffer)?;
-        Ok(())
+        self.data.serialize(&mut data_buffer);
+        (data_buffer.len() as u32).serialize(buffer);
+        data_buffer.serialize(buffer);
     }
 }
 

--- a/src/game_server/packets/player_update.rs
+++ b/src/game_server/packets/player_update.rs
@@ -308,7 +308,6 @@ impl SerializePacket for ItemDefinitionsReply<'_> {
     fn serialize(&self, buffer: &mut Vec<u8>) {
         let mut inner_buffer = Vec::new();
         self.definitions.serialize(&mut inner_buffer);
-        (inner_buffer.len() as u32).serialize(buffer);
         inner_buffer.serialize(buffer);
     }
 }

--- a/src/game_server/packets/player_update.rs
+++ b/src/game_server/packets/player_update.rs
@@ -1,8 +1,6 @@
-use std::{collections::BTreeMap, io::Write};
+use std::collections::BTreeMap;
 
-use byteorder::{LittleEndian, WriteBytesExt};
-
-use packet_serialize::{DeserializePacket, SerializePacket, SerializePacketError};
+use packet_serialize::{DeserializePacket, SerializePacket};
 use serde::{de::IgnoredAny, Deserialize};
 
 use super::{
@@ -52,10 +50,9 @@ pub enum PlayerUpdateOpCode {
 }
 
 impl SerializePacket for PlayerUpdateOpCode {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        OpCode::PlayerUpdate.serialize(buffer)?;
-        buffer.write_u16::<LittleEndian>(*self as u16)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        OpCode::PlayerUpdate.serialize(buffer);
+        (*self as u16).serialize(buffer);
     }
 }
 
@@ -66,10 +63,9 @@ pub enum PlayerUpdateRemoveOpCode {
 }
 
 impl SerializePacket for PlayerUpdateRemoveOpCode {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        PlayerUpdateOpCode::Remove.serialize(buffer)?;
-        buffer.write_u16::<LittleEndian>(*self as u16)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        PlayerUpdateOpCode::Remove.serialize(buffer);
+        (*self as u16).serialize(buffer);
     }
 }
 
@@ -184,9 +180,8 @@ pub enum NameplateImage {
 }
 
 impl SerializePacket for NameplateImage {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_u32::<LittleEndian>(*self as u32)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        (*self as u32).serialize(buffer);
     }
 }
 
@@ -310,12 +305,11 @@ pub struct ItemDefinitionsReply<'a> {
 }
 
 impl SerializePacket for ItemDefinitionsReply<'_> {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
+    fn serialize(&self, buffer: &mut Vec<u8>) {
         let mut inner_buffer = Vec::new();
-        self.definitions.serialize(&mut inner_buffer)?;
-        buffer.write_u32::<LittleEndian>(inner_buffer.len() as u32)?;
-        buffer.write_all(&inner_buffer)?;
-        Ok(())
+        self.definitions.serialize(&mut inner_buffer);
+        (inner_buffer.len() as u32).serialize(buffer);
+        inner_buffer.serialize(buffer);
     }
 }
 
@@ -339,9 +333,8 @@ pub enum CustomizationSlot {
 }
 
 impl SerializePacket for CustomizationSlot {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_u32::<LittleEndian>(*self as u32)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        (*self as u32).serialize(buffer);
     }
 }
 
@@ -628,15 +621,14 @@ pub struct SingleNotification {
 }
 
 impl SerializePacket for SingleNotification {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_u64::<LittleEndian>(self.guid)?;
-        buffer.write_u8(self.notification.is_none() as u8)?;
-        buffer.write_u32::<LittleEndian>(self.unknown1)?;
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        self.guid.serialize(buffer);
+        self.notification.is_none().serialize(buffer);
+        self.unknown1.serialize(buffer);
         if let Some(notification) = &self.notification {
-            notification.serialize(buffer)?;
+            notification.serialize(buffer);
         }
-        buffer.write_u8(self.unknown2 as u8)?;
-        Ok(())
+        self.unknown2.serialize(buffer);
     }
 }
 
@@ -657,14 +649,13 @@ pub struct SingleNpcRelevance {
 }
 
 impl SerializePacket for SingleNpcRelevance {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_u64::<LittleEndian>(self.guid)?;
-        buffer.write_u8(self.cursor.is_some() as u8)?;
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        self.guid.serialize(buffer);
+        self.cursor.is_some().serialize(buffer);
         if let Some(cursor) = self.cursor {
-            buffer.write_u8(cursor)?;
+            cursor.serialize(buffer);
         }
-        buffer.write_u8(self.unknown1 as u8)?;
-        Ok(())
+        self.unknown1.serialize(buffer);
     }
 }
 
@@ -687,9 +678,8 @@ pub enum Hostility {
 }
 
 impl SerializePacket for Hostility {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_u32::<LittleEndian>(*self as u32)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        (*self as u32).serialize(buffer);
     }
 }
 
@@ -709,9 +699,8 @@ pub enum Icon {
 }
 
 impl SerializePacket for Icon {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_u32::<LittleEndian>(*self as u32)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        (*self as u32).serialize(buffer);
     }
 }
 

--- a/src/game_server/packets/purchase.rs
+++ b/src/game_server/packets/purchase.rs
@@ -1,4 +1,4 @@
-use packet_serialize::{DeserializePacket, SerializePacket};
+use packet_serialize::{DeserializePacket, LengthlessVec, SerializePacket};
 
 use super::{GamePacket, OpCode};
 
@@ -56,9 +56,9 @@ pub struct Billboard {
     pub panels: Vec<BillboardPanel>,
 }
 
-#[derive(SerializePacket, DeserializePacket)]
+#[derive(SerializePacket)]
 pub struct BillboardsData {
-    pub billboards: Vec<Billboard>,
+    pub billboards: LengthlessVec<Billboard>,
 }
 
 pub struct Billboards {
@@ -69,9 +69,8 @@ impl SerializePacket for Billboards {
     fn serialize(&self, buffer: &mut Vec<u8>) {
         let mut inner_buffer = Vec::new();
         self.data.serialize(&mut inner_buffer);
-        (self.data.billboards.len() as u32).serialize(buffer);
-        (inner_buffer.len() as u32 - 4).serialize(buffer);
-        (&inner_buffer[4..]).serialize(buffer);
+        (self.data.billboards.0.len() as u32).serialize(buffer);
+        inner_buffer.serialize(buffer);
     }
 }
 

--- a/src/game_server/packets/purchase.rs
+++ b/src/game_server/packets/purchase.rs
@@ -1,7 +1,4 @@
-use std::io::Write;
-
-use byteorder::{LittleEndian, WriteBytesExt};
-use packet_serialize::{DeserializePacket, SerializePacket, SerializePacketError};
+use packet_serialize::{DeserializePacket, SerializePacket};
 
 use super::{GamePacket, OpCode};
 
@@ -13,10 +10,9 @@ pub enum PurchaseOpCode {
 }
 
 impl SerializePacket for PurchaseOpCode {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        OpCode::Purchase.serialize(buffer)?;
-        buffer.write_u16::<LittleEndian>(*self as u16)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        OpCode::Purchase.serialize(buffer);
+        (*self as u16).serialize(buffer);
     }
 }
 
@@ -70,13 +66,12 @@ pub struct Billboards {
 }
 
 impl SerializePacket for Billboards {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
+    fn serialize(&self, buffer: &mut Vec<u8>) {
         let mut inner_buffer = Vec::new();
-        self.data.serialize(&mut inner_buffer)?;
-        buffer.write_u32::<LittleEndian>(self.data.billboards.len() as u32)?;
-        buffer.write_u32::<LittleEndian>(inner_buffer.len() as u32 - 4)?;
-        buffer.write_all(&inner_buffer[4..])?;
-        Ok(())
+        self.data.serialize(&mut inner_buffer);
+        (self.data.billboards.len() as u32).serialize(buffer);
+        (inner_buffer.len() as u32 - 4).serialize(buffer);
+        (&inner_buffer[4..]).serialize(buffer);
     }
 }
 

--- a/src/game_server/packets/reference_data.rs
+++ b/src/game_server/packets/reference_data.rs
@@ -162,7 +162,6 @@ impl SerializePacket for ItemGroupDefinitions {
     fn serialize(&self, buffer: &mut Vec<u8>) {
         let mut inner_buffer = Vec::new();
         self.definitions.serialize(&mut inner_buffer);
-        (inner_buffer.len() as u32).serialize(buffer);
         inner_buffer.serialize(buffer);
     }
 }

--- a/src/game_server/packets/reference_data.rs
+++ b/src/game_server/packets/reference_data.rs
@@ -1,7 +1,6 @@
-use std::{collections::BTreeMap, io::Write};
+use std::collections::BTreeMap;
 
-use byteorder::{LittleEndian, WriteBytesExt};
-use packet_serialize::{SerializePacket, SerializePacketError};
+use packet_serialize::SerializePacket;
 use serde::{de::IgnoredAny, Deserialize};
 
 use super::{item::WieldType, GamePacket, OpCode};
@@ -15,10 +14,9 @@ pub enum ReferenceDataOpCode {
 }
 
 impl SerializePacket for ReferenceDataOpCode {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        OpCode::ReferenceData.serialize(buffer)?;
-        buffer.write_u16::<LittleEndian>(*self as u16)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        OpCode::ReferenceData.serialize(buffer);
+        (*self as u16).serialize(buffer);
     }
 }
 
@@ -36,15 +34,14 @@ pub struct ItemClassDefinition {
 }
 
 impl SerializePacket for ItemClassDefinition {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_i32::<LittleEndian>(self.guid)?;
-        buffer.write_i32::<LittleEndian>(self.guid)?;
-        buffer.write_u32::<LittleEndian>(self.name_id)?;
-        buffer.write_u32::<LittleEndian>(self.icon_set_id)?;
-        self.wield_type.serialize(buffer)?;
-        buffer.write_u32::<LittleEndian>(self.stat_id)?;
-        buffer.write_u32::<LittleEndian>(self.battle_class_name_id)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        self.guid.serialize(buffer);
+        self.guid.serialize(buffer);
+        self.name_id.serialize(buffer);
+        self.icon_set_id.serialize(buffer);
+        self.wield_type.serialize(buffer);
+        self.stat_id.serialize(buffer);
+        self.battle_class_name_id.serialize(buffer);
     }
 }
 
@@ -73,14 +70,13 @@ pub struct CategoryDefinition {
 }
 
 impl SerializePacket for CategoryDefinition {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_i32::<LittleEndian>(self.guid)?;
-        buffer.write_i32::<LittleEndian>(self.guid)?;
-        buffer.write_u32::<LittleEndian>(self.name_id)?;
-        buffer.write_u32::<LittleEndian>(self.icon_set_id)?;
-        buffer.write_i32::<LittleEndian>(self.sort_order)?;
-        buffer.write_u8(self.visible as u8)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        self.guid.serialize(buffer);
+        self.guid.serialize(buffer);
+        self.name_id.serialize(buffer);
+        self.icon_set_id.serialize(buffer);
+        self.sort_order.serialize(buffer);
+        self.visible.serialize(buffer);
     }
 }
 
@@ -95,11 +91,10 @@ pub struct CategoryRelation {
 }
 
 impl SerializePacket for CategoryRelation {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_i32::<LittleEndian>(self.parent_guid)?;
-        buffer.write_i32::<LittleEndian>(self.parent_guid)?;
-        buffer.write_i32::<LittleEndian>(self.child_guid)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        self.parent_guid.serialize(buffer);
+        self.parent_guid.serialize(buffer);
+        self.child_guid.serialize(buffer);
     }
 }
 
@@ -128,11 +123,10 @@ pub struct ItemGroupItem {
 }
 
 impl SerializePacket for ItemGroupItem {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_u32::<LittleEndian>(self.guid)?;
-        buffer.write_u32::<LittleEndian>(self.guid)?;
-        buffer.write_u32::<LittleEndian>(self.unknown)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        self.guid.serialize(buffer);
+        self.guid.serialize(buffer);
+        self.unknown.serialize(buffer);
     }
 }
 
@@ -165,12 +159,11 @@ pub struct ItemGroupDefinitions {
 }
 
 impl SerializePacket for ItemGroupDefinitions {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
+    fn serialize(&self, buffer: &mut Vec<u8>) {
         let mut inner_buffer = Vec::new();
-        self.definitions.serialize(&mut inner_buffer)?;
-        buffer.write_u32::<LittleEndian>(inner_buffer.len() as u32)?;
-        buffer.write_all(&inner_buffer)?;
-        Ok(())
+        self.definitions.serialize(&mut inner_buffer);
+        (inner_buffer.len() as u32).serialize(buffer);
+        inner_buffer.serialize(buffer);
     }
 }
 

--- a/src/game_server/packets/squad.rs
+++ b/src/game_server/packets/squad.rs
@@ -1,6 +1,5 @@
-use byteorder::{LittleEndian, WriteBytesExt};
 use num_enum::TryFromPrimitive;
-use packet_serialize::{DeserializePacket, SerializePacket, SerializePacketError};
+use packet_serialize::{DeserializePacket, SerializePacket};
 
 use crate::game_server::handlers::unique_guid::player_guid;
 
@@ -15,10 +14,9 @@ pub enum SquadOpCode {
 }
 
 impl SerializePacket for SquadOpCode {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        OpCode::Squad.serialize(buffer)?;
-        buffer.write_u16::<LittleEndian>(*self as u16)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        OpCode::Squad.serialize(buffer);
+        (*self as u16).serialize(buffer);
     }
 }
 
@@ -35,9 +33,8 @@ pub enum SquadEvent {
 }
 
 impl SerializePacket for SquadEvent {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_u32::<LittleEndian>(*self as u32)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        (*self as u32).serialize(buffer);
     }
 }
 
@@ -68,9 +65,8 @@ pub enum SquadNameStatus {
 }
 
 impl SerializePacket for SquadNameStatus {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_u32::<LittleEndian>(*self as u32)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        (*self as u32).serialize(buffer);
     }
 }
 
@@ -84,14 +80,14 @@ pub struct SquadMember {
 }
 
 impl SerializePacket for SquadMember {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        self.player_guid.serialize(buffer)?;
-        player_guid(self.player_guid).serialize(buffer)?;
-        self.name.serialize(buffer)?;
-        self.rank.serialize(buffer)?;
-        self.online.serialize(buffer)?;
-        self.member.serialize(buffer)?;
-        self.unknown7.serialize(buffer)
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        self.player_guid.serialize(buffer);
+        player_guid(self.player_guid).serialize(buffer);
+        self.name.serialize(buffer);
+        self.rank.serialize(buffer);
+        self.online.serialize(buffer);
+        self.member.serialize(buffer);
+        self.unknown7.serialize(buffer);
     }
 }
 
@@ -105,9 +101,8 @@ pub enum SquadRank {
 }
 
 impl SerializePacket for SquadRank {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_u32::<LittleEndian>(*self as u32)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        (*self as u32).serialize(buffer);
     }
 }
 
@@ -118,13 +113,13 @@ pub struct SquadRankDefinition {
 }
 
 impl SerializePacket for SquadRankDefinition {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
+    fn serialize(&self, buffer: &mut Vec<u8>) {
         // Use the rank as the ID because the client only allows IDs up to 4
-        self.rank.serialize(buffer)?;
-        self.unknown2.serialize(buffer)?;
-        self.rank.serialize(buffer)?;
-        self.name_override_id.serialize(buffer)?;
-        self.rank.serialize(buffer)
+        self.rank.serialize(buffer);
+        self.unknown2.serialize(buffer);
+        self.rank.serialize(buffer);
+        self.name_override_id.serialize(buffer);
+        self.rank.serialize(buffer);
     }
 }
 
@@ -139,15 +134,15 @@ pub struct SquadFullData {
 }
 
 impl SerializePacket for SquadFullData {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        self.squad_guid.serialize(buffer)?;
-        self.squad_guid.serialize(buffer)?;
-        self.squad_name.serialize(buffer)?;
-        self.unknown4.serialize(buffer)?;
-        self.name_status.serialize(buffer)?;
-        self.members.serialize(buffer)?;
-        self.rank_definitions.serialize(buffer)?;
-        self.max_members.serialize(buffer)
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        self.squad_guid.serialize(buffer);
+        self.squad_guid.serialize(buffer);
+        self.squad_name.serialize(buffer);
+        self.unknown4.serialize(buffer);
+        self.name_status.serialize(buffer);
+        self.members.serialize(buffer);
+        self.rank_definitions.serialize(buffer);
+        self.max_members.serialize(buffer);
     }
 }
 

--- a/src/game_server/packets/store.rs
+++ b/src/game_server/packets/store.rs
@@ -1,5 +1,4 @@
-use byteorder::{LittleEndian, WriteBytesExt};
-use packet_serialize::{SerializePacket, SerializePacketError};
+use packet_serialize::SerializePacket;
 
 use super::{GamePacket, OpCode};
 
@@ -10,10 +9,9 @@ pub enum StoreOpCode {
 }
 
 impl SerializePacket for StoreOpCode {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        OpCode::Store.serialize(buffer)?;
-        buffer.write_u16::<LittleEndian>(*self as u16)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        OpCode::Store.serialize(buffer);
+        (*self as u16).serialize(buffer);
     }
 }
 
@@ -34,22 +32,21 @@ pub struct StoreItem {
 }
 
 impl SerializePacket for StoreItem {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_u32::<LittleEndian>(self.guid)?;
-        buffer.write_u32::<LittleEndian>(self.guid)?;
-        buffer.write_u32::<LittleEndian>(self.unknown2)?;
-        buffer.write_u32::<LittleEndian>(self.unknown3)?;
-        buffer.write_u8(self.unknown4 as u8)?;
-        buffer.write_u8(self.unknown5 as u8)?;
-        buffer.write_u32::<LittleEndian>(self.unknown6)?;
-        buffer.write_u8(self.unknown7 as u8)?;
-        buffer.write_u8(self.unknown8 as u8)?;
-        buffer.write_u32::<LittleEndian>(self.base_cost)?;
-        buffer.write_u32::<LittleEndian>(self.unknown10)?;
-        buffer.write_u32::<LittleEndian>(self.unknown11)?;
-        buffer.write_u32::<LittleEndian>(self.unknown12)?;
-        buffer.write_u32::<LittleEndian>(self.member_cost)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        self.guid.serialize(buffer);
+        self.guid.serialize(buffer);
+        self.unknown2.serialize(buffer);
+        self.unknown3.serialize(buffer);
+        self.unknown4.serialize(buffer);
+        self.unknown5.serialize(buffer);
+        self.unknown6.serialize(buffer);
+        self.unknown7.serialize(buffer);
+        self.unknown8.serialize(buffer);
+        self.base_cost.serialize(buffer);
+        self.unknown10.serialize(buffer);
+        self.unknown11.serialize(buffer);
+        self.unknown12.serialize(buffer);
+        self.member_cost.serialize(buffer);
     }
 }
 

--- a/src/game_server/packets/tunnel.rs
+++ b/src/game_server/packets/tunnel.rs
@@ -12,14 +12,11 @@ fn serialize_tunneled_packet_from_game_packet<T: GamePacket>(
     unknown1.serialize(buffer);
 
     let inner_buffer = GamePacket::serialize(inner);
-    (inner_buffer.len() as u32).serialize(buffer);
     inner_buffer.serialize(buffer);
 }
 
 fn serialize_tunneled_packet_from_bytes(buffer: &mut Vec<u8>, unknown1: bool, inner: &[u8]) {
     unknown1.serialize(buffer);
-
-    (inner.len() as u32).serialize(buffer);
     inner.serialize(buffer);
 }
 

--- a/src/game_server/packets/ui.rs
+++ b/src/game_server/packets/ui.rs
@@ -1,6 +1,4 @@
-use byteorder::WriteBytesExt;
-
-use packet_serialize::{DeserializePacket, SerializePacket, SerializePacketError};
+use packet_serialize::{DeserializePacket, SerializePacket};
 
 use super::{GamePacket, OpCode};
 
@@ -11,10 +9,9 @@ pub enum UiOpCode {
 }
 
 impl SerializePacket for UiOpCode {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        OpCode::Ui.serialize(buffer)?;
-        buffer.write_u8(*self as u8)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        OpCode::Ui.serialize(buffer);
+        (*self as u8).serialize(buffer);
     }
 }
 

--- a/src/packet_serialize/src/lib.rs
+++ b/src/packet_serialize/src/lib.rs
@@ -9,4 +9,7 @@ pub use serialize::*;
 pub struct LengthlessVec<T>(pub Vec<T>);
 
 #[derive(Clone)]
+pub struct LengthlessSlice<'a, T>(pub &'a [T]);
+
+#[derive(Clone)]
 pub struct NullTerminatedString(pub String);

--- a/src/packet_serialize/src/serialize.rs
+++ b/src/packet_serialize/src/serialize.rs
@@ -1,173 +1,169 @@
 use crate::{LengthlessVec, NullTerminatedString};
 use byteorder::{LittleEndian, WriteBytesExt};
 use serde::de::IgnoredAny;
-use std::{
-    collections::BTreeMap,
-    io::{Error, Write},
-};
-
-#[non_exhaustive]
-#[derive(Debug)]
-pub enum SerializePacketError {
-    IoError(Error),
-}
-
-impl From<Error> for SerializePacketError {
-    fn from(value: Error) -> Self {
-        SerializePacketError::IoError(value)
-    }
-}
+use std::{collections::BTreeMap, io::Write};
 
 pub trait SerializePacket {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError>;
+    fn serialize(&self, buffer: &mut Vec<u8>);
 }
 
 // Unsigned integers
 impl SerializePacket for u8 {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_u8(*self)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        buffer.write_u8(*self).expect("Unable to write u8");
     }
 }
 
 impl SerializePacket for u16 {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_u16::<LittleEndian>(*self)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        buffer
+            .write_u16::<LittleEndian>(*self)
+            .expect("Unable to write u16");
     }
 }
 
 impl SerializePacket for u32 {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_u32::<LittleEndian>(*self)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        buffer
+            .write_u32::<LittleEndian>(*self)
+            .expect("Unable to write u32");
     }
 }
 
 impl SerializePacket for u64 {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_u64::<LittleEndian>(*self)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        buffer
+            .write_u64::<LittleEndian>(*self)
+            .expect("Unable to write u64");
     }
 }
 
 impl SerializePacket for u128 {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_u128::<LittleEndian>(*self)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        buffer
+            .write_u128::<LittleEndian>(*self)
+            .expect("Unable to write u128");
     }
 }
 
 // Signed integers
 impl SerializePacket for i8 {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_i8(*self)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        buffer.write_i8(*self).expect("Unable to write i8");
     }
 }
 
 impl SerializePacket for i16 {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_i16::<LittleEndian>(*self)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        buffer
+            .write_i16::<LittleEndian>(*self)
+            .expect("Unable to write i16");
     }
 }
 
 impl SerializePacket for i32 {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_i32::<LittleEndian>(*self)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        buffer
+            .write_i32::<LittleEndian>(*self)
+            .expect("Unable to write i32");
     }
 }
 
 impl SerializePacket for i64 {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_i64::<LittleEndian>(*self)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        buffer
+            .write_i64::<LittleEndian>(*self)
+            .expect("Unable to write i64");
     }
 }
 
 impl SerializePacket for i128 {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_i128::<LittleEndian>(*self)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        buffer
+            .write_i128::<LittleEndian>(*self)
+            .expect("Unable to write i128");
     }
 }
 
 // Floats
 impl SerializePacket for f32 {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_f32::<LittleEndian>(*self)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        buffer
+            .write_f32::<LittleEndian>(*self)
+            .expect("Unable to write f32");
     }
 }
 
 impl SerializePacket for f64 {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_f64::<LittleEndian>(*self)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        buffer
+            .write_f64::<LittleEndian>(*self)
+            .expect("Unable to write f64");
     }
 }
 
 // Other types
 impl SerializePacket for bool {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_u8(*self as u8)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        buffer.write_u8(*self as u8).expect("Unable to write bool");
     }
 }
 
 impl SerializePacket for String {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_u32::<LittleEndian>(self.len() as u32)?;
-        buffer.write_all(self.as_bytes())?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        buffer
+            .write_u32::<LittleEndian>(self.len() as u32)
+            .expect("Unable to write string length");
+        buffer
+            .write_all(self.as_bytes())
+            .expect("Unable to write string");
     }
 }
 
 impl SerializePacket for NullTerminatedString {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        buffer.write_all(self.0.as_bytes())?;
-        buffer.write_u8(0)?;
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        buffer
+            .write_all(self.0.as_bytes())
+            .expect("Unable to write null-terminated string");
+        buffer
+            .write_u8(0)
+            .expect("Unable to write string null terminator");
+    }
+}
+
+impl<T: SerializePacket> SerializePacket for &[T] {
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        SerializePacket::serialize(&(self.len() as u32), buffer);
+        for index in 0..self.len() {
+            SerializePacket::serialize(&self[index], buffer);
+        }
     }
 }
 
 impl<T: SerializePacket> SerializePacket for Vec<T> {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        SerializePacket::serialize(&(self.len() as u32), buffer)?;
-        for index in 0..self.len() {
-            SerializePacket::serialize(&self[index], buffer)?;
-        }
-
-        Ok(())
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        self.as_slice().serialize(buffer);
     }
 }
 
 impl<T: SerializePacket> SerializePacket for LengthlessVec<T> {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
+    fn serialize(&self, buffer: &mut Vec<u8>) {
         let inner_vec = &self.0;
         for index in 0..inner_vec.len() {
-            SerializePacket::serialize(&inner_vec[index], buffer)?;
+            SerializePacket::serialize(&inner_vec[index], buffer);
         }
-
-        Ok(())
     }
 }
 
 impl<K, V: SerializePacket> SerializePacket for BTreeMap<K, V> {
-    fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        SerializePacket::serialize(&(self.len() as u32), buffer)?;
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        SerializePacket::serialize(&(self.len() as u32), buffer);
         for value in self.values() {
-            SerializePacket::serialize(value, buffer)?;
+            SerializePacket::serialize(value, buffer);
         }
-
-        Ok(())
     }
 }
 
 impl SerializePacket for IgnoredAny {
-    fn serialize(&self, _: &mut Vec<u8>) -> Result<(), SerializePacketError> {
-        Ok(())
-    }
+    fn serialize(&self, _: &mut Vec<u8>) {}
 }

--- a/src/packet_serialize/src/serialize.rs
+++ b/src/packet_serialize/src/serialize.rs
@@ -1,4 +1,4 @@
-use crate::{LengthlessVec, NullTerminatedString};
+use crate::{LengthlessSlice, LengthlessVec, NullTerminatedString};
 use byteorder::{LittleEndian, WriteBytesExt};
 use serde::de::IgnoredAny;
 use std::{collections::BTreeMap, io::Write};
@@ -146,12 +146,18 @@ impl<T: SerializePacket> SerializePacket for Vec<T> {
     }
 }
 
+impl<'a, T: SerializePacket> SerializePacket for LengthlessSlice<'a, T> {
+    fn serialize(&self, buffer: &mut Vec<u8>) {
+        let inner_slice = self.0;
+        for index in 0..inner_slice.len() {
+            SerializePacket::serialize(&inner_slice[index], buffer);
+        }
+    }
+}
+
 impl<T: SerializePacket> SerializePacket for LengthlessVec<T> {
     fn serialize(&self, buffer: &mut Vec<u8>) {
-        let inner_vec = &self.0;
-        for index in 0..inner_vec.len() {
-            SerializePacket::serialize(&inner_vec[index], buffer);
-        }
+        LengthlessSlice(self.0.as_slice()).serialize(buffer);
     }
 }
 

--- a/src/packet_serialize_derive/src/lib.rs
+++ b/src/packet_serialize_derive/src/lib.rs
@@ -18,9 +18,8 @@ pub fn derive_serialize(input: proc_macro::TokenStream) -> proc_macro::TokenStre
 
     let expanded = quote! {
         impl #impl_generics packet_serialize::SerializePacket for #name #ty_generics #where_clause {
-            fn serialize(&self, buffer: &mut Vec<u8>) -> Result<(), packet_serialize::SerializePacketError> {
+            fn serialize(&self, buffer: &mut Vec<u8>) {
                 #writes
-                Ok(())
             }
         }
     };

--- a/src/packet_serialize_derive/src/serialize.rs
+++ b/src/packet_serialize_derive/src/serialize.rs
@@ -21,7 +21,7 @@ pub fn write_fields(data: &Data) -> TokenStream {
                 let writes = fields.named.iter().map(|f| {
                     let name = &f.ident;
                     quote_spanned! {f.span()=>
-                        packet_serialize::SerializePacket::serialize(&self.#name, buffer)?;
+                        packet_serialize::SerializePacket::serialize(&self.#name, buffer);
                     }
                 });
                 quote! {
@@ -34,7 +34,7 @@ pub fn write_fields(data: &Data) -> TokenStream {
                 let writes = fields.unnamed.iter().enumerate().map(|(i, f)| {
                     let index = Index::from(i);
                     quote_spanned! {f.span()=>
-                        packet_serialize::SerializePacket::serialize(&self.#index, buffer)?;
+                        packet_serialize::SerializePacket::serialize(&self.#index, buffer);
                     }
                 });
                 quote! {


### PR DESCRIPTION
`Vec` write methods can never return an error. We can significantly simplify packet serialization by removing the error case entirely.