### PR TITLE
Add texture alias config for NPCs

### DIFF
--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -228,7 +228,7 @@ impl BaseNpc {
                 attachments: vec![],
                 hostility: Hostility::Neutral,
                 unknown10: 1,
-                texture_alias: "".to_string(),
+                texture_alias: self.texture_alias.clone(),
                 tint_name: "".to_string(),
                 tint_id: 0,
                 unknown11: true,

--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -134,6 +134,8 @@ pub struct BaseNpcConfig {
     #[serde(default)]
     pub model_id: u32,
     #[serde(default)]
+    pub texture_alias: String,
+    #[serde(default)]
     pub name_id: u32,
     #[serde(default)]
     pub terrain_object_id: u32,
@@ -183,6 +185,7 @@ pub struct BaseNpcConfig {
 #[derive(Clone)]
 pub struct BaseNpc {
     pub model_id: u32,
+    pub texture_alias: String,
     pub name_id: u32,
     pub terrain_object_id: u32,
     pub name_offset_x: f32,
@@ -225,7 +228,7 @@ impl BaseNpc {
                 attachments: vec![],
                 hostility: Hostility::Neutral,
                 unknown10: 1,
-                texture_name: "".to_string(),
+                texture_alias: "".to_string(),
                 tint_name: "".to_string(),
                 tint_id: 0,
                 unknown11: true,
@@ -322,6 +325,7 @@ impl From<BaseNpcConfig> for BaseNpc {
     fn from(value: BaseNpcConfig) -> Self {
         BaseNpc {
             model_id: value.model_id,
+            texture_alias: value.texture_alias,
             name_id: value.name_id,
             terrain_object_id: value.terrain_object_id,
             name_offset_x: value.name_offset_x,
@@ -1374,7 +1378,7 @@ pub struct PreviousFixture {
     pub scale: f32,
     pub item_def_id: u32,
     pub model_id: u32,
-    pub texture_name: String,
+    pub texture_alias: String,
 }
 
 impl PreviousFixture {
@@ -1382,7 +1386,7 @@ impl PreviousFixture {
         CurrentFixture {
             item_def_id: self.item_def_id,
             model_id: self.model_id,
-            texture_name: self.texture_name.clone(),
+            texture_alias: self.texture_alias.clone(),
         }
     }
 }
@@ -1391,7 +1395,7 @@ impl PreviousFixture {
 pub struct CurrentFixture {
     pub item_def_id: u32,
     pub model_id: u32,
-    pub texture_name: String,
+    pub texture_alias: String,
 }
 
 #[derive(Clone)]

--- a/src/game_server/handlers/housing.rs
+++ b/src/game_server/handlers/housing.rs
@@ -168,7 +168,7 @@ pub fn fixture_packets(
                 attachments: vec![],
                 hostility: Hostility::Neutral,
                 unknown10: 0,
-                texture_name: fixture.texture_name.clone(),
+                texture_alias: fixture.texture_alias.clone(),
                 tint_name: "".to_string(),
                 tint_id: 0,
                 unknown11: true,
@@ -547,7 +547,7 @@ pub fn lookup_house(sender: u32, house_guid: u64) -> Result<House, ProcessPacket
                 scale: 1.0,
                 item_def_id: 6,
                 model_id: 1417,
-                texture_name: "".to_string(),
+                texture_alias: "".to_string(),
             },
             PreviousFixture {
                 pos: Pos {
@@ -565,7 +565,7 @@ pub fn lookup_house(sender: u32, house_guid: u64) -> Result<House, ProcessPacket
                 scale: 1.0,
                 item_def_id: 7,
                 model_id: 1419,
-                texture_name: "".to_string(),
+                texture_alias: "".to_string(),
             },
             PreviousFixture {
                 pos: Pos {
@@ -583,7 +583,7 @@ pub fn lookup_house(sender: u32, house_guid: u64) -> Result<House, ProcessPacket
                 scale: 1.0,
                 item_def_id: 7,
                 model_id: 1419,
-                texture_name: "".to_string(),
+                texture_alias: "".to_string(),
             },
             PreviousFixture {
                 pos: Pos {
@@ -601,7 +601,7 @@ pub fn lookup_house(sender: u32, house_guid: u64) -> Result<House, ProcessPacket
                 scale: 1.0,
                 item_def_id: 8,
                 model_id: 1420,
-                texture_name: "".to_string(),
+                texture_alias: "".to_string(),
             },
             PreviousFixture {
                 pos: Pos {
@@ -619,7 +619,7 @@ pub fn lookup_house(sender: u32, house_guid: u64) -> Result<House, ProcessPacket
                 scale: 1.0,
                 item_def_id: 9,
                 model_id: 1418,
-                texture_name: "".to_string(),
+                texture_alias: "".to_string(),
             },
             PreviousFixture {
                 pos: Pos {
@@ -637,7 +637,7 @@ pub fn lookup_house(sender: u32, house_guid: u64) -> Result<House, ProcessPacket
                 scale: 1.0,
                 item_def_id: 9,
                 model_id: 1418,
-                texture_name: "".to_string(),
+                texture_alias: "".to_string(),
             },
             PreviousFixture {
                 pos: Pos {
@@ -655,7 +655,7 @@ pub fn lookup_house(sender: u32, house_guid: u64) -> Result<House, ProcessPacket
                 scale: 1.0,
                 item_def_id: 9,
                 model_id: 1418,
-                texture_name: "".to_string(),
+                texture_alias: "".to_string(),
             },
             PreviousFixture {
                 pos: Pos {
@@ -673,7 +673,7 @@ pub fn lookup_house(sender: u32, house_guid: u64) -> Result<House, ProcessPacket
                 scale: 1.0,
                 item_def_id: 9,
                 model_id: 1418,
-                texture_name: "".to_string(),
+                texture_alias: "".to_string(),
             },
             PreviousFixture {
                 pos: Pos {
@@ -691,7 +691,7 @@ pub fn lookup_house(sender: u32, house_guid: u64) -> Result<House, ProcessPacket
                 scale: 1.0,
                 item_def_id: 10,
                 model_id: 1416,
-                texture_name: "".to_string(),
+                texture_alias: "".to_string(),
             },
             PreviousFixture {
                 pos: Pos {
@@ -709,7 +709,7 @@ pub fn lookup_house(sender: u32, house_guid: u64) -> Result<House, ProcessPacket
                 scale: 1.0,
                 item_def_id: 10,
                 model_id: 1416,
-                texture_name: "".to_string(),
+                texture_alias: "".to_string(),
             },
             PreviousFixture {
                 pos: Pos {
@@ -727,7 +727,7 @@ pub fn lookup_house(sender: u32, house_guid: u64) -> Result<House, ProcessPacket
                 scale: 1.0,
                 item_def_id: 10,
                 model_id: 1416,
-                texture_name: "".to_string(),
+                texture_alias: "".to_string(),
             },
             PreviousFixture {
                 pos: Pos {
@@ -745,7 +745,7 @@ pub fn lookup_house(sender: u32, house_guid: u64) -> Result<House, ProcessPacket
                 scale: 1.0,
                 item_def_id: 10,
                 model_id: 1416,
-                texture_name: "".to_string(),
+                texture_alias: "".to_string(),
             },
         ],
         build_areas: vec![BuildArea {

--- a/src/game_server/handlers/mount.rs
+++ b/src/game_server/handlers/mount.rs
@@ -431,7 +431,7 @@ pub fn spawn_mount_npc(
                 attachments: vec![],
                 hostility: Hostility::Neutral,
                 unknown10: 0,
-                texture_name: mount.texture.clone(),
+                texture_alias: mount.texture.clone(),
                 tint_name: "".to_string(),
                 tint_id: 0,
                 unknown11: true,

--- a/src/game_server/packets/player_update.rs
+++ b/src/game_server/packets/player_update.rs
@@ -719,7 +719,7 @@ pub struct AddNpc {
     pub attachments: Vec<Attachment>,
     pub hostility: Hostility,
     pub unknown10: u32,
-    pub texture_name: String,
+    pub texture_alias: String,
     pub tint_name: String,
     pub tint_id: u32,
     pub unknown11: bool,


### PR DESCRIPTION
Make `texture_alias` configurable for NPCs. Rename `texture_name` to `texture_alias` across the repo for consistency.