### PR TITLE
Fix `clippy` warnings to format

### DIFF
--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -813,7 +813,7 @@ impl TickableProcedureTracker {
                             if let Some(procedure) = procedures.get(procedure_key) {
                                 procedure.reference.weight
                             } else {
-                                panic!("Reference to unknown procedure {}", procedure_key);
+                                panic!("Reference to unknown procedure {procedure_key}");
                             }
                         })
                         .collect();
@@ -1487,7 +1487,7 @@ impl NpcTemplate {
                 keys_to_guid
                     .get(key)
                     .copied()
-                    .unwrap_or_else(|| panic!("Tried to synchronize with unknown NPC {}", key))
+                    .unwrap_or_else(|| panic!("Tried to synchronize with unknown NPC {key}"))
             }),
         }
     }

--- a/src/game_server/handlers/chat.rs
+++ b/src/game_server/handlers/chat.rs
@@ -42,7 +42,7 @@ pub fn process_chat_packet(
                                 .ok_or_else(|| {
                                     ProcessPacketError::new(
                                         ProcessPacketErrorType::ConstraintViolated,
-                                        format!("Unknown player {} sent chat message", sender),
+                                        format!("Unknown player {sender} sent chat message"),
                                     )
                                 })?;
                             message.payload.channel_name.last_name = String::default();
@@ -55,8 +55,7 @@ pub fn process_chat_packet(
                                             ProcessPacketError::new(
                                                 ProcessPacketErrorType::ConstraintViolated,
                                                 format!(
-                                                    "Unknown player {} sent world chat message",
-                                                    sender
+                                                    "Unknown player {sender} sent world chat message"
                                                 ),
                                             )
                                         })?;
@@ -156,13 +155,13 @@ pub fn process_chat_packet(
                 cursor.read_to_end(&mut buffer)?;
                 Err(ProcessPacketError::new(
                     ProcessPacketErrorType::UnknownOpCode,
-                    format!("Unimplemented chat op code: {:?}, {:x?}", op_code, buffer),
+                    format!("Unimplemented chat op code: {op_code:?}, {buffer:x?}"),
                 ))
             }
         },
         Err(_) => Err(ProcessPacketError::new(
             ProcessPacketErrorType::UnknownOpCode,
-            format!("Unknown chat op code: {}", raw_op_code),
+            format!("Unknown chat op code: {raw_op_code}"),
         )),
     }
 }

--- a/src/game_server/handlers/command.rs
+++ b/src/game_server/handlers/command.rs
@@ -28,7 +28,7 @@ pub fn process_command(
                 cursor.read_to_end(&mut buffer)?;
                 Err(ProcessPacketError::new(
                     ProcessPacketErrorType::UnknownOpCode,
-                    format!("Unimplemented command packet: {:?}, {:x?}", op_code, buffer),
+                    format!("Unimplemented command packet: {op_code:?}, {buffer:x?}"),
                 ))
             }
         },
@@ -37,7 +37,7 @@ pub fn process_command(
             cursor.read_to_end(&mut buffer)?;
             Err(ProcessPacketError::new(
                 ProcessPacketErrorType::UnknownOpCode,
-                format!("Unknown command packet: {}, {:x?}", raw_op_code, buffer),
+                format!("Unknown command packet: {raw_op_code}, {buffer:x?}"),
             ))
         }
     }

--- a/src/game_server/handlers/force_connection.rs
+++ b/src/game_server/handlers/force_connection.rs
@@ -85,7 +85,7 @@ impl ForceConnectionBoard {
         let Some(next_open_row) = self.next_open_row(col) else {
             return Err(ProcessPacketError::new(
                 ProcessPacketErrorType::ConstraintViolated,
-                format!("Cannot drop piece in column {} that is already full", col),
+                format!("Cannot drop piece in column {col} that is already full"),
             ));
         };
 
@@ -111,20 +111,14 @@ impl ForceConnectionBoard {
         if piece1 == ForceConnectionPiece::Empty || piece1 == ForceConnectionPiece::Wall {
             return Err(ProcessPacketError::new(
                 ProcessPacketErrorType::ConstraintViolated,
-                format!(
-                    "Piece 1 at ({}, {}) must be a player piece but was: {:?}",
-                    row1, col1, piece1
-                ),
+                format!("Piece 1 at ({row1}, {col1}) must be a player piece but was: {piece1:?}"),
             ));
         }
 
         if piece2 == ForceConnectionPiece::Empty || piece2 == ForceConnectionPiece::Wall {
             return Err(ProcessPacketError::new(
                 ProcessPacketErrorType::ConstraintViolated,
-                format!(
-                    "Piece 2 at ({}, {}) must be a player piece but was: {:?}",
-                    row2, col2, piece2
-                ),
+                format!("Piece 2 at ({row2}, {col2}) must be a player piece but was: {piece2:?}"),
             ));
         }
 
@@ -132,8 +126,7 @@ impl ForceConnectionBoard {
             return Err(ProcessPacketError::new(
                 ProcessPacketErrorType::ConstraintViolated,
                 format!(
-                    "Tried to swap identical pieces at ({}, {}) and ({}, {}): {:?}",
-                    row1, col1, row2, col2, piece1
+                    "Tried to swap identical pieces at ({row1}, {col1}) and ({row2}, {col2}): {piece1:?}"
                 ),
             ));
         }
@@ -142,8 +135,7 @@ impl ForceConnectionBoard {
             return Err(ProcessPacketError::new(
                 ProcessPacketErrorType::ConstraintViolated,
                 format!(
-                    "Tried to swap pieces at ({}, {}) and ({}, {}), which are more than 1 row or column apart: {:?}",
-                    row1, col1, row2, col2, piece1
+                    "Tried to swap pieces at ({row1}, {col1}) and ({row2}, {col2}), which are more than 1 row or column apart: {piece1:?}"
                 ),
             ));
         }
@@ -168,8 +160,7 @@ impl ForceConnectionBoard {
             return Err(ProcessPacketError::new(
                 ProcessPacketErrorType::ConstraintViolated,
                 format!(
-                    "Piece to remove at ({}, {}) was expected to be {:?}, but was {:?}",
-                    row, col, expected_piece, piece
+                    "Piece to remove at ({row}, {col}) was expected to be {expected_piece:?}, but was {piece:?}",
                 ),
             ));
         }
@@ -201,7 +192,7 @@ impl ForceConnectionBoard {
                 match piece_type {
                     ForceConnectionPiece::Player1 => player1_matches.push(match_len),
                     ForceConnectionPiece::Player2 => player2_matches.push(match_len),
-                    _ => panic!("Found match for non-player piece type {:?}", piece_type),
+                    _ => panic!("Found match for non-player piece type {piece_type:?}"),
                 }
 
                 for (match_row, match_col) in match_pieces.iter() {
@@ -221,7 +212,7 @@ impl ForceConnectionBoard {
         if row >= BOARD_SIZE {
             return Err(ProcessPacketError::new(
                 ProcessPacketErrorType::ConstraintViolated,
-                format!("Row {} is outside the board", row),
+                format!("Row {row} is outside the board"),
             ));
         }
 
@@ -232,7 +223,7 @@ impl ForceConnectionBoard {
         if col >= BOARD_SIZE {
             return Err(ProcessPacketError::new(
                 ProcessPacketErrorType::ConstraintViolated,
-                format!("Column {} is outside the board", col),
+                format!("Column {col} is outside the board"),
             ));
         }
 
@@ -460,7 +451,7 @@ fn try_external_row_to_internal_row(external_row: u8) -> Result<u8, ProcessPacke
     if external_row >= BOARD_SIZE {
         return Err(ProcessPacketError::new(
             ProcessPacketErrorType::ConstraintViolated,
-            format!("External row {} is outside the board", external_row),
+            format!("External row {external_row} is outside the board"),
         ));
     }
 
@@ -520,9 +511,7 @@ impl ForceConnectionGame {
             return Err(ProcessPacketError::new(
                 ProcessPacketErrorType::ConstraintViolated,
                 format!(
-                    "Player {} tried to connect to Force Connection, but the game has already started ({:?})",
-                    sender,
-                    self
+                    "Player {sender} tried to connect to Force Connection, but the game has already started ({self:?})"
                 ),
             ));
         }
@@ -531,8 +520,8 @@ impl ForceConnectionGame {
             return Err(ProcessPacketError::new(
                 ProcessPacketErrorType::ConstraintViolated,
                 format!(
-                    "Force Connection player 1 with GUID {} is missing or has no name ({:?})",
-                    self.player1, self
+                    "Force Connection player 1 with GUID {} is missing or has no name ({self:?})",
+                    self.player1
                 ),
             ));
         };
@@ -543,8 +532,7 @@ impl ForceConnectionGame {
                 .ok_or(ProcessPacketError::new(
                     ProcessPacketErrorType::ConstraintViolated,
                     format!(
-                        "Force Connection player 2 with GUID {} is missing or has no name ({:?})",
-                        player2_guid, self
+                        "Force Connection player 2 with GUID {player2_guid} is missing or has no name ({self:?})"
                     ),
                 ))?,
             None => &"".to_string(),
@@ -572,9 +560,8 @@ impl ForceConnectionGame {
                             stage_group_guid: self.stage_group_guid,
                         },
                         payload: format!(
-                            "OnLevelDataMsg\t{size},{size},{board}",
-                            size = BOARD_SIZE,
-                            board = self.board
+                            "OnLevelDataMsg\t{BOARD_SIZE},{BOARD_SIZE},{}",
+                            self.board
                         ),
                     },
                 }),
@@ -600,7 +587,7 @@ impl ForceConnectionGame {
                             sub_op_code: -1,
                             stage_group_guid: self.stage_group_guid,
                         },
-                        payload: format!("OnAddPlayerMsg\t0\t{}\t{}\tfalse", name1, self.player1),
+                        payload: format!("OnAddPlayerMsg\t0\t{name1}\t{}\tfalse", self.player1),
                     },
                 }),
                 GamePacket::serialize(&TunneledPacket {
@@ -612,8 +599,7 @@ impl ForceConnectionGame {
                             stage_group_guid: self.stage_group_guid,
                         },
                         payload: format!(
-                            "OnAddPlayerMsg\t1\t{}\t{}\t{}",
-                            name2,
+                            "OnAddPlayerMsg\t1\t{name2}\t{}\t{}",
                             self.player2.unwrap_or(0),
                             self.is_ai_match()
                         ),
@@ -641,7 +627,7 @@ impl ForceConnectionGame {
             }
             self.ready[1] = true;
         } else {
-            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} sent a ready payload for Force Connection, but they aren't one of the game's players ({:?})", sender, self)));
+            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {sender} sent a ready payload for Force Connection, but they aren't one of the game's players ({self:?})")));
         }
 
         if !self.ready[0] || !self.ready[1] {
@@ -681,7 +667,7 @@ impl ForceConnectionGame {
         self.check_turn(sender, player_index, Instant::now())?;
 
         if col >= BOARD_SIZE {
-            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} (index {}) tried to select column {} in Force Connection, but it isn't a valid column ({:?})", sender, player_index, col, self)));
+            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {sender} (index {player_index}) tried to select column {col} in Force Connection, but it isn't a valid column ({self:?})")));
         }
 
         let recipient = match self.turn {
@@ -705,7 +691,7 @@ impl ForceConnectionGame {
                         sub_op_code: -1,
                         stage_group_guid: self.stage_group_guid,
                     },
-                    payload: format!("OnOtherPlayerSelectNewColumnMsg\t{}", col),
+                    payload: format!("OnOtherPlayerSelectNewColumnMsg\t{col}"),
                 },
             })],
         )])
