### PR TITLE
Fix removal of mount NPCs for non-players

### DIFF
--- a/src/game_server/handlers/login.rs
+++ b/src/game_server/handlers/login.rs
@@ -157,7 +157,7 @@ pub fn log_out(
             let remove_packets = character
                 .read()
                 .stats
-                .remove_packets(RemovalMode::default())?;
+                .remove_packets(RemovalMode::default());
 
             zones_lock_enforcer.write_zones(|zones_table_write_handle| {
                 clean_up_zone_if_no_players(

--- a/src/game_server/handlers/test_data.rs
+++ b/src/game_server/handlers/test_data.rs
@@ -31,7 +31,7 @@ pub fn make_test_player(
             mount_id: mount.guid(),
             name_id: mount.name_id,
             icon_set_id: mount.icon_set_id,
-            guid: mount_guid(guid, mount.guid()),
+            guid: mount_guid(player_guid(guid)),
             unknown5: false,
             unknown6: 0,
             unknown7: "".to_string(),

--- a/src/game_server/handlers/unique_guid.rs
+++ b/src/game_server/handlers/unique_guid.rs
@@ -24,6 +24,7 @@ pub fn shorten_zone_index(instance_guid: u64) -> u32 {
 
 pub const AMBIENT_NPC_DISCRIMINANT: u8 = 0x10;
 pub const FIXTURE_DISCRIMINANT: u8 = 0x20;
+pub const MOUNT_DISCRIMINANT: u8 = 0x30;
 
 pub fn npc_guid(discriminant: u8, zone_guid: u64, index: u16) -> u64 {
     ((discriminant as u64) << 56) | ((index as u64) << 40) | zone_guid
@@ -44,6 +45,6 @@ pub fn shorten_player_guid(player_guid: u64) -> Result<u32, ProcessPacketError> 
     }
 }
 
-pub fn mount_guid(rider: u32, mount_id: u32) -> u64 {
-    0x0100000000000000u64 | ((mount_id as u64) << 32) | (rider as u64)
+pub fn mount_guid(rider: u64) -> u64 {
+    ((MOUNT_DISCRIMINANT as u64) << 56) | rider
 }

--- a/src/game_server/handlers/zone.rs
+++ b/src/game_server/handlers/zone.rs
@@ -617,10 +617,10 @@ impl ZoneInstance {
                             mount_configs,
                             item_definitions,
                             customizations,
-                        )?);
+                        ));
                     } else {
                         diff_packets
-                            .append(&mut character.stats.remove_packets(RemovalMode::default())?);
+                            .append(&mut character.stats.remove_packets(RemovalMode::default()));
                     }
                 }
             }
@@ -636,13 +636,13 @@ impl ZoneInstance {
                     mount_configs,
                     item_definitions,
                     customizations,
-                )?,
+                ),
             ));
             broadcasts.push(Broadcast::Multi(
                 character_diffs.players_too_far_from_moved_character,
                 moved_character_read_handle
                     .stats
-                    .remove_packets(RemovalMode::default())?,
+                    .remove_packets(RemovalMode::default()),
             ));
         }
 
@@ -866,7 +866,7 @@ impl ZoneInstance {
                                 previous_other_players_nearby,
                                 moved_character_write_handle
                                     .stats
-                                    .remove_packets(RemovalMode::default())?,
+                                    .remove_packets(RemovalMode::default()),
                             ));
 
                             // Move the character
@@ -896,7 +896,7 @@ impl ZoneInstance {
                                     game_server.mounts(),
                                     game_server.items(),
                                     game_server.customizations(),
-                                )?;
+                                );
                             new_chunk_packets.push(GamePacket::serialize(&TunneledPacket {
                                 unknown1: true,
                                 inner: full_update_packet,
@@ -1016,7 +1016,7 @@ pub fn enter_zone(
                     other_players_nearby,
                     character_write_handle
                         .stats
-                        .remove_packets(RemovalMode::default())?,
+                        .remove_packets(RemovalMode::default()),
                 ));
 
                 let previous_zone_template_guid =

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -442,7 +442,7 @@ impl GameServer {
                                         character_write_handle.stats.speed.base = zone.speed;
                                         character_write_handle.stats.jump_height_multiplier.base = zone.jump_height_multiplier;
 
-                                        let mut global_packets = character_write_handle.stats.add_packets(false, self.mounts(), self.items(), self.customizations())?;
+                                        let mut global_packets = character_write_handle.stats.add_packets(false, self.mounts(), self.items(), self.customizations());
                                         let wield_type = TunneledPacket {
                                             unknown1: true,
                                             inner: UpdateWieldType {
@@ -946,7 +946,7 @@ impl GameServer {
                     for tickable_character in characters_write.values_mut() {
                         if tickable_character.synchronize_with.is_none() {
                             broadcasts.append(
-                                &mut tickable_character.tick(now, &nearby_player_guids, &characters_read, self.mounts(), self.items(), self.customizations())?,
+                                &mut tickable_character.tick(now, &nearby_player_guids, &characters_read, self.mounts(), self.items(), self.customizations()),
                             );
                         } else {
                             characters_not_updated.push(tickable_character.guid());
@@ -990,7 +990,7 @@ impl GameServer {
                         }
 
                         broadcasts.append(
-                            &mut tickable_character.tick(now, &nearby_player_guids, &characters_read, self.mounts(), self.items(), self.customizations())?,
+                            &mut tickable_character.tick(now, &nearby_player_guids, &characters_read, self.mounts(), self.items(), self.customizations()),
                         );
                     }
 


### PR DESCRIPTION
Remove some unnecessary `ProcessPacketError` cases for NPC ticking and fix removal of mount NPCs for non-players.