### PR TITLE
Refactor chunk and matchmaking ticking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ chrono = "0.4.38"
 crc32fast = "1.4.2"
 crossbeam-channel = "0.5.13"
 defer-lite = "1.0.0"
+enum-iterator = "2.1.0"
 evalexpr = "11.3.0"
 packet_serialize = { path = "src/packet_serialize" }
 miniz_oxide = "0.7.2"
@@ -19,5 +20,4 @@ rand = "0.8.5"
 rand_distr = "0.4.3"
 serde_yaml = "0.9.34"
 serde = { version = "1.0.196", features = ["derive", "rc"] }
-strum = { version = "0.26.2", features = ["derive"] }
 tokio = { version = "1.38.0", features = ["fs", "io-util", "rt", "rt-multi-thread", "macros"] }

--- a/config/server.yaml
+++ b/config/server.yaml
@@ -19,5 +19,6 @@ desired_resend_pct: 5
 max_millis_until_resend: 300
 chunk_tick_period_millis: 500
 chunk_tick_threads: 2
+matchmaking_tick_period_millis: 1000
 channel_cleanup_period_millis: 1000
 channel_inactive_timeout_millis: 60000

--- a/config/server.yaml
+++ b/config/server.yaml
@@ -17,6 +17,7 @@ default_millis_until_resend: 30
 max_round_trip_entries: 30
 desired_resend_pct: 5
 max_millis_until_resend: 300
-game_tick_period_millis: 500
+chunk_tick_period_millis: 500
+chunk_tick_threads: 2
 channel_cleanup_period_millis: 1000
 channel_inactive_timeout_millis: 60000

--- a/src/game_server/handlers/mod.rs
+++ b/src/game_server/handlers/mod.rs
@@ -15,6 +15,7 @@ pub mod reference_data;
 pub mod saber_strike;
 pub mod store;
 pub mod test_data;
+pub mod tick;
 pub mod time;
 pub mod unique_guid;
 pub mod update_position;