@@ -739,10 +725,8 @@ impl ForceConnectionGame {
                         stage_group_guid: self.stage_group_guid,
                     },
                     payload: format!(
-                        "OnDropPieceMsg\t{}\t{}\t{}",
-                        player_index,
-                        internal_row_to_external_row(row),
-                        col
+                        "OnDropPieceMsg\t{player_index}\t{}\t{col}",
+                        internal_row_to_external_row(row)
                     ),
                 },
             })],
@@ -760,11 +744,11 @@ impl ForceConnectionGame {
         self.check_turn(sender, player_index, Instant::now())?;
 
         if powerup > 1 {
-            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} (index {}) tried to toggle powerup {} in Force Connection, but it isn't a valid powerup ({:?})", sender, player_index, powerup, self)));
+            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {sender} (index {player_index}) tried to toggle powerup {powerup} in Force Connection, but it isn't a valid powerup ({self:?})")));
         }
 
         if self.powerups[player_index as usize][powerup as usize] == 0 {
-            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} (index {}) tried to toggle powerup {} in Force Connection, but they don't have any more of that powerup ({:?})", sender, player_index, powerup, self)));
+            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {sender} (index {player_index}) tried to toggle powerup {powerup} in Force Connection, but they don't have any more of that powerup ({self:?})")));
         }
 
         let recipient = match self.turn {
@@ -788,7 +772,7 @@ impl ForceConnectionGame {
                         sub_op_code: -1,
                         stage_group_guid: self.stage_group_guid,
                     },
-                    payload: format!("OnOtherPlayerToggledPowerUpMsg\t{}", powerup),
+                    payload: format!("OnOtherPlayerToggledPowerUpMsg\t{powerup}"),
                 },
             })],
         )])
@@ -810,7 +794,7 @@ impl ForceConnectionGame {
         let internal_row2 = try_external_row_to_internal_row(row2)?;
 
         if self.powerups[player_index as usize][ForceConnectionPowerup::Swap as usize] == 0 {
-            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} (index {}) tried to swap pieces ({}, {}) and ({}, {}) in Force Connection, but they have no swap powersups ({:?})", sender, player_index, row1, col1, row2, col2, self)));
+            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {sender} (index {player_index}) tried to swap pieces ({row1}, {col1}) and ({row2}, {col2}) in Force Connection, but they have no swap powersups ({self:?})")));
         }
 
         self.powerups[player_index as usize][ForceConnectionPowerup::Swap as usize] -= 1;
@@ -830,8 +814,7 @@ impl ForceConnectionGame {
                         stage_group_guid: self.stage_group_guid,
                     },
                     payload: format!(
-                        "OnUseLightPowerUpMsg\t{}\t{}\t{}\t{}\t{}",
-                        player_index, row1, col1, row2, col2
+                        "OnUseLightPowerUpMsg\t{player_index}\t{row1}\t{col1}\t{row2}\t{col2}"
                     ),
                 },
             })],
@@ -853,7 +836,7 @@ impl ForceConnectionGame {
         let internal_row = try_external_row_to_internal_row(row)?;
 
         if self.powerups[player_index as usize][ForceConnectionPowerup::Delete as usize] == 0 {
-            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} (index {}) tried to delete piece ({}, {}) in Force Connection, but they have no delete powersups ({:?})", sender, player_index, row, col, self)));
+            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {sender} (index {player_index}) tried to delete piece ({row}, {col}) in Force Connection, but they have no delete powersups ({self:?})")));
         }
 
         self.powerups[player_index as usize][ForceConnectionPowerup::Delete as usize] -= 1;
@@ -879,7 +862,7 @@ impl ForceConnectionGame {
                             sub_op_code: -1,
                             stage_group_guid: self.stage_group_guid,
                         },
-                        payload: format!("OnUseDarkPowerUpMsg\t{}\t{}\t{}", player_index, row, col),
+                        payload: format!("OnUseDarkPowerUpMsg\t{player_index}\t{row}\t{col}"),
                     },
                 }),
                 GamePacket::serialize(&TunneledPacket {
@@ -945,7 +928,7 @@ impl ForceConnectionGame {
         pause: bool,
     ) -> Result<Vec<Broadcast>, ProcessPacketError> {
         if player != self.player1 && Some(player) != self.player2 {
-            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to pause or resume (pause: {}) the game for player {}, who is not playing this instance of Force Connection ({:?})", pause, player, self)));
+            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to pause or resume (pause: {pause}) the game for player {player}, who is not playing this instance of Force Connection ({self:?})")));
         };
 
         if !self.is_ai_match() {
@@ -971,7 +954,7 @@ impl ForceConnectionGame {
         } else if Some(player) == self.player2 {
             1
         } else {
-            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to remove player {}, who is not playing this instance of Force Connection ({:?})", player, self)));
+            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to remove player {player}, who is not playing this instance of Force Connection ({self:?})")));
         };
 
         minigame_status.game_won = self.matches[player_index] >= MATCHES_TO_WIN;
@@ -1030,15 +1013,15 @@ impl ForceConnectionGame {
         let is_valid_for_player = match player_index {
             0 => self.turn == ForceConnectionTurn::Player1 && sender == self.player1,
             1 => self.turn == ForceConnectionTurn::Player2 && ((sender == self.player1 && self.is_ai_match()) || (Some(sender) == self.player2)),
-            _ => return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} tried to make a move in Force Connection, but the player index {} isn't valid ({:?})", sender, player_index, self)))
+            _ => return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {sender} tried to make a move in Force Connection, but the player index {player_index} isn't valid ({self:?})")))
         };
 
         if !is_valid_for_player {
-            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} (index {}) tried to make a move in Force Connection, but it isn't their turn ({:?})", sender, player_index, self)));
+            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {sender} (index {player_index}) tried to make a move in Force Connection, but it isn't their turn ({self:?})")));
         }
 
         if self.time_until_next_event(turn_time).is_zero() {
-            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} (index {}) tried to make a move in Force Connection, but their turn expired ({:?})", sender, player_index, self)));
+            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {sender} (index {player_index}) tried to make a move in Force Connection, but their turn expired ({self:?})")));
         }
 
         if self.state != ForceConnectionGameState::WaitingForMove {
@@ -1049,7 +1032,7 @@ impl ForceConnectionGame {
             } else {
                 LogLevel::Info
             };
-            return Err(ProcessPacketError::new_with_log_level(ProcessPacketErrorType::ConstraintViolated, format!("Player {} (index {}) tried to make a move in Force Connection, but the state is {:?} instead of waiting for a move ({:?})", sender, player_index, self.state, self), log_level));
+            return Err(ProcessPacketError::new_with_log_level(ProcessPacketErrorType::ConstraintViolated, format!("Player {sender} (index {player_index}) tried to make a move in Force Connection, but the state is {:?} instead of waiting for a move ({self:?})", self.state), log_level));
         }
 
         Ok(())
@@ -1075,8 +1058,8 @@ impl ForceConnectionGame {
                             stage_group_guid: self.stage_group_guid,
                         },
                         payload: format!(
-                            "OnScoreFromTimeMsg\t{}\t{}",
-                            self.turn, score_from_turn_time
+                            "OnScoreFromTimeMsg\t{}\t{score_from_turn_time}",
+                            self.turn
                         ),
                     },
                 })],
