### PR TITLE
Fix player being teleported when logging out in matchmaking, merge removal code

### DIFF
--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -1172,6 +1172,7 @@ pub struct BattleClass {
 #[derive(Clone)]
 pub struct MinigameStatus {
     pub group: MinigameMatchmakingGroup,
+    pub teleported_to_game: bool,
     pub game_created: bool,
     pub game_won: bool,
     pub score_entries: Vec<ScoreEntry>,

--- a/src/game_server/handlers/login.rs
+++ b/src/game_server/handlers/login.rs
@@ -2,7 +2,7 @@ use packet_serialize::NullTerminatedString;
 
 use crate::{
     game_server::{
-        handlers::minigame::leave_active_minigame_if_any,
+        handlers::minigame::{leave_active_minigame_if_any, LeaveMinigameTarget},
         packets::{
             login::{DefinePointsOfInterest, DeploymentEnv, GameSettings, LoginReply},
             player_update::ItemDefinitionsReply,
@@ -146,7 +146,7 @@ pub fn log_out(sender: u32, game_server: &GameServer) -> Vec<Broadcast> {
                         let mut broadcasts = Vec::new();
 
                         let leave_minigame_result = leave_active_minigame_if_any(
-                            sender,
+                            LeaveMinigameTarget::Single(sender),
                             characters_table_write_handle,
                             minigame_data_write_handle,
                             zones_table_write_handle,

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -2166,10 +2166,6 @@ fn leave_active_minigame_single_player_if_any(
                 return Ok((Vec::new(), previous_location, true));
             };
 
-            if stage_config.guid() != minigame_status.group.stage_guid {
-                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to end player {}'s active minigame (stage {}), but they're in a different minigame (stage group {}, stage {})", sender, stage_config.guid(), minigame_status.group.stage_group_guid, minigame_status.group.stage_guid)));
-            }
-
             // If we've already awarded credits after a round, don't grant those credits again
             let mut broadcasts = if minigame_status.awarded_credits > 0 {
                 Vec::new()

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -1507,7 +1507,8 @@ pub fn prepare_active_minigame_instance(
             );
         }
         Err(err) => {
-            // We don't need to clean up the zone here, since the next instance of this stage that starts will use it instead
+            // Teleportation out of the minigame zone should clean it up if it is empty. If there is some error, the next game that starts
+            // can use the zone
             info!("Couldn't add a player to the minigame, ending the game: {} (stage group {}, stage {})", err, stage_group_guid, stage_guid);
             let leave_result = leave_active_minigame_if_any(
                 LeaveMinigameTarget::Group(matchmaking_group),

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -2339,7 +2339,7 @@ fn remove_single_player_from_matchmaking(
         let Some(character_write_handle) = possible_character_write_handle  else {
             return Err(ProcessPacketError::new(
                 ProcessPacketErrorType::ConstraintViolated,
-                format!("Tried to end unknown player {}'s active minigame", player),
+                format!("Tried to remove unknown player {} from matchmaking", player),
             ));
         };
 

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -28,9 +28,10 @@ use crate::{
                 LeaveActiveMinigame, MinigameDefinitions, MinigameHeader, MinigameOpCode,
                 MinigamePortalCategory, MinigamePortalEntry, MinigameStageDefinition,
                 MinigameStageGroupDefinition, MinigameStageGroupLink, MinigameStageInstance,
-                RequestCreateActiveMinigame, RequestMinigameStageGroupInstance,
-                RequestStartActiveMinigame, ScoreEntry, ScoreType, ShowStageInstanceSelect,
-                StartActiveMinigame, UpdateActiveMinigameRewards,
+                RequestCancelActiveMinigame, RequestCreateActiveMinigame,
+                RequestMinigameStageGroupInstance, RequestStartActiveMinigame, ScoreEntry,
+                ScoreType, ShowStageInstanceSelect, StartActiveMinigame,
+                UpdateActiveMinigameRewards,
             },
             saber_strike::{SaberStrikeOpCode, SaberStrikeStageData},
             tunnel::TunneledPacket,
@@ -1080,6 +1081,7 @@ pub fn process_minigame_packet(
                 handle_request_start_active_minigame(request, sender, game_server)
             }
             MinigameOpCode::RequestCancelActiveMinigame => {
+                RequestCancelActiveMinigame::deserialize(cursor)?;
                 handle_request_cancel_active_minigame(true, sender, game_server)
             }
             MinigameOpCode::FlashPayload => {

--- a/src/game_server/handlers/saber_strike.rs
+++ b/src/game_server/handlers/saber_strike.rs
@@ -14,7 +14,8 @@ use crate::game_server::{
 };
 
 use super::minigame::{
-    handle_minigame_packet_write, leave_active_minigame_if_any, MinigameTypeData,
+    handle_minigame_packet_write, leave_active_minigame_if_any, LeaveMinigameTarget,
+    MinigameTypeData,
 };
 
 pub fn process_saber_strike_packet(
@@ -172,11 +173,11 @@ fn handle_saber_strike_game_over(
                 |minigame_data_table_write_handle, zones_lock_enforcer| {
                     zones_lock_enforcer.write_zones(|zones_table_write_handle| {
                         leave_active_minigame_if_any(
-                            sender,
+                            LeaveMinigameTarget::Single(sender),
                             characters_table_write_handle,
                             minigame_data_table_write_handle,
                             zones_table_write_handle,
-                            Some(header.stage_guid),
+                            None,
                             false,
                             game_server,
                         )


### PR DESCRIPTION
When a player logs out, we currently clear their minigame status and teleport them, assuming they're actively playing a minigame. However, it's possible for them to still be in matchmaking, and we teleport them to their previous position anyway. If we save their position in the future, this means that logging out during matchmaking could unexpectedly teleport you to a previous location when you log back in.

I've merged the leave active minigame and matchmaking removal code to reduce duplication and handle both cases, without needing to check if the player is in matchmaking or in a minigame everywhere else.

I also removed a check in `RequestCancelActiveMinigame` for a requried stage GUID. The client only ever requests to exit its own current minigame that was already tracked by the server. This check really only would guard against a case where a cancel request was sent absurdly late, even though the player already entered another minigame. I removed it to simplify the code.