### PR TITLE
Fix warning from `clippy` about size of err variant

### DIFF
--- a/src/channel_manager.rs
+++ b/src/channel_manager.rs
@@ -44,6 +44,7 @@ impl ChannelManager {
         self.authenticated.guid(addr)
     }
 
+    #[allow(clippy::result_large_err)]
     pub fn insert(
         &mut self,
         addr: &SocketAddr,


### PR DESCRIPTION
Disable warning from new version of `clippy`. This error variant simply returns the channel that was provided as a function argument, so we don't need to put it on the heap.