@@ -1101,7 +1084,7 @@ impl ForceConnectionGame {
                         sub_op_code: -1,
                         stage_group_guid: self.stage_group_guid,
                     },
-                    payload: format!("OnStartPlayerTurnMsg\t{}\t{}", self.turn, TURN_TIME_SECONDS),
+                    payload: format!("OnStartPlayerTurnMsg\t{}\t{TURN_TIME_SECONDS}", self.turn),
                 },
             })],
         ));
@@ -1175,7 +1158,7 @@ impl ForceConnectionGame {
                             sub_op_code: -1,
                             stage_group_guid: self.stage_group_guid,
                         },
-                        payload: format!("OnPowerUpAddedMsg\t{}\t{}", player_index, new_powerup),
+                        payload: format!("OnPowerUpAddedMsg\t{player_index}\t{new_powerup}"),
                     },
                 })],
             ));
@@ -1193,7 +1176,7 @@ impl ForceConnectionGame {
                             sub_op_code: -1,
                             stage_group_guid: self.stage_group_guid,
                         },
-                        payload: format!("OnAddScoreMsg\t{}\t{}", player_index, score_from_match),
+                        payload: format!("OnAddScoreMsg\t{player_index}\t{score_from_match}"),
                     },
                 }),
                 GamePacket::serialize(&TunneledPacket {
@@ -1204,7 +1187,7 @@ impl ForceConnectionGame {
                             sub_op_code: -1,
                             stage_group_guid: self.stage_group_guid,
                         },
-                        payload: format!("OnAddMatchMsg\t{}", player_index),
+                        payload: format!("OnAddMatchMsg\t{player_index}"),
                     },
                 }),
             ],
@@ -1286,8 +1269,7 @@ impl ForceConnectionGame {
                         stage_group_guid: self.stage_group_guid,
                     },
                     payload: format!(
-                        "OnPowerUpRemainingMsg\t{}\t{},{}",
-                        player_index,
+                        "OnPowerUpRemainingMsg\t{player_index}\t{},{}",
                         self.powerups[player_index as usize][ForceConnectionPowerup::Swap as usize],
                         self.powerups[player_index as usize]
                             [ForceConnectionPowerup::Delete as usize]

--- a/src/game_server/handlers/housing.rs
+++ b/src/game_server/handlers/housing.rs
@@ -363,7 +363,7 @@ pub fn process_housing_packet(
                     write_guids: Vec::new(),
                     character_consumer: |characters_table_read_handle, _, _, minigame_data_lock_enforcer| {
                         let Some((_, instance_guid, _)) = characters_table_read_handle.index1(player_guid(sender)) else {
-                            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Non-existent player {} tried to set edit mode", sender)));
+                            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Non-existent player {sender} tried to set edit mode")));
                         };
 
                         let zones_lock_enforcer: ZoneLockEnforcer = minigame_data_lock_enforcer.into();
@@ -373,22 +373,19 @@ pub fn process_housing_packet(
                             zone_consumer: |_, zones_read, _| {
                                 let Some(zone_read_handle) = zones_read.get(&instance_guid) else {
                                     return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!(
-                                        "Player {} tried to set edit mode but is not in any zone",
-                                        sender
+                                        "Player {sender} tried to set edit mode but is not in any zone"
                                     )));
                                 };
 
                                 let Some(house) = &zone_read_handle.house_data else {
                                     return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!(
-                                        "Player {} tried to set edit mode outside of a house",
-                                        sender
+                                        "Player {sender} tried to set edit mode outside of a house"
                                     )));
                                 };
 
                                 if house.owner != sender {
                                     return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!(
-                                        "Player {} tried to set edit mode in a house they don't own",
-                                        sender
+                                        "Player {sender} tried to set edit mode in a house they don't own"
                                     )));
                                 }
 
@@ -466,8 +463,7 @@ pub fn process_housing_packet(
                                     return Err(ProcessPacketError::new(
                                         ProcessPacketErrorType::ConstraintViolated,
                                         format!(
-                                            "Tried to enter house with unknown template {}",
-                                            template_guid
+                                            "Tried to enter house with unknown template {template_guid}"
                                         ),
                                     ));
                                 };
@@ -507,7 +503,7 @@ pub fn process_housing_packet(
                 cursor.read_to_end(&mut buffer)?;
                 Err(ProcessPacketError::new(
                     ProcessPacketErrorType::UnknownOpCode,
-                    format!("Unimplemented housing packet: {:?}, {:x?}", op_code, buffer),
+                    format!("Unimplemented housing packet: {op_code:?}, {buffer:x?}"),
                 ))
             }
         },
@@ -516,7 +512,7 @@ pub fn process_housing_packet(
             cursor.read_to_end(&mut buffer)?;
             Err(ProcessPacketError::new(
                 ProcessPacketErrorType::UnknownOpCode,
-                format!("Unknown housing packet: {}, {:x?}", raw_op_code, buffer),
+                format!("Unknown housing packet: {raw_op_code}, {buffer:x?}"),
             ))
         }
     }

--- a/src/game_server/handlers/inventory.rs
+++ b/src/game_server/handlers/inventory.rs
@@ -92,7 +92,7 @@ pub fn process_inventory_packet(
         },
         Err(_) => Err(ProcessPacketError::new(
             ProcessPacketErrorType::UnknownOpCode,
-            format!("Unknown inventory packet: {}, {:x?}", raw_op_code, cursor),
+            format!("Unknown inventory packet: {raw_op_code}, {cursor:x?}"),
         )),
     }
 }
@@ -149,8 +149,7 @@ pub fn customizations_from_item_guids(
             return Err(ProcessPacketError::new(
                 ProcessPacketErrorType::ConstraintViolated,
                 format!(
-                    "Player {} tried to use unknown customization item guid {}",
-                    sender, customization_item_guid
+                    "Player {sender} tried to use unknown customization item guid {customization_item_guid}"
                 ),
             ));
         };
@@ -160,8 +159,7 @@ pub fn customizations_from_item_guids(
                 return Err(ProcessPacketError::new(
                     ProcessPacketErrorType::ConstraintViolated,
                     format!(
-                        "Player {} tried to use unknown customization {}",
-                        sender, customization_guid
+                        "Player {sender} tried to use unknown customization {customization_guid}"
                     ),
                 ));
             };
@@ -184,18 +182,18 @@ fn process_unequip_slot(
             write_guids: vec![player_guid(sender)],
             character_consumer: |characters_table_read_handle, _, mut characters_write, _| {
                 let Some(character_write_handle) = characters_write.get_mut(&player_guid(sender)) else {
-                    return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Unknown player {} tried to unequip slot", sender)));
+                    return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Unknown player {sender} tried to unequip slot")));
                 };
 
                 let mut brandished_wield_type = None;
                 let CharacterType::Player(ref mut player_data) = character_write_handle.stats.character_type else {
-                    return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Non-player character {} tried to unequip slot", sender)));
+                    return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Non-player character {sender} tried to unequip slot")));
                 };
 
                 let possible_battle_class = player_data.battle_classes.get_mut(&unequip_slot.battle_class);
 
                 let Some(battle_class) = possible_battle_class else {
-                    return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} tried to unequip slot in battle class {} that they don't own", sender, unequip_slot.battle_class)));
+                    return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {sender} tried to unequip slot in battle class {} that they don't own", unequip_slot.battle_class)));
                 };
 
                 battle_class.items.remove(&unequip_slot.slot);
@@ -333,8 +331,8 @@ fn process_equip_saber(
             return Err(ProcessPacketError::new(
                 ProcessPacketErrorType::ConstraintViolated,
                 format!(
-                    "Player {} tried to equip saber in slot {:?}",
-                    sender, equip_guid.slot
+                    "Player {sender} tried to equip saber in slot {:?}",
+                    equip_guid.slot
                 ),
             ));
         }
@@ -351,8 +349,8 @@ fn process_equip_saber(
                     return Err(ProcessPacketError::new(
                         ProcessPacketErrorType::ConstraintViolated,
                         format!(
-                            "Player {} tried to equip unknown saber {}",
-                            sender, equip_guid.item_guid
+                            "Player {sender} tried to equip unknown saber {}",
+                            equip_guid.item_guid
                         ),
                     ));
                 };
@@ -443,7 +441,7 @@ fn process_equip_customization(
                 let Some(character_write_handle) = characters_write.get_mut(&player_guid(sender)) else {
                     return Err(ProcessPacketError::new(
                         ProcessPacketErrorType::ConstraintViolated,
-                        format!("Unknown player {} tried to equip customization", sender),
+                        format!("Unknown player {sender} tried to equip customization"),
                     ));
                 };
 
@@ -452,8 +450,7 @@ fn process_equip_customization(
                     return Err(ProcessPacketError::new(
                         ProcessPacketErrorType::ConstraintViolated,
                         format!(
-                            "Non-player character {} tried to equip customization",
-                            sender
+                            "Non-player character {sender} tried to equip customization"
                         ),
                     ));
                 };
@@ -471,7 +468,7 @@ fn process_equip_customization(
                 };
 
                 if cost > player.credits {
-                    return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} tried to purchase customization {} for {} but only has {} credits", sender, equip_customization.item_guid, cost, player.credits)));
+                    return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {sender} tried to purchase customization {} for {cost} but only has {} credits", equip_customization.item_guid, player.credits)));
                 }
                 player.credits -= cost;
                 let new_credits = player.credits;
@@ -683,7 +680,7 @@ fn equip_item_in_slot<'a>(
     let Some(character_write_handle) = characters_write.get_mut(&player_guid(sender)) else {
         return Err(ProcessPacketError::new(
             ProcessPacketErrorType::ConstraintViolated,
-            format!("Unknown player {} tried to equip item", sender),
+            format!("Unknown player {sender} tried to equip item"),
         ));
     };
 
@@ -701,7 +698,7 @@ fn equip_item_in_slot<'a>(
     else {
         return Err(ProcessPacketError::new(
             ProcessPacketErrorType::ConstraintViolated,
-            format!("Non-player character {} tried to equip item", sender),
+            format!("Non-player character {sender} tried to equip item"),
         ));
     };
 
@@ -709,8 +706,8 @@ fn equip_item_in_slot<'a>(
         return Err(ProcessPacketError::new(
             ProcessPacketErrorType::ConstraintViolated,
             format!(
-                "Player {} tried to equip item {} that they don't own",
-                sender, equip_guid.battle_class
+                "Player {sender} tried to equip item {} that they don't own",
+                equip_guid.battle_class
             ),
         ));
     }
