### PR TITLE
Fix location index not updated for tickable NPC

### DIFF
--- a/src/game_server/handlers/tick.rs
+++ b/src/game_server/handlers/tick.rs
@@ -65,7 +65,7 @@ pub fn tick_single_chunk(
     chunk: Chunk,
     synchronization: TickableNpcSynchronization,
 ) -> Vec<Broadcast> {
-    game_server.lock_enforcer().read_characters(|characters_table_read_handle| {
+    let (mut broadcasts, pos_updates) = game_server.lock_enforcer().read_characters(|characters_table_read_handle| {
         let tickable_characters: Vec<u64> = tickable_categories(synchronization)
             .into_iter()
             .flat_map(|category| characters_table_read_handle.keys_by_index1((category, instance_guid, chunk)))
@@ -90,6 +90,7 @@ pub fn tick_single_chunk(
             mut characters_write,
             _| {
                 let mut broadcasts = Vec::new();
+                let mut pos_updates = Vec::new();
 
                 for guid in tickable_characters.iter() {
                     let tickable_character = characters_write.get_mut(guid).unwrap();
@@ -117,15 +118,27 @@ pub fn tick_single_chunk(
                         }
                     }
 
-                    broadcasts.append(
-                        &mut tickable_character.tick(now, &nearby_player_guids, &characters_read, game_server.mounts(), game_server.items(), game_server.customizations()),
-                    );
+                    let (mut character_broadcasts, character_pos_update) = tickable_character.tick(now, &nearby_player_guids, &characters_read, game_server.mounts(), game_server.items(), game_server.customizations());
+                    broadcasts.append(&mut character_broadcasts);
+                    if let Some(pos_update) = character_pos_update {
+                        pos_updates.push((*guid, pos_update));
+                    }
                 }
 
-                broadcasts
+                (broadcasts, pos_updates)
             },
         }
-    })
+    });
+
+    for (guid, pos_update) in pos_updates {
+        let move_result = ZoneInstance::move_character(pos_update, false, game_server);
+        match move_result {
+            Ok(mut move_broadcasts) => broadcasts.append(&mut move_broadcasts),
+            Err(err) => info!("Couldn't move tickable NPC {guid}: {err}"),
+        }
+    }
+
+    broadcasts
 }
 
 pub fn tick_matchmaking_groups(game_server: &GameServer) -> Vec<Broadcast> {

--- a/src/game_server/packets/mod.rs
+++ b/src/game_server/packets/mod.rs
@@ -94,7 +94,7 @@ pub trait GamePacket: SerializePacket {
     }
 }
 
-#[derive(Copy, Clone, SerializePacket, DeserializePacket, Deserialize, Default)]
+#[derive(Copy, Clone, SerializePacket, DeserializePacket, Deserialize, Default, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct Pos {
     pub x: f32,


### PR DESCRIPTION
* Fix tickable NPCs' location index not being updated when they changed positions.
* Allow for rotation offsets in addition to a fixed rotation change.