--- a/src/game_server/handlers/tick.rs
+++ b/src/game_server/handlers/tick.rs
@@ -1,0 +1,236 @@
+use std::time::{Duration, Instant};
+
+use crossbeam_channel::Sender;
+
+use crate::{
+    game_server::{handlers::guid::IndexedGuid, Broadcast, GameServer, TickableNpcSynchronization},
+    info,
+};
+
+use super::{
+    character::{Character, CharacterCategory, Chunk, MinigameMatchmakingGroup},
+    guid::GuidTableIndexer,
+    lock_enforcer::CharacterLockRequest,
+    minigame::{
+        leave_active_minigame_if_any, prepare_active_minigame_instance, LeaveMinigameTarget,
+        MatchmakingGroupStatus,
+    },
+    unique_guid::shorten_player_guid,
+    zone::ZoneInstance,
+};
+
+const fn tickable_categories(
+    synchronization: TickableNpcSynchronization,
+) -> [CharacterCategory; 2] {
+    [
+        CharacterCategory::NpcTickable(synchronization),
+        CharacterCategory::NpcAutoInteractableTickable(synchronization),
+    ]
+}
+
+pub fn enqueue_tickable_chunks(
+    game_server: &GameServer,
+    synchronization: TickableNpcSynchronization,
+    chunks_enqueue: Sender<(u64, Chunk, TickableNpcSynchronization)>,
+) {
+    game_server
+        .lock_enforcer()
+        .read_characters(|characters_table_read_handle| {
+            tickable_categories(synchronization)
+                .into_iter()
+                .flat_map(|category| {
+                    let range = (category, u64::MIN, Character::MIN_CHUNK)
+                        ..=(category, u64::MAX, Character::MAX_CHUNK);
+                    characters_table_read_handle.indices1_by_range(range)
+                })
+                .for_each(|(_, instance_guid, chunk)| {
+                    chunks_enqueue
+                        .send((instance_guid, chunk, synchronization))
+                        .expect("Tickable channel disconnected")
+                });
+
+            CharacterLockRequest {
+                read_guids: Vec::new(),
+                write_guids: Vec::new(),
+                character_consumer: |_, _, _, _| {},
+            }
+        })
+}
+
+pub fn tick_single_chunk(
+    game_server: &GameServer,
+    now: Instant,
+    instance_guid: u64,
+    chunk: Chunk,
+    synchronization: TickableNpcSynchronization,
+) -> Vec<Broadcast> {
+    game_server.lock_enforcer().read_characters(|characters_table_read_handle| {
+        let tickable_characters: Vec<u64> = tickable_categories(synchronization)
+            .into_iter()
+            .flat_map(|category| characters_table_read_handle.keys_by_index1((category, instance_guid, chunk)))
+            .collect();
+
+        let nearby_player_guids = ZoneInstance::all_players_nearby(chunk, instance_guid, characters_table_read_handle);
+        let mut read_guids: Vec<u64> = nearby_player_guids.iter()
+            .map(|guid| *guid as u64)
+            .collect();
+
+        for ticked_character_guid in tickable_characters.iter() {
+            if let Some(synchronzied_character_guid) = characters_table_read_handle.index5(*ticked_character_guid) {
+                read_guids.push(*synchronzied_character_guid);
+            }
+        }
+
+        CharacterLockRequest {
+            read_guids,
+            write_guids: tickable_characters.clone(),
+            character_consumer: move |_,
+            characters_read,
+            mut characters_write,
+            _| {
+                let mut broadcasts = Vec::new();
+
+                for guid in tickable_characters.iter() {
+                    let tickable_character = characters_write.get_mut(guid).unwrap();
+
+                    if let Some(synchronize_with) = &tickable_character.synchronize_with {
+                        if let Some(synchronized_character) =
+                            characters_read.get(synchronize_with)
+                        {
+                            if let Some(synchronized_guid) = synchronized_character.synchronize_with {
+                                panic!(
+                                    "Cannot synchronize character {} to a character {} because they are synchronized to character {}",
+                                    guid,
+                                    synchronized_character.guid(),
+                                    synchronized_guid
+                                );
+                            }
+
+                            if synchronized_character.last_procedure_change() > tickable_character.last_procedure_change() {
+                                if let Some(key) =
+                                    synchronized_character.current_tickable_procedure()
+                                {
+                                    tickable_character.set_tickable_procedure_if_exists(key.clone(), now)
+                                }
+                            }
+                        }
+                    }
+
+                    broadcasts.append(
+                        &mut tickable_character.tick(now, &nearby_player_guids, &characters_read, game_server.mounts(), game_server.items(), game_server.customizations()),
+                    );
+                }
+
+                broadcasts
+            },
+        }
+    })
+}
+
+pub fn tick_minigame_groups(game_server: &GameServer) -> Vec<Broadcast> {
+    let now = Instant::now();
+    game_server.lock_enforcer().write_characters(
+        |characters_table_write_handle, minigame_data_lock_enforcer| {
+            minigame_data_lock_enforcer.write_minigame_data(|minigame_data_table_write_handle, zones_lock_enforcer| {
+                let mut broadcasts = Vec::new();
+
+                // Iterate over timed-out groups for every stage, since the number of stages remains
+                // a fairly small constant, while there can theoretically be billions of matchmaking groups.
+                for stage in game_server.minigames().stage_configs() {
+                    let timeout =
+                        Duration::from_millis(stage.stage_config.matchmaking_timeout_millis() as u64);
+                    // Make sure max time is greater than or equal to start time so that the range is valid
+                    let max_time = match now.checked_sub(timeout) {
+                        Some(max_time) => max_time,
+                        None => continue,
+                    }.max(game_server.start_time);
+                    let stage_group_guid = stage.stage_group_guid;
+                    let stage_guid = stage.stage_config.guid();
+                    let min_players = stage.stage_config.min_players();
+
+                    let timed_out_group_range = (MatchmakingGroupStatus::Open, stage_guid, game_server.start_time)..=(MatchmakingGroupStatus::Open, stage_guid, max_time);
+                    let timed_out_groups: Vec<MinigameMatchmakingGroup> = minigame_data_table_write_handle
+                        .keys_by_index2_range(timed_out_group_range)
+                        .collect();
+                    for matchmaking_group in timed_out_groups {
+                        let players_in_group: Vec<u32> = characters_table_write_handle
+                            .keys_by_index4(&matchmaking_group)
+                            .filter_map(|guid| shorten_player_guid(guid).ok())
+                            .collect();
+
+                        zones_lock_enforcer.write_zones(|zones_table_write_handle| {
+                            if players_in_group.len() as u32 >= min_players {
+                                broadcasts.append(&mut prepare_active_minigame_instance(
+                                    matchmaking_group,
+                                    &players_in_group,
+                                    &stage,
+                                    characters_table_write_handle,
+                                    minigame_data_table_write_handle,
+                                    zones_table_write_handle,
+                                    None,
+                                    game_server,
+                                ));
+                                return;
+                            }
+
+                            if players_in_group.len() == 1 {
+                                if let Some(replacement_stage_locator) = &stage.stage_config.single_player_stage_guid() {
+                                    if let Some(replacement_stage) = game_server
+                                        .minigames()
+                                        .stage_config(replacement_stage_locator.stage_group_guid, replacement_stage_locator.stage_guid)
+                                    {
+                                        if replacement_stage.stage_config.min_players() == 1 {
+                                            broadcasts.append(&mut prepare_active_minigame_instance(
+                                                matchmaking_group,
+                                                &players_in_group,
+                                                &replacement_stage,
+                                                characters_table_write_handle,
+                                                minigame_data_table_write_handle,
+                                                zones_table_write_handle,
+                                                Some(44218),
+                                                game_server,
+                                            ));
+                                            return;
+                                        } else {
+                                            info!(
+                                                "Replacement stage (stage group {}, stage {}) for (stage group {}, stage {}) isn't single-player",
+                                                replacement_stage_locator.stage_group_guid,
+                                                replacement_stage_locator.stage_guid,
+                                                stage_group_guid,
+                                                stage_guid
+                                            );
+                                        }
+                                    } else {
+                                        info!(
+                                            "Couldn't find replacement stage (stage group {}, stage {}) for (stage group {}, stage {})",
+                                            replacement_stage_locator.stage_group_guid,
+                                            replacement_stage_locator.stage_guid,
+                                            stage_group_guid,
+                                            stage_guid
+                                        );
+                                    }
+                                }
+                            }
+
+                            let leave_result = leave_active_minigame_if_any(
+                                LeaveMinigameTarget::Group(matchmaking_group),
+                                characters_table_write_handle,
+                                minigame_data_table_write_handle,
+                                zones_table_write_handle,
+                                Some(33781),
+                                false,
+                                game_server,
+                            );
+                            match leave_result {
+                                Ok(mut leave_broadcasts) => broadcasts.append(&mut leave_broadcasts),
+                                Err(err) => info!("Unable to remove timed-out group {:?} from matchmaking: {}", matchmaking_group, err),
+                            }
+                        })
+                    }
+                }
+
+                broadcasts
+            })
+        },
+    )
+}

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -213,8 +213,8 @@ impl GameServer {
         &self,
         synchronization: TickableNpcSynchronization,
         chunks_enqueue: Sender<(u64, Chunk, TickableNpcSynchronization)>,
-    ) {
-        enqueue_tickable_chunks(self, synchronization, chunks_enqueue);
+    ) -> usize {
+        enqueue_tickable_chunks(self, synchronization, chunks_enqueue)
     }
 
     pub fn tick_single_chunk(


### PR DESCRIPTION
* Fix an issue where a synchronized character could be updated before the character it depends on was updated, if the other character was in a different chunk. All unsynchronized characters are now updated before any synchronized character is updated.
* Split chunk ticking among a configurable number of threads.
* Split matchmaking ticking from chunk ticking. Matchmaking ticking is fixed to 1 thread because it requires the characters table write handle, so all work has to be done synchronously anyway.
* The matchmaking tick period is now 1 second instead of using the 500ms chunk tick period.
* Set a panic hook so that the entire server exits if any single thread panics. A panic means that there was some unrecoverable error that we treat as a crash scenario.
* This is a prerequisite to making certain minigames tickable.