@@ -719,8 +716,8 @@ fn equip_item_in_slot<'a>(
         return Err(ProcessPacketError::new(
             ProcessPacketErrorType::ConstraintViolated,
             format!(
-                "Player {} tried to equip item in battle class {} that they don't own",
-                sender, equip_guid.battle_class
+                "Player {sender} tried to equip item in battle class {} that they don't own",
+                equip_guid.battle_class
             ),
         ));
     };
@@ -737,8 +734,8 @@ fn equip_item_in_slot<'a>(
         return Err(ProcessPacketError::new(
             ProcessPacketErrorType::ConstraintViolated,
             format!(
-                "Player {} tried to equip unknown item {}",
-                sender, equip_guid.item_guid
+                "Player {sender} tried to equip unknown item {}",
+                equip_guid.item_guid
             ),
         ));
     };

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -963,10 +963,7 @@ impl AllMinigameConfigs {
         else {
             return Err(ProcessPacketError::new(
                 ProcessPacketErrorType::ConstraintViolated,
-                format!(
-                    "Requested unknown stage group instance {}",
-                    stage_group_guid
-                ),
+                format!("Requested unknown stage group instance {stage_group_guid}"),
             ));
         };
 
@@ -1218,10 +1215,7 @@ pub fn process_minigame_packet(
                 cursor.read_to_end(&mut buffer)?;
                 Err(ProcessPacketError::new(
                     ProcessPacketErrorType::UnknownOpCode,
-                    format!(
-                        "Unimplemented minigame op code: {:?} {:x?}",
-                        op_code, buffer
-                    ),
+                    format!("Unimplemented minigame op code: {op_code:?} {buffer:x?}"),
                 ))
             }
         },
@@ -1230,7 +1224,7 @@ pub fn process_minigame_packet(
             cursor.read_to_end(&mut buffer)?;
             Err(ProcessPacketError::new(
                 ProcessPacketErrorType::UnknownOpCode,
-                format!("Unknown minigame packet: {}, {:x?}", raw_op_code, buffer),
+                format!("Unknown minigame packet: {raw_op_code}, {buffer:x?}"),
             ))
         }
     }
@@ -1251,8 +1245,8 @@ fn handle_request_stage_group_instance(
                     return Err(ProcessPacketError::new(
                         ProcessPacketErrorType::ConstraintViolated,
                         format!(
-                            "Unknown character {} requested a stage group instance {}",
-                            sender, request.header.stage_group_guid
+                            "Unknown character {sender} requested a stage group instance {}",
+                            request.header.stage_group_guid
                         ),
                     ));
                 };
@@ -1262,8 +1256,8 @@ fn handle_request_stage_group_instance(
                     return Err(ProcessPacketError::new(
                         ProcessPacketErrorType::ConstraintViolated,
                         format!(
-                            "Non-player character {} requested a stage group instance {}",
-                            sender, request.header.stage_group_guid
+                            "Non-player character {sender} requested a stage group instance {}",
+                            request.header.stage_group_guid
                         ),
                     ));
                 };
@@ -1381,8 +1375,8 @@ fn handle_request_create_active_minigame(
         return Err(ProcessPacketError::new(
             ProcessPacketErrorType::ConstraintViolated,
             format!(
-                "Player {} requested to join stage {} in stage group {}, but it doesn't exist",
-                sender, request.header.stage_guid, request.header.stage_group_guid
+                "Player {sender} requested to join stage {} in stage group {}, but it doesn't exist",
+                request.header.stage_guid, request.header.stage_group_guid
             ),
         ));
     };
@@ -1499,10 +1493,7 @@ pub fn prepare_active_minigame_instance(
             let Some(minigame_data) = possible_minigame_data else {
                 return Err(ProcessPacketError::new(
                     ProcessPacketErrorType::ConstraintViolated,
-                    format!(
-                        "Unable to find shared minigame data for group {:?}",
-                        matchmaking_group
-                    ),
+                    format!("Unable to find shared minigame data for group {matchmaking_group:?}"),
                 ));
             };
 
@@ -1546,26 +1537,25 @@ pub fn prepare_active_minigame_instance(
                     return Err(ProcessPacketError::new(
                         ProcessPacketErrorType::ConstraintViolated,
                         format!(
-                            "Unknown player {} tried to create an active minigame",
-                            member_guid
+                            "Unknown player {member_guid} tried to create an active minigame"
                         ),
                     ));
                 };
 
                 let CharacterType::Player(player) = &mut character_write_handle.stats.character_type
                 else {
-                    return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} tried to create an active minigame, but their character isn't a player", member_guid)));
+                    return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {member_guid} tried to create an active minigame, but their character isn't a player")));
                 };
 
                 if !game_server
                     .minigames()
                     .stage_unlocked(stage_group_guid, stage_guid, player)
                 {
-                    return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} tried to create an active minigame for a stage {} they haven't unlocked", member_guid, stage_guid)));
+                    return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {member_guid} tried to create an active minigame for a stage {stage_guid} they haven't unlocked")));
                 }
 
                 let Some(minigame_status) = &mut player.minigame_status else {
-                    return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} tried to create an active minigame, but their minigame status is not set", member_guid)));
+                    return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {member_guid} tried to create an active minigame, but their minigame status is not set")));
                 };
 
                 minigame_status.type_data = stage_config.stage_config.minigame_type().into();
