### PR TITLE
Add special flash minigame types, shared minigame data types

### DIFF
--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -12,6 +12,7 @@ use byteorder::ReadBytesExt;
 use evalexpr::{context_map, eval_with_context, Value};
 use num_enum::TryFromPrimitive;
 use packet_serialize::DeserializePacket;
+use rand::{seq::SliceRandom, thread_rng};
 use serde::{de::IgnoredAny, Deserialize};
 
 use crate::{
@@ -203,18 +204,32 @@ impl
 #[non_exhaustive]
 #[derive(Clone, Default)]
 pub enum SharedMinigameTypeData {
-    FleetCommander,
-    ForceConnection,
+    FleetCommander {
+        player1: u32,
+        player2: Option<u32>,
+    },
+    ForceConnection {
+        player1: u32,
+        player2: Option<u32>,
+    },
     #[default]
     None,
 }
 
-impl From<&MinigameType> for SharedMinigameTypeData {
-    fn from(value: &MinigameType) -> Self {
-        match value {
+impl SharedMinigameTypeData {
+    pub fn from(minigame_type: &MinigameType, members: &[u32]) -> Self {
+        // We can't have a game without at least one player
+        let player1 = members[0];
+        let player2 = members.get(1).cloned();
+
+        match minigame_type {
             MinigameType::Flash { game_type, .. } => match game_type {
-                FlashMinigameType::FleetCommander => SharedMinigameTypeData::FleetCommander,
-                FlashMinigameType::ForceConnection => SharedMinigameTypeData::ForceConnection,
+                FlashMinigameType::FleetCommander => {
+                    SharedMinigameTypeData::FleetCommander { player1, player2 }
+                }
+                FlashMinigameType::ForceConnection => {
+                    SharedMinigameTypeData::ForceConnection { player1, player2 }
+                }
                 FlashMinigameType::Simple => SharedMinigameTypeData::default(),
             },
             MinigameType::SaberStrike { .. } => SharedMinigameTypeData::default(),
@@ -1330,21 +1345,25 @@ fn handle_request_create_active_minigame(
                         )?;
 
                         // Wait to insert a new group in case there's an error updating the player's status
+                        let mut players_in_group: Vec<u32> = characters_table_write_handle
+                            .keys_by_index4(&open_group)
+                            .filter_map(|guid| shorten_player_guid(guid).ok())
+                            .collect();
+                        players_in_group.shuffle(&mut thread_rng());
+
                         if minigame_data_table_write_handle.get(open_group).is_none() {
                             minigame_data_table_write_handle.insert(SharedMinigameData {
                                 guid: open_group,
                                 readiness: MinigameReadiness::Matchmaking,
-                                data: stage_config.stage_config.minigame_type().into(),
+                                data: SharedMinigameTypeData::from(
+                                    stage_config.stage_config.minigame_type(),
+                                    &players_in_group,
+                                ),
                             });
                         }
 
                         // Start the game because the group is full
                         if space_left <= required_space {
-                            let players_in_group: Vec<u32> = characters_table_write_handle
-                                .keys_by_index4(&open_group)
-                                .filter_map(|guid| shorten_player_guid(guid).ok())
-                                .collect();
-
                             broadcasts.append(&mut prepare_active_minigame_instance(
                                 open_group,
                                 &players_in_group,


### PR DESCRIPTION
* Add special minigame types for Fleet Commander and Force Connection (currently unused)
* Add logic to populate shared minigame data based on the minigame type
* Randomize the order of all players in a minigame