### PR TITLE
Refactor matchmaking and multiplayer minigame start

### DIFF
--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -1169,17 +1169,10 @@ pub struct BattleClass {
     pub items: BTreeMap<EquipmentSlot, EquippedItem>,
 }
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum MinigameJoinedState {
-    NotCreated,
-    Created,
-    Joined(Instant),
-}
-
 #[derive(Clone)]
 pub struct MinigameStatus {
     pub group: CharacterMatchmakingGroupIndex,
-    pub joined_state: MinigameJoinedState,
+    pub game_created: bool,
     pub game_won: bool,
     pub score_entries: Vec<ScoreEntry>,
     pub total_score: i32,
@@ -1499,7 +1492,7 @@ impl NpcTemplate {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum MatchmakingGroupStatus {
     Closed,
     OpenToAll,
@@ -1511,7 +1504,7 @@ pub type CharacterLocationIndex = (CharacterCategory, u64, Chunk);
 pub type CharacterNameIndex = String;
 pub type CharacterSquadIndex = u64;
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct CharacterMatchmakingGroupIndex {
     pub status: MatchmakingGroupStatus,
     pub stage_group_guid: i32,

--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -1169,15 +1169,21 @@ pub struct BattleClass {
     pub items: BTreeMap<EquipmentSlot, EquippedItem>,
 }
 
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum MinigameJoinedState {
+    NotCreated,
+    Created,
+    Joined(Instant),
+}
+
 #[derive(Clone)]
 pub struct MinigameStatus {
     pub group: CharacterMatchmakingGroupIndex,
-    pub game_created: bool,
+    pub joined_state: MinigameJoinedState,
     pub game_won: bool,
     pub score_entries: Vec<ScoreEntry>,
     pub total_score: i32,
     pub awarded_credits: u32,
-    pub start_time: Instant,
     pub type_data: MinigameTypeData,
 }
 

--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -1171,7 +1171,7 @@ pub struct BattleClass {
 
 #[derive(Clone)]
 pub struct MinigameStatus {
-    pub group: CharacterMatchmakingGroupIndex,
+    pub group: MinigameMatchmakingGroup,
     pub game_created: bool,
     pub game_won: bool,
     pub score_entries: Vec<ScoreEntry>,
@@ -1492,26 +1492,20 @@ impl NpcTemplate {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub enum MatchmakingGroupStatus {
-    Closed,
-    OpenToAll,
-    OpenToFriends,
-}
-
 pub type Chunk = (i32, i32);
 pub type CharacterLocationIndex = (CharacterCategory, u64, Chunk);
 pub type CharacterNameIndex = String;
 pub type CharacterSquadIndex = u64;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct CharacterMatchmakingGroupIndex {
-    pub status: MatchmakingGroupStatus,
+pub struct MinigameMatchmakingGroup {
     pub stage_group_guid: i32,
     pub stage_guid: i32,
     pub creation_time: Instant,
     pub owner_guid: u32,
 }
+
+pub type CharacterMatchmakingGroupIndex = MinigameMatchmakingGroup;
 
 #[derive(Clone)]
 pub struct CharacterStat {
@@ -1698,7 +1692,7 @@ impl
     fn index4(&self) -> Option<CharacterMatchmakingGroupIndex> {
         match &self.stats.character_type {
             CharacterType::Player(player) => {
-                player.minigame_status.as_ref().map(|status| status.group)
+                (player.minigame_status.as_ref().map(|status| status.group))
             }
             _ => None,
         }

--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -1692,7 +1692,7 @@ impl
     fn index4(&self) -> Option<CharacterMatchmakingGroupIndex> {
         match &self.stats.character_type {
             CharacterType::Player(player) => {
-                (player.minigame_status.as_ref().map(|status| status.group))
+                player.minigame_status.as_ref().map(|status| status.group)
             }
             _ => None,
         }

--- a/src/game_server/handlers/lock_enforcer.rs
+++ b/src/game_server/handlers/lock_enforcer.rs
@@ -15,7 +15,7 @@ use super::{
         IndexedGuid,
     },
     minigame::{
-        SharedMinigameData, SharedMinigameDataMatchmakingIndex, SharedMinigameDataStageGuidIndex,
+        SharedMinigameData, SharedMinigameDataMatchmakingIndex, SharedMinigameDataUnusedIndex,
     },
     zone::ZoneInstance,
 };
@@ -173,14 +173,14 @@ pub type MinigameDataTableReadHandle<'a> = TableReadHandleWrapper<
     'a,
     MinigameMatchmakingGroup,
     SharedMinigameData,
-    SharedMinigameDataStageGuidIndex,
+    SharedMinigameDataUnusedIndex,
     SharedMinigameDataMatchmakingIndex,
 >;
 pub type MinigameDataTableWriteHandle<'a> = GuidTableWriteHandle<
     'a,
     MinigameMatchmakingGroup,
     SharedMinigameData,
-    SharedMinigameDataStageGuidIndex,
+    SharedMinigameDataUnusedIndex,
     SharedMinigameDataMatchmakingIndex,
 >;
 pub type MinigameDataReadGuard<'a> = RwLockReadGuard<'a, SharedMinigameData>;
@@ -359,7 +359,7 @@ pub struct MinigameDataLockEnforcer<'a> {
         'a,
         MinigameMatchmakingGroup,
         SharedMinigameData,
-        SharedMinigameDataStageGuidIndex,
+        SharedMinigameDataUnusedIndex,
         SharedMinigameDataMatchmakingIndex,
     >,
     zones: &'a GuidTable<u64, ZoneInstance, u8>,
@@ -452,7 +452,7 @@ pub struct CharacterLockEnforcer<'a> {
     minigame_data: &'a GuidTable<
         MinigameMatchmakingGroup,
         SharedMinigameData,
-        SharedMinigameDataStageGuidIndex,
+        SharedMinigameDataUnusedIndex,
         SharedMinigameDataMatchmakingIndex,
     >,
 }
@@ -543,7 +543,7 @@ pub struct LockEnforcerSource {
     minigame_data: GuidTable<
         MinigameMatchmakingGroup,
         SharedMinigameData,
-        SharedMinigameDataStageGuidIndex,
+        SharedMinigameDataUnusedIndex,
         SharedMinigameDataMatchmakingIndex,
     >,
 }
@@ -562,7 +562,7 @@ impl LockEnforcerSource {
         minigame_data: GuidTable<
             MinigameMatchmakingGroup,
             SharedMinigameData,
-            SharedMinigameDataStageGuidIndex,
+            SharedMinigameDataUnusedIndex,
             SharedMinigameDataMatchmakingIndex,
         >,
     ) -> LockEnforcerSource {

--- a/src/game_server/handlers/lock_enforcer.rs
+++ b/src/game_server/handlers/lock_enforcer.rs
@@ -8,13 +8,15 @@ use parking_lot::{RwLockReadGuard, RwLockWriteGuard};
 use super::{
     character::{
         Character, CharacterLocationIndex, CharacterMatchmakingGroupIndex, CharacterNameIndex,
-        CharacterSquadIndex,
+        CharacterSquadIndex, MinigameMatchmakingGroup,
     },
     guid::{
         GuidTable, GuidTableHandle, GuidTableIndexer, GuidTableReadHandle, GuidTableWriteHandle,
         IndexedGuid,
     },
-    minigame::SharedMinigameData,
+    minigame::{
+        SharedMinigameData, SharedMinigameDataMatchmakingIndex, SharedMinigameDataStageGuidIndex,
+    },
     zone::ZoneInstance,
 };
 
@@ -167,10 +169,20 @@ pub type ZoneTableReadHandle<'a> = TableReadHandleWrapper<'a, u64, ZoneInstance,
 pub type ZoneTableWriteHandle<'a> = GuidTableWriteHandle<'a, u64, ZoneInstance, u8>;
 pub type ZoneReadGuard<'a> = RwLockReadGuard<'a, ZoneInstance>;
 pub type ZoneWriteGuard<'a> = RwLockWriteGuard<'a, ZoneInstance>;
-pub type MinigameDataTableReadHandle<'a> =
-    TableReadHandleWrapper<'a, CharacterMatchmakingGroupIndex, SharedMinigameData>;
-pub type MinigameDataTableWriteHandle<'a> =
-    GuidTableWriteHandle<'a, CharacterMatchmakingGroupIndex, SharedMinigameData>;
+pub type MinigameDataTableReadHandle<'a> = TableReadHandleWrapper<
+    'a,
+    MinigameMatchmakingGroup,
+    SharedMinigameData,
+    SharedMinigameDataStageGuidIndex,
+    SharedMinigameDataMatchmakingIndex,
+>;
+pub type MinigameDataTableWriteHandle<'a> = GuidTableWriteHandle<
+    'a,
+    MinigameMatchmakingGroup,
+    SharedMinigameData,
+    SharedMinigameDataStageGuidIndex,
+    SharedMinigameDataMatchmakingIndex,
+>;
 pub type MinigameDataReadGuard<'a> = RwLockReadGuard<'a, SharedMinigameData>;
 pub type MinigameDataWriteGuard<'a> = RwLockWriteGuard<'a, SharedMinigameData>;
 
@@ -313,13 +325,13 @@ pub struct MinigameDataLockRequest<
     R,
     F: FnOnce(
         &MinigameDataTableReadHandle<'_>,
-        BTreeMap<CharacterMatchmakingGroupIndex, MinigameDataReadGuard<'_>>,
-        BTreeMap<CharacterMatchmakingGroupIndex, MinigameDataWriteGuard<'_>>,
+        BTreeMap<MinigameMatchmakingGroup, MinigameDataReadGuard<'_>>,
+        BTreeMap<MinigameMatchmakingGroup, MinigameDataWriteGuard<'_>>,
         ZoneLockEnforcer<'_>,
     ) -> R,
 > {
-    pub read_guids: Vec<CharacterMatchmakingGroupIndex>,
-    pub write_guids: Vec<CharacterMatchmakingGroupIndex>,
+    pub read_guids: Vec<MinigameMatchmakingGroup>,
+    pub write_guids: Vec<MinigameMatchmakingGroup>,
     pub minigame_data_consumer: F,
 }
 
@@ -327,11 +339,11 @@ impl<
         R,
         F: FnOnce(
             &MinigameDataTableReadHandle<'_>,
-            BTreeMap<CharacterMatchmakingGroupIndex, MinigameDataReadGuard<'_>>,
-            BTreeMap<CharacterMatchmakingGroupIndex, MinigameDataWriteGuard<'_>>,
+            BTreeMap<MinigameMatchmakingGroup, MinigameDataReadGuard<'_>>,
+            BTreeMap<MinigameMatchmakingGroup, MinigameDataWriteGuard<'_>>,
             ZoneLockEnforcer<'_>,
         ) -> R,
-    > From<MinigameDataLockRequest<R, F>> for LockRequest<CharacterMatchmakingGroupIndex, F>
+    > From<MinigameDataLockRequest<R, F>> for LockRequest<MinigameMatchmakingGroup, F>
 {
     fn from(value: MinigameDataLockRequest<R, F>) -> Self {
         LockRequest {
@@ -343,7 +355,13 @@ impl<
 }
 
 pub struct MinigameDataLockEnforcer<'a> {
-    enforcer: LockEnforcer<'a, CharacterMatchmakingGroupIndex, SharedMinigameData>,
+    enforcer: LockEnforcer<
+        'a,
+        MinigameMatchmakingGroup,
+        SharedMinigameData,
+        SharedMinigameDataStageGuidIndex,
+        SharedMinigameDataMatchmakingIndex,
+    >,
     zones: &'a GuidTable<u64, ZoneInstance, u8>,
 }
 
@@ -352,8 +370,8 @@ impl MinigameDataLockEnforcer<'_> {
         R,
         F: FnOnce(
             &MinigameDataTableReadHandle<'_>,
-            BTreeMap<CharacterMatchmakingGroupIndex, MinigameDataReadGuard<'_>>,
-            BTreeMap<CharacterMatchmakingGroupIndex, MinigameDataWriteGuard<'_>>,
+            BTreeMap<MinigameMatchmakingGroup, MinigameDataReadGuard<'_>>,
+            BTreeMap<MinigameMatchmakingGroup, MinigameDataWriteGuard<'_>>,
             ZoneLockEnforcer<'_>,
         ) -> R,
         T: FnOnce(&MinigameDataTableReadHandle<'_>) -> MinigameDataLockRequest<R, F>,
@@ -369,11 +387,11 @@ impl MinigameDataLockEnforcer<'_> {
                     write_guids: minigame_data_lock_request.write_guids,
                     consumer: |table_read_handle: &MinigameDataTableReadHandle<'_>,
                                minigame_data_read: BTreeMap<
-                        CharacterMatchmakingGroupIndex,
+                        MinigameMatchmakingGroup,
                         MinigameDataReadGuard<'_>,
                     >,
                                minigame_data_write: BTreeMap<
-                        CharacterMatchmakingGroupIndex,
+                        MinigameMatchmakingGroup,
                         MinigameDataWriteGuard<'_>,
                     >| {
                         let zones_enforcer = ZoneLockEnforcer {
@@ -431,7 +449,12 @@ pub struct CharacterLockEnforcer<'a> {
         CharacterMatchmakingGroupIndex,
     >,
     zones: &'a GuidTable<u64, ZoneInstance, u8>,
-    minigame_data: &'a GuidTable<CharacterMatchmakingGroupIndex, SharedMinigameData>,
+    minigame_data: &'a GuidTable<
+        MinigameMatchmakingGroup,
+        SharedMinigameData,
+        SharedMinigameDataStageGuidIndex,
+        SharedMinigameDataMatchmakingIndex,
+    >,
 }
 
 impl CharacterLockEnforcer<'_> {
@@ -517,7 +540,12 @@ pub struct LockEnforcerSource {
         CharacterMatchmakingGroupIndex,
     >,
     zones: GuidTable<u64, ZoneInstance, u8>,
-    minigame_data: GuidTable<CharacterMatchmakingGroupIndex, SharedMinigameData>,
+    minigame_data: GuidTable<
+        MinigameMatchmakingGroup,
+        SharedMinigameData,
+        SharedMinigameDataStageGuidIndex,
+        SharedMinigameDataMatchmakingIndex,
+    >,
 }
 
 impl LockEnforcerSource {
@@ -531,7 +559,12 @@ impl LockEnforcerSource {
             CharacterMatchmakingGroupIndex,
         >,
         zones: GuidTable<u64, ZoneInstance, u8>,
-        minigame_data: GuidTable<CharacterMatchmakingGroupIndex, SharedMinigameData>,
+        minigame_data: GuidTable<
+            MinigameMatchmakingGroup,
+            SharedMinigameData,
+            SharedMinigameDataStageGuidIndex,
+            SharedMinigameDataMatchmakingIndex,
+        >,
     ) -> LockEnforcerSource {
         LockEnforcerSource {
             characters,

--- a/src/game_server/handlers/login.rs
+++ b/src/game_server/handlers/login.rs
@@ -155,10 +155,7 @@ pub fn log_out(sender: u32, game_server: &GameServer) -> Vec<Broadcast> {
                             game_server,
                         );
                         match leave_minigame_result {
-                            Ok(mut leave_minigame_broadcasts) => {
-                                info!("Removing player {} from minigame because they logged out", sender);
-                                broadcasts.append(&mut leave_minigame_broadcasts);
-                            },
+                            Ok(mut leave_minigame_broadcasts) => broadcasts.append(&mut leave_minigame_broadcasts),
                             Err(err) => info!("Unable to remove player {} from minigame as they were logging out: {}", sender, err),
                         }
 

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -1037,7 +1037,6 @@ pub fn process_minigame_packet(
                 handle_request_create_active_minigame(request, sender, game_server)
             }
             MinigameOpCode::RequestStartActiveMinigame => {
-                info!("START MINIGAME!");
                 let request = RequestStartActiveMinigame::deserialize(cursor)?;
                 handle_request_start_active_minigame(request, sender, game_server)
             }

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -148,7 +148,7 @@ pub enum MinigameReadiness {
     Ready(Instant),
 }
 
-pub type SharedMinigameDataStageGuidIndex = i32;
+pub type SharedMinigameDataUnusedIndex = ();
 pub type SharedMinigameDataMatchmakingIndex = (MatchmakingGroupStatus, i32, Instant);
 
 #[derive(Clone)]
@@ -161,7 +161,7 @@ pub struct SharedMinigameData {
 impl
     IndexedGuid<
         MinigameMatchmakingGroup,
-        SharedMinigameDataStageGuidIndex,
+        SharedMinigameDataUnusedIndex,
         SharedMinigameDataMatchmakingIndex,
     > for SharedMinigameData
 {
@@ -169,9 +169,7 @@ impl
         self.guid
     }
 
-    fn index1(&self) -> SharedMinigameDataStageGuidIndex {
-        self.guid.stage_guid
-    }
+    fn index1(&self) -> SharedMinigameDataUnusedIndex {}
 
     fn index2(&self) -> Option<SharedMinigameDataMatchmakingIndex> {
         let matchmaking_status = match self.readiness {

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -2433,6 +2433,8 @@ pub fn leave_active_minigame_if_any(
                 Err(err) => info!("Unable to remove other player {} from minigame (stage group {}, stage {}) that does not have enough players: {}", member_guid, group.stage_group_guid, group.stage_guid, err),
             }
         }
+
+        minigame_data_table_write_handle.remove(group);
     }
 
     Ok(broadcasts)

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -1529,7 +1529,16 @@ pub fn prepare_active_minigame_instance(
     })();
 
     match teleport_result {
-        Ok(mut teleport_broadcasts) => broadcasts.append(&mut teleport_broadcasts),
+        Ok(mut teleport_broadcasts) => {
+            broadcasts.append(&mut teleport_broadcasts);
+            minigame_data_table_write_handle.insert(SharedMinigameData {
+                guid: matchmaking_group,
+                readiness: MinigameReadiness::InitialPlayersLoading(BTreeSet::from_iter(
+                    members.iter().cloned(),
+                )),
+                data: SharedMinigameTypeData::None,
+            });
+        }
         Err(err) => {
             // We don't need to clean up the zone here, since the next instance of this stage that starts will use it instead
             info!("Couldn't add a player to the minigame, ending the game: {} (stage group {}, stage {})", err, stage_group_guid, stage_guid);
@@ -1556,14 +1565,6 @@ pub fn prepare_active_minigame_instance(
             }
         }
     }
-
-    minigame_data_table_write_handle.insert(SharedMinigameData {
-        guid: matchmaking_group,
-        readiness: MinigameReadiness::InitialPlayersLoading(BTreeSet::from_iter(
-            members.iter().cloned(),
-        )),
-        data: SharedMinigameTypeData::None,
-    });
 
     // Don't return a result here so that we properly handle updates for all players in the group, rather than returning early
     broadcasts

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -1037,6 +1037,7 @@ pub fn process_minigame_packet(
                 handle_request_create_active_minigame(request, sender, game_server)
             }
             MinigameOpCode::RequestStartActiveMinigame => {
+                info!("START MINIGAME!");
                 let request = RequestStartActiveMinigame::deserialize(cursor)?;
                 handle_request_start_active_minigame(request, sender, game_server)
             }

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -1591,6 +1591,10 @@ pub fn prepare_active_minigame_instance(
                 matchmaking_group,
                 |possible_minigame_data, _| {
                     let Some(minigame_data) = possible_minigame_data else {
+                        info!(
+                            "Unable to find shared minigame data for group {:?}",
+                            matchmaking_group
+                        );
                         return;
                     };
 

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -1170,8 +1170,8 @@ fn handle_request_stage_group_instance(
 }
 
 fn find_matchmaking_group(
-    characters_table_write_handle: &mut CharacterTableWriteHandle<'_>,
-    minigame_data_table_write_handle: &mut MinigameDataTableWriteHandle<'_>,
+    characters_table_write_handle: &CharacterTableWriteHandle<'_>,
+    minigame_data_table_write_handle: &MinigameDataTableWriteHandle<'_>,
     required_space: u32,
     max_players: u32,
     stage_guid: i32,

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -1548,7 +1548,7 @@ pub fn prepare_active_minigame_instance(
         }
     }
 
-    // We don't want to return a `Result` because an error would disconnect the sender without disconnecting the group members
+    // Don't return a result here so that we properly handle updates for all players in the group, rather than returning early
     broadcasts
 }
 

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -1307,12 +1307,6 @@ fn handle_request_create_active_minigame(
                                 owner_guid: sender,
                             };
 
-                            minigame_data_table_write_handle.insert(SharedMinigameData {
-                                guid: new_group,
-                                readiness: MinigameReadiness::Matchmaking,
-                                data: SharedMinigameTypeData::None,
-                            });
-
                             (new_group, stage_config.stage_config.max_players())
                         });
 
@@ -1323,6 +1317,16 @@ fn handle_request_create_active_minigame(
                             &stage_config,
                         )?;
 
+                        // Wait to insert a new group in case there's an error updating the player's status
+                        if minigame_data_table_write_handle.get(open_group).is_none() {
+                            minigame_data_table_write_handle.insert(SharedMinigameData {
+                                guid: open_group,
+                                readiness: MinigameReadiness::Matchmaking,
+                                data: SharedMinigameTypeData::None,
+                            });
+                        }
+
+                        // Start the game because the group is full
                         if space_left <= required_space {
                             let players_in_group: Vec<u32> = characters_table_write_handle
                                 .keys_by_index4(&open_group)

--- a/src/game_server/handlers/saber_strike.rs
+++ b/src/game_server/handlers/saber_strike.rs
@@ -45,7 +45,7 @@ pub fn process_saber_strike_packet(
                     sender,
                     game_server,
                     &header,
-                    |minigame_status, _, _, _| {
+                    |minigame_status, _, _, _, _| {
                         match &mut minigame_status.type_data {
                             MinigameTypeData::SaberStrike { obfuscated_score } => {
                                 *obfuscated_score = obfuscated_score_packet.score();
@@ -95,7 +95,7 @@ fn handle_saber_strike_game_over(
         sender,
         game_server,
         header,
-        |minigame_status, minigame_stats, _, stage_config| {
+        |minigame_status, minigame_stats, _, stage_config, _| {
             let MinigameTypeData::SaberStrike { obfuscated_score } = minigame_status.type_data
             else {
                 return Err(ProcessPacketError::new(

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -27,7 +27,7 @@ use handlers::lock_enforcer::{
 };
 use handlers::login::{log_in, log_out, send_points_of_interest};
 use handlers::minigame::{
-    create_active_minigame, load_all_minigames, prepare_active_minigame_instance,
+    create_active_minigame_if_uncreated, load_all_minigames, prepare_active_minigame_instance,
     process_minigame_packet, remove_from_matchmaking, AllMinigameConfigs,
 };
 use handlers::mount::{load_mounts, process_mount_packet, MountConfig};
@@ -283,14 +283,13 @@ impl GameServer {
                                     };
 
                                     if let Some(minigame_status) = &mut player.minigame_status {
-                                        if !minigame_status.game_created {
-                                            minigame_status.game_created = true;
-                                            broadcasts.append(&mut create_active_minigame(
+                                        broadcasts.append(
+                                            &mut create_active_minigame_if_uncreated(
                                                 sender,
                                                 self.minigames(),
                                                 minigame_status,
-                                            )?);
-                                        }
+                                            )?,
+                                        );
                                     }
 
                                     if player.first_load {

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -1041,7 +1041,9 @@ impl GameServer {
                                         self,
                                     ));
                                     return;
-                                } else if players_in_group.len() == 1 {
+                                }
+
+                                if players_in_group.len() == 1 {
                                     if let Some(replacement_stage_locator) = &stage.stage_config.single_player_stage_guid() {
                                         if let Some(replacement_stage) = self
                                             .minigames()


### PR DESCRIPTION
* Combine matchmaking group with minigame status. A player in a minigame must always now have a group, so there is no reason to keep them separate.
  * This removes some awkwardness where every player would track the group's open/closed state. Now, we don't have to update a bunch of duplicate states.
* All games now have shared minigame data created/destroyed.
* Game time is now tracked as the time all players became ready. Minigames also now track which players still need to finish loading, which is useful to gate multiplayer games on all players' readiness.
  * For bunkers, we'll want to freeze players before everyone is ready or track the first ready time when calculating the speedy completion bonus.
* Remove misleading log statement in login.rs. This statement would print that the player was being removed from a minigame even if they weren't in one (because removal returns `Ok` even if the player wasn't in a minigame).