@@ -1602,8 +1592,7 @@ pub fn prepare_active_minigame_instance(
                 &zones_table_write_handle
                     .get(new_instance_guid)
                     .unwrap_or_else(|| panic!(
-                        "Zone instance {} should have been created or already exist but is missing",
-                        new_instance_guid
+                        "Zone instance {new_instance_guid} should have been created or already exist but is missing"
                     ))
                     .read(),
                 None,
@@ -1619,8 +1608,7 @@ pub fn prepare_active_minigame_instance(
                 return Err(ProcessPacketError::new(
                     ProcessPacketErrorType::ConstraintViolated,
                     format!(
-                        "Unknown player {} disappeared after being teleported to a minigame",
-                        member_guid
+                        "Unknown player {member_guid} disappeared after being teleported to a minigame"
                     ),
                 ));
             };
@@ -1630,8 +1618,7 @@ pub fn prepare_active_minigame_instance(
                 return Err(ProcessPacketError::new(
                     ProcessPacketErrorType::ConstraintViolated,
                     format!(
-                        "Player {} became a non-player after teleporting them to a minigame",
-                        member_guid
+                        "Player {member_guid} became a non-player after teleporting them to a minigame"
                     ),
                 ));
             };
@@ -1640,8 +1627,7 @@ pub fn prepare_active_minigame_instance(
                 return Err(ProcessPacketError::new(
                     ProcessPacketErrorType::ConstraintViolated,
                     format!(
-                        "Player {} lost their minigame status after being teleported to a minigame",
-                        member_guid
+                        "Player {member_guid} lost their minigame status after being teleported to a minigame"
                     ),
                 ));
             };
@@ -1688,25 +1674,25 @@ fn handle_request_start_active_minigame(
         write_guids: Vec::new(),
         character_consumer: |_, characters_read, _, minigame_data_lock_enforcer| {
             let Some(character_read_handle) = characters_read.get(&player_guid(sender)) else {
-                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Unknown player {} requested to start an active minigame", sender)));
+                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Unknown player {sender} requested to start an active minigame")));
             };
 
             let CharacterType::Player(player) = &character_read_handle.stats.character_type else {
-                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} requested to start an active minigame, but their character isn't a player", sender)));
+                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {sender} requested to start an active minigame, but their character isn't a player")));
             };
 
             let Some(minigame_status) = &player.minigame_status else {
-                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} requested to start an active minigame (stage {}), but they aren't in an active minigame", sender, request.header.stage_guid)));
+                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {sender} requested to start an active minigame (stage {}), but they aren't in an active minigame", request.header.stage_guid)));
             };
 
             if request.header.stage_guid != minigame_status.group.stage_guid {
-                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} requested to start an active minigame (stage {}), but they're in a different minigame (stage group {}, stage {})", sender, request.header.stage_guid, minigame_status.group.stage_group_guid, minigame_status.group.stage_guid)));
+                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {sender} requested to start an active minigame (stage {}), but they're in a different minigame (stage group {}, stage {})", request.header.stage_guid, minigame_status.group.stage_group_guid, minigame_status.group.stage_guid)));
             };
 
             let mut packets = Vec::new();
 
             let Some(StageConfigRef {stage_config, ..}) = game_server.minigames().stage_config(minigame_status.group.stage_group_guid, minigame_status.group.stage_guid) else {
-                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} requested to start active minigame with stage config {} (stage group {}) that does not exist", sender, minigame_status.group.stage_guid, minigame_status.group.stage_group_guid)));
+                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {sender} requested to start active minigame with stage config {} (stage group {}) that does not exist", minigame_status.group.stage_guid, minigame_status.group.stage_group_guid)));
             };
 
             minigame_data_lock_enforcer.read_minigame_data(|_| MinigameDataLockRequest {
@@ -1714,7 +1700,7 @@ fn handle_request_start_active_minigame(
                 write_guids: vec![minigame_status.group],
                 minigame_data_consumer: |_, _, mut minigame_data_write, _| {
                     let Some(shared_minigame_data) = minigame_data_write.get_mut(&minigame_status.group) else {
-                        return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Unable to find shared minigame data for group {:?} when starting minigame for player {}", minigame_status.group, sender)));
+                        return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Unable to find shared minigame data for group {:?} when starting minigame for player {sender}", minigame_status.group)));
                     };
 
                     if let MinigameReadiness::InitialPlayersLoading(players, first_player_load_time) = &mut shared_minigame_data.readiness {
@@ -1854,7 +1840,7 @@ pub fn handle_minigame_packet_write<T: Default>(
             let Some(character_write_handle) = characters_write.get_mut(&player_guid(sender)) else {
                 return Err(ProcessPacketError::new(
                     ProcessPacketErrorType::ConstraintViolated,
-                    format!("Tried to process packet for unknown player {}'s active minigame", sender),
+                    format!("Tried to process packet for unknown player {sender}'s active minigame"),
                 ));
             };
 
@@ -1862,24 +1848,23 @@ pub fn handle_minigame_packet_write<T: Default>(
                 return Err(ProcessPacketError::new(
                     ProcessPacketErrorType::ConstraintViolated,
                     format!(
-                        "Tried to process packet for {}'s active minigame, but their character isn't a player",
-                        sender
+                        "Tried to process packet for {sender}'s active minigame, but their character isn't a player"
                     ),
                 ));
             };
 
             let Some(minigame_status) = &mut player.minigame_status else {
-                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to process packet for {}'s active minigame (stage {}), but they aren't in an active minigame", sender, header.stage_guid)));
+                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to process packet for {sender}'s active minigame (stage {}), but they aren't in an active minigame", header.stage_guid)));
             };
 
             if header.stage_guid != minigame_status.group.stage_guid {
-                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to process packet for {}'s active minigame (stage {}), but they're in a different minigame (stage group {}, stage {})", sender, header.stage_guid, minigame_status.group.stage_group_guid, minigame_status.group.stage_guid)));
+                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to process packet for {sender}'s active minigame (stage {}), but they're in a different minigame (stage group {}, stage {})", header.stage_guid, minigame_status.group.stage_group_guid, minigame_status.group.stage_guid)));
             };
 
             let Some(stage_config_ref) = game_server
                 .minigames()
                 .stage_config(minigame_status.group.stage_group_guid, minigame_status.group.stage_guid) else {
-                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to process packet for {}'s active minigame with stage config {} (stage group {}) that does not exist", sender, minigame_status.group.stage_guid, minigame_status.group.stage_group_guid)));
+                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to process packet for {sender}'s active minigame with stage config {} (stage group {}) that does not exist", minigame_status.group.stage_guid, minigame_status.group.stage_group_guid)));
             };
 
             minigame_data_lock_enforcer.read_minigame_data(|_| MinigameDataLockRequest {
@@ -1887,7 +1872,7 @@ pub fn handle_minigame_packet_write<T: Default>(
                 write_guids: vec![minigame_status.group],
                 minigame_data_consumer: |_, _, mut minigame_data_write, _| {
                     let Some(shared_minigame_data) = minigame_data_write.get_mut(&minigame_status.group) else {
-                        return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to process packet for {}'s active minigame with stage config {} (stage group {}) that is missing shared minigame data", sender, minigame_status.group.stage_guid, minigame_status.group.stage_group_guid)))
+                        return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to process packet for {sender}'s active minigame with stage config {} (stage group {}) that is missing shared minigame data", minigame_status.group.stage_guid, minigame_status.group.stage_group_guid)))
                     };
 
                     func(minigame_status, &mut player.minigame_stats, &mut player.credits, stage_config_ref, shared_minigame_data, characters_table_read_handle)
@@ -1914,7 +1899,7 @@ fn handle_flash_payload_read_only<T: Default>(
             let Some(character_read_handle) = characters_read.get(&player_guid(sender)) else {
                 return Err(ProcessPacketError::new(
                     ProcessPacketErrorType::ConstraintViolated,
-                    format!("Tried to process Flash payload for unknown player {}'s active minigame", sender),
+                    format!("Tried to process Flash payload for unknown player {sender}'s active minigame"),
                 ));
             };
 
@@ -1922,24 +1907,23 @@ fn handle_flash_payload_read_only<T: Default>(
                 return Err(ProcessPacketError::new(
                     ProcessPacketErrorType::ConstraintViolated,
                     format!(
-                        "Tried to process Flash payload for {}'s active minigame, but their character isn't a player",
-                        sender
+                        "Tried to process Flash payload for {sender}'s active minigame, but their character isn't a player"
                     ),
                 ));
             };
 
             let Some(minigame_status) = &player.minigame_status else {
-                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to process Flash payload for {}'s active minigame (stage {}), but they aren't in an active minigame", sender, header.stage_guid)));
+                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to process Flash payload for {sender}'s active minigame (stage {}), but they aren't in an active minigame", header.stage_guid)));
             };
 
             if header.stage_guid != minigame_status.group.stage_guid {
-                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to process Flash payload for {}'s active minigame (stage {}), but they're in a different minigame (stage group {}, stage {})", sender, header.stage_guid, minigame_status.group.stage_group_guid, minigame_status.group.stage_guid)));
+                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to process Flash payload for {sender}'s active minigame (stage {}), but they're in a different minigame (stage group {}, stage {})", header.stage_guid, minigame_status.group.stage_group_guid, minigame_status.group.stage_guid)));
             }
 
             let Some(stage_config_ref) = game_server
                 .minigames()
                 .stage_config(minigame_status.group.stage_group_guid, minigame_status.group.stage_guid) else {
-                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to process Flash payload for {}'s active minigame with stage config {} (stage group {}) that does not exist", sender, minigame_status.group.stage_guid, minigame_status.group.stage_group_guid)));
+                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to process Flash payload for {sender}'s active minigame with stage config {} (stage group {}) that does not exist", minigame_status.group.stage_guid, minigame_status.group.stage_group_guid)));
             };
 
             minigame_data_lock_enforcer.read_minigame_data(|_| MinigameDataLockRequest {
@@ -1947,7 +1931,7 @@ fn handle_flash_payload_read_only<T: Default>(
                 write_guids: Vec::new(),
                 minigame_data_consumer: |_, minigame_data_read, _, _| {
                     let Some(shared_minigame_data) = minigame_data_read.get(&minigame_status.group) else {
-                        return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to process Flash payload for {}'s active minigame with stage config {} (stage group {}) that is missing shared minigame data", sender, minigame_status.group.stage_guid, minigame_status.group.stage_group_guid)))
+                        return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to process Flash payload for {sender}'s active minigame with stage config {} (stage group {}) that is missing shared minigame data", minigame_status.group.stage_guid, minigame_status.group.stage_group_guid)))
                     };
 
                     func(minigame_status, stage_config_ref, shared_minigame_data)
@@ -1982,7 +1966,7 @@ fn handle_flash_payload_game_result(
             let MinigameReadiness::Ready(previous_time, possible_resume_time) =
                 shared_minigame_data.readiness
             else {
-                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} sent a Flash game result payload (won: {}) for a game that isn't ready yet", sender, won)));
+                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {sender} sent a Flash game result payload (won: {won}) for a game that isn't ready yet")));
             };
 
             let now = Instant::now();
@@ -2012,7 +1996,7 @@ fn handle_flash_payload_game_result(
                             sub_op_code: -1,
                             stage_group_guid: minigame_status.group.stage_group_guid,
                         },
-                        payload: format!("OnGamePlayTimeMsg\t{}", total_time),
+                        payload: format!("OnGamePlayTimeMsg\t{total_time}"),
                     },
                 })],
             )])
@@ -2117,7 +2101,7 @@ fn handle_flash_payload(
                                     sub_op_code: -1,
                                     stage_group_guid: minigame_status.group.stage_group_guid,
                                 },
-                                payload: format!("OnShowEndRoundScreenMsg\t{}", awarded_credits),
+                                payload: format!("OnShowEndRoundScreenMsg\t{awarded_credits}"),
                             },
                         })],
                     ));
@@ -2217,8 +2201,7 @@ fn handle_flash_payload(
                     _ => Err(ProcessPacketError::new(
                         ProcessPacketErrorType::ConstraintViolated,
                         format!(
-                            "Received connect message for unexpected game from player {}",
-                            sender
+                            "Received connect message for unexpected game from player {sender}"
                         ),
                     )),
                 }
@@ -2233,8 +2216,7 @@ fn handle_flash_payload(
                 _ => Err(ProcessPacketError::new(
                     ProcessPacketErrorType::ConstraintViolated,
                     format!(
-                        "Received player ready message for unexpected game from player {}",
-                        sender
+                        "Received player ready message for unexpected game from player {sender}"
                     ),
                 )),
             },
@@ -2262,8 +2244,7 @@ fn handle_flash_payload(
                 _ => Err(ProcessPacketError::new(
                     ProcessPacketErrorType::ConstraintViolated,
                     format!(
-                        "Received select column message for unexpected game from player {}",
-                        sender
+                        "Received select column message for unexpected game from player {sender}"
                     ),
                 )),
             },
@@ -2291,8 +2272,7 @@ fn handle_flash_payload(
                 _ => Err(ProcessPacketError::new(
                     ProcessPacketErrorType::ConstraintViolated,
                     format!(
-                        "Received drop piece message for unexpected game from player {}",
-                        sender
+                        "Received drop piece message for unexpected game from player {sender}"
                     ),
                 )),
             },
@@ -2320,8 +2300,7 @@ fn handle_flash_payload(
                 _ => Err(ProcessPacketError::new(
                     ProcessPacketErrorType::ConstraintViolated,
                     format!(
-                        "Received toggle powerup message for unexpected game from player {}",
-                        sender
+                        "Received toggle powerup message for unexpected game from player {sender}"
                     ),
                 )),
             },
@@ -2352,8 +2331,7 @@ fn handle_flash_payload(
                 _ => Err(ProcessPacketError::new(
                     ProcessPacketErrorType::ConstraintViolated,
                     format!(
-                        "Received swap powerup request for unexpected game from player {}",
-                        sender
+                        "Received swap powerup request for unexpected game from player {sender}"
                     ),
                 )),
             },
@@ -2382,8 +2360,7 @@ fn handle_flash_payload(
                 _ => Err(ProcessPacketError::new(
                     ProcessPacketErrorType::ConstraintViolated,
                     format!(
-                        "Received delete powerup request for unexpected game from player {}",
-                        sender
+                        "Received delete powerup request for unexpected game from player {sender}"
                     ),
                 )),
             },
@@ -2391,16 +2368,16 @@ fn handle_flash_payload(
         _ => Err(ProcessPacketError::new(
             ProcessPacketErrorType::ConstraintViolated,
             format!(
-                "Received unknown Flash payload {} in stage {}, stage group {} from player {}",
-                payload.payload, payload.header.stage_guid, payload.header.stage_group_guid, sender
+                "Received unknown Flash payload {} in stage {}, stage group {} from player {sender}",
+                payload.payload, payload.header.stage_guid, payload.header.stage_group_guid
             ),
         )),
     };
 
     result.map_err(|err| {
         err.wrap(format!(
-            "Error while processing Flash payload \"{}\" from player {}",
-            payload.payload, sender
+            "Error while processing Flash payload \"{}\" from player {sender}",
+            payload.payload
         ))
     })
 }
@@ -2422,8 +2399,8 @@ pub fn create_active_minigame_if_uncreated(
         return Err(ProcessPacketError::new(
             ProcessPacketErrorType::ConstraintViolated,
             format!(
-                "Player {} requested creation of unknown stage {} (stage group {})",
-                sender, minigame_status.group.stage_guid, minigame_status.group.stage_group_guid
+                "Player {sender} requested creation of unknown stage {} (stage group {})",
+                minigame_status.group.stage_guid, minigame_status.group.stage_group_guid
             ),
         ));
     };
@@ -2530,7 +2507,7 @@ fn leave_active_minigame_single_player_if_any(
             let Some(character_write_handle) = possible_character_write_handle else {
                 return Err(ProcessPacketError::new(
                     ProcessPacketErrorType::ConstraintViolated,
-                    format!("Tried to end unknown player {}'s active minigame", sender),
+                    format!("Tried to end unknown player {sender}'s active minigame"),
                 ));
             };
 
@@ -2539,8 +2516,7 @@ fn leave_active_minigame_single_player_if_any(
                 return Err(ProcessPacketError::new(
                     ProcessPacketErrorType::ConstraintViolated,
                     format!(
-                    "Tried to end player {}'s active minigame, but their character isn't a player",
-                    sender
+                    "Tried to end player {sender}'s active minigame, but their character isn't a player"
                 ),
                 ));
             };
@@ -2710,8 +2686,7 @@ fn leave_active_minigame_single_player_if_any(
         &zones_table_write_handle
             .get(instance_guid)
             .unwrap_or_else(|| panic!(
-                "Zone instance {} should have been created or already exist but is missing",
-                instance_guid
+                "Zone instance {instance_guid} should have been created or already exist but is missing"
             ))
             .read(),
         Some(previous_location.pos),
@@ -2742,7 +2717,7 @@ fn remove_single_player_from_matchmaking(
         let Some(character_write_handle) = possible_character_write_handle else {
             return Err(ProcessPacketError::new(
                 ProcessPacketErrorType::ConstraintViolated,
-                format!("Tried to remove unknown player {} from matchmaking", player),
+                format!("Tried to remove unknown player {player} from matchmaking"),
             ));
         };
 
@@ -2750,8 +2725,7 @@ fn remove_single_player_from_matchmaking(
             return Err(ProcessPacketError::new(
                 ProcessPacketErrorType::ConstraintViolated,
                 format!(
-                    "Tried to remove player {} from matchmaking, but their character isn't a player",
-                    player
+                    "Tried to remove player {player} from matchmaking, but their character isn't a player"
                 ),
             ));
         };
@@ -2816,8 +2790,7 @@ fn remove_single_player_from_matchmaking(
             &zones_table_write_handle
                 .get(instance_guid)
                 .unwrap_or_else(|| panic!(
-                    "Zone instance {} should have been created or already exist but is missing",
-                    instance_guid
+                    "Zone instance {instance_guid} should have been created or already exist but is missing"
                 ))
                 .read(),
             Some(previous_location.pos),
@@ -2896,11 +2869,11 @@ pub fn leave_active_minigame_if_any(
         .minigames()
         .stage_config(group.stage_group_guid, group.stage_guid)
     else {
-        return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to end target {:?}'s active minigame with stage config {} (stage group {}) that does not exist", target, group.stage_guid, group.stage_group_guid)));
+        return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to end target {target:?}'s active minigame with stage config {} (stage group {}) that does not exist", group.stage_guid, group.stage_group_guid)));
     };
 
     let Some(shared_minigame_data) = minigame_data_table_write_handle.get(group) else {
-        return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to end target {:?}'s active minigame with shared minigame data {} (stage group {}) that does not exist", target, group.stage_guid, group.stage_group_guid)));
+        return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to end target {target:?}'s active minigame with shared minigame data {} (stage group {}) that does not exist", group.stage_guid, group.stage_group_guid)));
     };
     let mut minigame_data_write_handle = shared_minigame_data.write();
     let is_matchmaking = minigame_data_write_handle.readiness == MinigameReadiness::Matchmaking;
@@ -2977,20 +2950,12 @@ fn evaluate_score_to_credits_expression(
     let context = context_map! {
         "x" => evalexpr::Value::Float(score as f64),
     }
-    .unwrap_or_else(|_| {
-        panic!(
-            "Couldn't build expression evaluation context for score {}",
-            score
-        )
-    });
+    .unwrap_or_else(|_| panic!("Couldn't build expression evaluation context for score {score}"));
 
     let result = eval_with_context(score_to_credits_expression, &context).map_err(|err| {
         Error::new(
             ErrorKind::InvalidData,
-            format!(
-                "Unable to evaluate score-to-credits expression for score {}: {}",
-                score, err
-            ),
+            format!("Unable to evaluate score-to-credits expression for score {score}: {err}"),
         )
     })?;
 
@@ -2998,8 +2963,7 @@ fn evaluate_score_to_credits_expression(
         return Err(Error::new(
             ErrorKind::InvalidData,
             format!(
-                "Score-to-credits expression did not return an integer for score {}, returned: {}",
-                score, result
+                "Score-to-credits expression did not return an integer for score {score}, returned: {result}"
             ),
         ));
     };
@@ -3008,10 +2972,7 @@ fn evaluate_score_to_credits_expression(
         Error::new(
             ErrorKind::InvalidData,
             format!(
-                "Score-to-credits expression returned float that could not be converted to an integer for score {}: {}, {}",
-                score,
-                credits,
-                err
+                "Score-to-credits expression returned float that could not be converted to an integer for score {score}: {credits}, {err}"
             ),
         )
     })

--- a/src/game_server/handlers/mount.rs
+++ b/src/game_server/handlers/mount.rs
@@ -64,7 +64,7 @@ pub fn load_mounts(config_dir: &Path) -> Result<BTreeMap<u32, MountConfig>, Conf
         let previous = mount_table.insert(guid, mount);
 
         if previous.is_some() {
-            panic!("Two mounts have ID {}", guid);
+            panic!("Two mounts have ID {guid}");
         }
     }
 
@@ -100,10 +100,7 @@ pub fn reply_dismount<'a>(
     let Some(mount) = mounts.get(&mount_id) else {
         return Err(ProcessPacketError::new(
             ProcessPacketErrorType::ConstraintViolated,
-            format!(
-                "Player {} tried to dismount from non-existent mount",
-                sender
-            ),
+            format!("Player {sender} tried to dismount from non-existent mount"),
         ));
     };
 
@@ -191,7 +188,7 @@ fn process_dismount(
                 else {
                     return Err(ProcessPacketError::new(
                         ProcessPacketErrorType::ConstraintViolated,
-                        format!("Non-existent player {} tried to dismount", sender),
+                        format!("Non-existent player {sender} tried to dismount"),
                     ));
                 };
 
@@ -205,7 +202,7 @@ fn process_dismount(
                         else {
                             return Err(ProcessPacketError::new(
                                 ProcessPacketErrorType::ConstraintViolated,
-                                format!("Player {} tried to enter unknown zone", sender),
+                                format!("Player {sender} tried to enter unknown zone"),
                             ));
                         };
 
@@ -234,8 +231,8 @@ fn process_mount_spawn(
         return Err(ProcessPacketError::new(
             ProcessPacketErrorType::ConstraintViolated,
             format!(
-                "Player {} tried to mount on unknown mount ID {}",
-                sender, mount_spawn.mount_id
+                "Player {sender} tried to mount on unknown mount ID {}",
+                mount_spawn.mount_id
             ),
         ));
     };
@@ -253,7 +250,7 @@ fn process_mount_spawn(
                 else {
                     return Err(ProcessPacketError::new(
                         ProcessPacketErrorType::ConstraintViolated,
-                        format!("Non-existent player {} tried to mount", sender),
+                        format!("Non-existent player {sender} tried to mount"),
                     ));
                 };
 
@@ -270,8 +267,7 @@ fn process_mount_spawn(
                             return Err(ProcessPacketError::new(
                                 ProcessPacketErrorType::ConstraintViolated,
                                 format!(
-                                    "Player {} tried to mount but is in a non-existent zone",
-                                    sender
+                                    "Player {sender} tried to mount but is in a non-existent zone"
                                 ),
                             ));
                         };
@@ -305,8 +301,7 @@ fn process_mount_spawn(
                             return Err(ProcessPacketError::new(
                                 ProcessPacketErrorType::ConstraintViolated,
                                 format!(
-                                    "Player {} tried to mount while already mounted on mount ID {}, GUID {}",
-                                    sender, mount_id, mount_guid
+                                    "Player {sender} tried to mount while already mounted on mount ID {mount_id}, GUID {mount_guid}"
                                 ),
                             ));
                         }
@@ -371,12 +366,12 @@ pub fn process_mount_packet(
             MountOpCode::MountSpawn => process_mount_spawn(cursor, sender, game_server),
             _ => Err(ProcessPacketError::new(
                 ProcessPacketErrorType::UnknownOpCode,
-                format!("Unimplemented mount op code: {:?}", op_code),
+                format!("Unimplemented mount op code: {op_code:?}"),
             )),
         },
         Err(_) => Err(ProcessPacketError::new(
             ProcessPacketErrorType::UnknownOpCode,
-            format!("Unknown mount op code: {}", raw_op_code),
+            format!("Unknown mount op code: {raw_op_code}"),
         )),
     }
 }

--- a/src/game_server/handlers/saber_strike.rs
+++ b/src/game_server/handlers/saber_strike.rs
@@ -54,7 +54,7 @@ pub fn process_saber_strike_packet(
                             },
                             _ => Err(ProcessPacketError::new(
                                 ProcessPacketErrorType::ConstraintViolated,
-                                format!("Player {} sent a Saber Strike obfuscated score packet, but they have no Saber Strike game data", sender)
+                                format!("Player {sender} sent a Saber Strike obfuscated score packet, but they have no Saber Strike game data")
                             ))
                         }
                     },
@@ -65,10 +65,7 @@ pub fn process_saber_strike_packet(
                 cursor.read_to_end(&mut buffer)?;
                 Err(ProcessPacketError::new(
                     ProcessPacketErrorType::UnknownOpCode,
-                    format!(
-                        "Unimplemented minigame op code: {:?} {:x?}",
-                        op_code, buffer
-                    ),
+                    format!("Unimplemented minigame op code: {op_code:?} {buffer:x?}"),
                 ))
             }
         },
@@ -78,8 +75,8 @@ pub fn process_saber_strike_packet(
             Err(ProcessPacketError::new(
                 ProcessPacketErrorType::UnknownOpCode,
                 format!(
-                    "Unknown minigame packet: {}, {:x?}",
-                    header.sub_op_code, buffer
+                    "Unknown minigame packet: {}, {buffer:x?}",
+                    header.sub_op_code
                 ),
             ))
         }
@@ -101,7 +98,7 @@ fn handle_saber_strike_game_over(
             else {
                 return Err(ProcessPacketError::new(
                     ProcessPacketErrorType::ConstraintViolated,
-                    format!("Player {} sent a Saber Strike game over packet, but they have no Saber Strike game data", sender)
+                    format!("Player {sender} sent a Saber Strike game over packet, but they have no Saber Strike game data")
                 ));
             };
 
@@ -109,10 +106,8 @@ fn handle_saber_strike_game_over(
                 return Err(ProcessPacketError::new(
                     ProcessPacketErrorType::ConstraintViolated,
                     format!(
-                        "Player {} sent a Saber Strike game over packet with score {}, but their obfuscated score was {}",
-                        sender,
+                        "Player {sender} sent a Saber Strike game over packet with score {}, but their obfuscated score was {obfuscated_score}",
                         game_over.total_score,
-                        obfuscated_score,
                     )
                 ));
             }

--- a/src/game_server/handlers/store.rs
+++ b/src/game_server/handlers/store.rs
@@ -147,19 +147,13 @@ fn evaluate_cost_expression(
         "x" => evalexpr::Value::Float(cost as f64),
     }
     .unwrap_or_else(|_| {
-        panic!(
-            "Couldn't build expression evaluation context for item {}",
-            item_guid
-        )
+        panic!("Couldn't build expression evaluation context for item {item_guid}")
     });
 
     let result = eval_with_context(cost_expression, &context).map_err(|err| {
         Error::new(
             ErrorKind::InvalidData,
-            format!(
-                "Unable to evaluate cost expression for item {}: {}",
-                item_guid, err
-            ),
+            format!("Unable to evaluate cost expression for item {item_guid}: {err}"),
         )
     })?;
 
@@ -167,8 +161,7 @@ fn evaluate_cost_expression(
         return Err(Error::new(
             ErrorKind::InvalidData,
             format!(
-                "Cost expression did not return an integer for item {}, returned: {}",
-                item_guid, result
+                "Cost expression did not return an integer for item {item_guid}, returned: {result}"
             ),
         ));
     };
@@ -177,10 +170,7 @@ fn evaluate_cost_expression(
         Error::new(
             ErrorKind::InvalidData,
             format!(
-                "Cost expression returned float that could not be converted to an integer for item {}: {}, {}",
-                item_guid,
-                new_cost,
-                err
+                "Cost expression returned float that could not be converted to an integer for item {item_guid}: {new_cost}, {err}"
             ),
         )
     })

--- a/src/game_server/handlers/test_data.rs
+++ b/src/game_server/handlers/test_data.rs
@@ -95,7 +95,7 @@ pub fn make_test_player(
                 last_name: if guid == 1 {
                     String::from("NICESHOT")
                 } else {
-                    format!("NICESHOT {}", guid)
+                    format!("NICESHOT {guid}")
                 },
             },
             credits: 1000000,

--- a/src/game_server/handlers/unique_guid.rs
+++ b/src/game_server/handlers/unique_guid.rs
@@ -38,7 +38,7 @@ pub fn shorten_player_guid(player_guid: u64) -> Result<u32, ProcessPacketError> 
     if player_guid > u32::MAX as u64 {
         Err(ProcessPacketError::new(
             ProcessPacketErrorType::ConstraintViolated,
-            format!("Player GUID {} must be <= {}", player_guid, u32::MAX),
+            format!("Player GUID {player_guid} must be <= {}", u32::MAX),
         ))
     } else {
         Ok(player_guid as u32)

--- a/src/game_server/handlers/zone.rs
+++ b/src/game_server/handlers/zone.rs
@@ -1000,7 +1000,7 @@ pub fn load_zones(config_dir: &Path) -> Result<LoadedZones, ConfigError> {
             let template_guid = Guid::guid(&template);
 
             if templates.insert(template_guid, template).is_some() {
-                panic!("Two zone templates have ID {}", template_guid);
+                panic!("Two zone templates have ID {template_guid}");
             }
         }
     }
@@ -1233,7 +1233,7 @@ pub fn teleport_anywhere(
                             Some(character) => Ok(character.read().stats.instance_guid),
                             None => Err(ProcessPacketError::new(
                                 ProcessPacketErrorType::ConstraintViolated,
-                                format!("Tried to teleport unknown player {} anywhere", requester),
+                                format!("Tried to teleport unknown player {requester} anywhere"),
                             )),
                         }?;
 
@@ -1303,8 +1303,7 @@ pub fn interact_with_character(
                         return Err(ProcessPacketError::new(
                             ProcessPacketErrorType::ConstraintViolated,
                             format!(
-                                "Received request to interact with unknown NPC {} from {}",
-                                target, requester
+                                "Received request to interact with unknown NPC {target} from {requester}"
                             ),
                         ));
                     };

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -117,7 +117,7 @@ impl ProcessPacketError {
         ProcessPacketError {
             backtrace: self.backtrace,
             err_type: self.err_type,
-            message: format!("{}: {}", message, self.message),
+            message: format!("{message}: {}", self.message),
             log_level: self.log_level,
         }
     }
@@ -131,7 +131,7 @@ impl From<Error> for ProcessPacketError {
     fn from(err: Error) -> Self {
         ProcessPacketError::new(
             ProcessPacketErrorType::DeserializeError,
-            format!("IO Error: {}", err),
+            format!("IO Error: {err}"),
         )
     }
 }
@@ -140,7 +140,7 @@ impl From<ParseBoolError> for ProcessPacketError {
     fn from(err: ParseBoolError) -> Self {
         ProcessPacketError::new(
             ProcessPacketErrorType::DeserializeError,
-            format!("Parse bool error: {}", err),
+            format!("Parse bool error: {err}"),
         )
     }
 }
@@ -149,7 +149,7 @@ impl From<ParseIntError> for ProcessPacketError {
     fn from(err: ParseIntError) -> Self {
         ProcessPacketError::new(
             ProcessPacketErrorType::DeserializeError,
-            format!("Parse int error: {}", err),
+            format!("Parse int error: {err}"),
         )
     }
 }
@@ -158,7 +158,7 @@ impl From<DeserializePacketError> for ProcessPacketError {
     fn from(err: DeserializePacketError) -> Self {
         ProcessPacketError::new(
             ProcessPacketErrorType::DeserializeError,
-            format!("Deserialize Error: {:?}", err),
+            format!("Deserialize Error: {err:?}"),
         )
     }
 }
@@ -233,15 +233,12 @@ impl GameServer {
                 }
                 _ => Err(ProcessPacketError::new(
                     ProcessPacketErrorType::ConstraintViolated,
-                    format!(
-                        "Client tried to log in without a login request, data: {:x?}",
-                        data
-                    ),
+                    format!("Client tried to log in without a login request, data: {data:x?}"),
                 )),
             },
             Err(_) => Err(ProcessPacketError::new(
                 ProcessPacketErrorType::UnknownOpCode,
-                format!("Unknown op code at login: {}", raw_op_code),
+                format!("Unknown op code at login: {raw_op_code}"),
             )),
         }
     }
