### PR TITLE
Spawn minigame tick threads and tick shared minigame data

### DIFF
--- a/config/server.yaml
+++ b/config/server.yaml
@@ -20,5 +20,7 @@ max_millis_until_resend: 300
 chunk_tick_period_millis: 500
 chunk_tick_threads: 2
 matchmaking_tick_period_millis: 1000
+minigame_tick_period_millis: 500
+minigame_tick_threads: 2
 channel_cleanup_period_millis: 1000
 channel_inactive_timeout_millis: 60000

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -178,6 +178,12 @@ pub struct SharedMinigameData {
     pub data: SharedMinigameTypeData,
 }
 
+impl SharedMinigameData {
+    pub fn tick(&self, now: Instant) -> Vec<Broadcast> {
+        self.data.tick(now)
+    }
+}
+
 impl
     IndexedGuid<
         MinigameMatchmakingGroup,
@@ -244,6 +250,13 @@ impl SharedMinigameTypeData {
                 FlashMinigameType::Simple => SharedMinigameTypeData::default(),
             },
             MinigameType::SaberStrike { .. } => SharedMinigameTypeData::default(),
+        }
+    }
+
+    pub fn tick(&self, _: Instant) -> Vec<Broadcast> {
+        match self {
+            SharedMinigameTypeData::ForceConnection { .. } => Vec::new(),
+            _ => Vec::new(),
         }
     }
 }

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -179,7 +179,7 @@ pub struct SharedMinigameData {
 }
 
 impl SharedMinigameData {
-    pub fn tick(&self, now: Instant) -> Vec<Broadcast> {
+    pub fn tick(&mut self, now: Instant) -> Vec<Broadcast> {
         self.data.tick(now)
     }
 }
@@ -253,7 +253,7 @@ impl SharedMinigameTypeData {
         }
     }
 
-    pub fn tick(&self, _: Instant) -> Vec<Broadcast> {
+    pub fn tick(&mut self, _: Instant) -> Vec<Broadcast> {
         match self {
             SharedMinigameTypeData::ForceConnection { .. } => Vec::new(),
             _ => Vec::new(),


### PR DESCRIPTION
* Add ticking for minigames with a configurable number of threads
* Fix an issue where chunk ticks could be throttled by a bound on the size of the done queue