@@ -327,8 +324,7 @@ impl GameServer {
                                         return Err(ProcessPacketError::new(
                                             ProcessPacketErrorType::ConstraintViolated,
                                             format!(
-                                                "Player {} sent ready packet but does not exist",
-                                                sender
+                                                "Player {sender} sent ready packet but does not exist"
                                             ),
                                         ));
                                     };
@@ -423,8 +419,7 @@ impl GameServer {
                             write_guids: vec![player_guid(sender)],
                             character_consumer: move |characters_table_read_handle, characters_read, mut characters_write, minigame_data_lock_enforcer| {
                                 let Some((_, instance_guid, chunk)) = possible_index else {
-                                    return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} sent a ready packet but is not in any zone",
-                                        sender)));
+                                    return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {sender} sent a ready packet but is not in any zone")));
                                 };
 
                                 let zones_lock_enforcer: ZoneLockEnforcer = minigame_data_lock_enforcer.into();
@@ -433,8 +428,7 @@ impl GameServer {
                                     write_guids: Vec::new(),
                                     zone_consumer: |_, zones_read, _| {
                                         let Some(zone) = zones_read.get(&instance_guid) else {
-                                            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} sent a ready packet from unknown zone {}",
-                                                sender, instance_guid)));
+                                            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {sender} sent a ready packet from unknown zone {instance_guid}")));
                                         };
 
                                         let mut sender_only_character_packets = zone.send_self_on_client_ready();
@@ -499,7 +493,7 @@ impl GameServer {
                                         let mut character_broadcasts = Vec::new();
 
                                         let Some(character_write_handle) = characters_write.get_mut(&player_guid(sender)) else {
-                                            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Unknown player {} sent a ready packet", sender)));
+                                            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Unknown player {sender} sent a ready packet")));
                                         };
 
                                         character_write_handle.stats.speed.base = zone.speed;
@@ -580,7 +574,7 @@ impl GameServer {
                                     else {
                                         return Err(ProcessPacketError::new(
                                             ProcessPacketErrorType::ConstraintViolated,
-                                            format!("Couldn't sync time for player {} because they are not in any zone", sender_guid)
+                                            format!("Couldn't sync time for player {sender_guid} because they are not in any zone")
                                         ));
                                     };
 
@@ -593,7 +587,7 @@ impl GameServer {
                                             let Some(zone_read_handle) = zones_read.get(&instance_guid) else {
                                                 return Err(ProcessPacketError::new(
                                                     ProcessPacketErrorType::ConstraintViolated,
-                                                    format!("Couldn't sync time for player {} because their instance {} does not exist", sender_guid, instance_guid)
+                                                    format!("Couldn't sync time for player {sender_guid} because their instance {instance_guid} does not exist")
                                                 ));
                                             };
 
@@ -656,8 +650,8 @@ impl GameServer {
                         return Err(ProcessPacketError::new(
                             ProcessPacketErrorType::ConstraintViolated,
                             format!(
-                                "Player {} requested to teleport to unknown point of interest {}",
-                                sender, teleport_request.point_of_interest_guid
+                                "Player {sender} requested to teleport to unknown point of interest {}",
+                                teleport_request.point_of_interest_guid
                             ),
                         ));
                     };
@@ -680,7 +674,7 @@ impl GameServer {
                             write_guids: Vec::new(),
                             character_consumer: |characters_table_read_handle, _, _, minigame_data_lock_enforcer| {
                                 let Some((_, instance_guid, _)) = characters_table_read_handle.index1(player_guid(sender)) else {
-                                    return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Unknown player {} tried to teleport to safety", sender)));
+                                    return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Unknown player {sender} tried to teleport to safety")));
                                 };
 
                                 let zones_lock_enforcer: ZoneLockEnforcer = minigame_data_lock_enforcer.into();
@@ -689,7 +683,7 @@ impl GameServer {
                                     write_guids: Vec::new(),
                                     zone_consumer: |_, zones_read, _| {
                                         let Some(zone) = zones_read.get(&instance_guid) else {
-                                            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {} outside zone tried to teleport to safety", sender)));
+                                            return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Player {sender} outside zone tried to teleport to safety")));
                                         };
 
                                         let spawn_pos = zone.default_spawn_pos;
@@ -721,7 +715,7 @@ impl GameServer {
                         write_guids: vec![player_guid(sender)],
                         character_consumer: |characters_table_read_handle, _, mut characters_write, _| {
                             let Some(character_write_handle) = characters_write.get_mut(&player_guid(sender)) else {
-                                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Unknown player {} requested to brandish or holster their weapon", sender)));
+                                return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Unknown player {sender} requested to brandish or holster their weapon")));
                             };
 
                             character_write_handle.brandish_or_holster();
@@ -764,14 +758,14 @@ impl GameServer {
                 _ => {
                     return Err(ProcessPacketError::new(
                         ProcessPacketErrorType::UnknownOpCode,
-                        format!("Unimplemented: {:?}, {:x?}", op_code, data),
+                        format!("Unimplemented: {op_code:?}, {data:x?}"),
                     ))
                 }
             },
             Err(_) => {
                 return Err(ProcessPacketError::new(
                     ProcessPacketErrorType::UnknownOpCode,
-                    format!("Unknown op code: {}, {:x?}", raw_op_code, data),
+                    format!("Unknown op code: {raw_op_code}, {data:x?}"),
                 ))
             }
         }
@@ -849,17 +843,14 @@ impl GameServer {
         else {
             return Err(ProcessPacketError::new(
                 ProcessPacketErrorType::ConstraintViolated,
-                format!("At capacity for zones for template ID {}", template_guid),
+                format!("At capacity for zones for template ID {template_guid}"),
             ));
         };
 
         let Some(template) = self.zone_templates.get(&template_guid) else {
             return Err(ProcessPacketError::new(
                 ProcessPacketErrorType::ConstraintViolated,
-                format!(
-                    "Tried to teleport to unknown zone template {}",
-                    template_guid
-                ),
+                format!("Tried to teleport to unknown zone template {template_guid}"),
             ));
         };
 
@@ -867,8 +858,8 @@ impl GameServer {
             return Err(ProcessPacketError::new(
                 ProcessPacketErrorType::ConstraintViolated,
                 format!(
-                    "Zone template {} (capacity {}) does not have the required capacity {}",
-                    template_guid, template.max_players, required_capacity
+                    "Zone template {template_guid} (capacity {}) does not have the required capacity {required_capacity}",
+                    template.max_players
                 ),
             ));
         }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -336,7 +336,7 @@ async fn try_start(
     let manifests = read_manifests_config(config_dir).await?;
     let crc_map = prepare_asset_cache(assets_path, &assets_cache_path, &manifests).await?;
 
-    let listener = TcpListener::bind(format!("{}:{}", bind_ip, port)).await?;
+    let listener = TcpListener::bind(format!("{bind_ip}:{port}")).await?;
     let app: Router<()> = Router::new()
         .route("/assets/*asset", get(asset_handler))
         .with_state((Arc::new(assets_cache_path), Arc::new(crc_map)));

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,16 +33,16 @@ thread_local! {
 
 pub fn log_info(message: &str) {
     let client = if let Some(addr) = PROCESSED_CLIENT_ADDR.get() {
-        format!(" [client={}]", addr)
+        format!(" [client={addr}]")
     } else {
         "".to_string()
     };
     let guid = if let Some(guid) = PROCESSED_CLIENT_GUID.get() {
-        format!(" [guid={}]", guid)
+        format!(" [guid={guid}]")
     } else {
         "".to_string()
     };
-    println!("{}{}{}\t{}", Utc::now().to_rfc3339(), client, guid, message);
+    println!("{}{client}{guid}\t{message}", Utc::now().to_rfc3339());
 }
 
 static DEBUG_ENABLED: LazyLock<bool> = LazyLock::new(|| {


### PR DESCRIPTION
Fix `clippy` warnings for `format!()` calls with variables.