### PR TITLE
Make chunk size configurable per zone, refactor character movement

### DIFF
--- a/config/zones.yaml
+++ b/config/zones.yaml
@@ -6,7 +6,6 @@
   asset_name: MonCala_Venetor
   hide_ui: false
   is_combat: false
-  chunk_size: 200
   default_point_of_interest:
     guid: 14
     pos:
@@ -155,7 +154,6 @@
   asset_name: Combat_Umbara_South_01
   hide_ui: false
   is_combat: true
-  chunk_size: 200
   default_point_of_interest:
     guid: 19
     pos:
@@ -245,7 +243,6 @@
   asset_name: Combat_Carlac_01
   hide_ui: false
   is_combat: true
-  chunk_size: 200
   default_point_of_interest:
     guid: 34
     pos:
@@ -311,7 +308,6 @@
   asset_name: Combat_Felucia_01
   hide_ui: false
   is_combat: true
-  chunk_size: 200
   default_point_of_interest:
     guid: 36
     pos:
@@ -1268,7 +1264,6 @@
   asset_name: Housing_EmptyLot_Mustafar
   hide_ui: false
   is_combat: false
-  chunk_size: 200
   default_point_of_interest:
     guid: 100
     pos:

--- a/config/zones.yaml
+++ b/config/zones.yaml
@@ -6,6 +6,7 @@
   asset_name: MonCala_Venetor
   hide_ui: false
   is_combat: false
+  chunk_size: 200
   default_point_of_interest:
     guid: 14
     pos:
@@ -53,6 +54,7 @@
   asset_name: Combat_Ryloth_StartingZone_01
   hide_ui: false
   is_combat: true
+  chunk_size: 70
   default_point_of_interest:
     guid: 15
     pos:
@@ -153,6 +155,7 @@
   asset_name: Combat_Umbara_South_01
   hide_ui: false
   is_combat: true
+  chunk_size: 200
   default_point_of_interest:
     guid: 19
     pos:
@@ -242,6 +245,7 @@
   asset_name: Combat_Carlac_01
   hide_ui: false
   is_combat: true
+  chunk_size: 200
   default_point_of_interest:
     guid: 34
     pos:
@@ -307,6 +311,7 @@
   asset_name: Combat_Felucia_01
   hide_ui: false
   is_combat: true
+  chunk_size: 200
   default_point_of_interest:
     guid: 36
     pos:
@@ -368,6 +373,7 @@
   asset_name: JediTemple
   hide_ui: false
   is_combat: false
+  chunk_size: 70
   default_point_of_interest:
     guid: 24
     pos:
@@ -1194,6 +1200,7 @@
   asset_name: Members
   hide_ui: false
   is_combat: false
+  chunk_size: 70
   default_point_of_interest:
     guid: 25
     pos:
@@ -1261,6 +1268,7 @@
   asset_name: Housing_EmptyLot_Mustafar
   hide_ui: false
   is_combat: false
+  chunk_size: 200
   default_point_of_interest:
     guid: 100
     pos:
@@ -1307,6 +1315,7 @@
   asset_name: Starship_Housing
   hide_ui: false
   is_combat: false
+  chunk_size: 1000
   default_point_of_interest:
     guid: 200
     pos:
@@ -1335,6 +1344,7 @@
   asset_name: Starship_Housing
   hide_ui: false
   is_combat: false
+  chunk_size: 1000
   default_point_of_interest:
     guid: 201
     pos:

--- a/src/game_server/handlers/zone.rs
+++ b/src/game_server/handlers/zone.rs
@@ -871,7 +871,7 @@ impl ZoneInstance {
 
                             let CharacterMovementType::SameChunk {
                                 chunk,
-                                npcs_to_interact_with: npcs_to_interact,
+                                npcs_to_interact_with,
                             } = movement_type
                             else {
                                 return Ok((Vec::new(), movement_type));
@@ -886,8 +886,8 @@ impl ZoneInstance {
                                 .unwrap_or(1.0);
                             full_update_packet.apply_jump_height_multiplier(jump_multiplier);
 
-                            let filtered_npcs_to_interact = ZoneInstance::move_character_with_locks(
-                                &npcs_to_interact,
+                            let filtered_npcs_to_interact_with = ZoneInstance::move_character_with_locks(
+                                &npcs_to_interact_with,
                                 characters_read,
                                 characters_write.get_mut(&moved_character_guid).unwrap(),
                                 new_pos,
@@ -913,7 +913,7 @@ impl ZoneInstance {
                                 broadcasts,
                                 CharacterMovementType::SameChunk {
                                     chunk,
-                                    npcs_to_interact_with: filtered_npcs_to_interact,
+                                    npcs_to_interact_with: filtered_npcs_to_interact_with,
                                 },
                             ))
                         },

--- a/src/game_server/handlers/zone.rs
+++ b/src/game_server/handlers/zone.rs
@@ -84,6 +84,7 @@ struct ZoneConfig {
     asset_name: String,
     hide_ui: bool,
     is_combat: bool,
+    chunk_size: u16,
     default_point_of_interest: PointOfInterestConfig,
     #[serde(default)]
     other_points_of_interest: Vec<PointOfInterestConfig>,
@@ -100,7 +101,6 @@ struct ZoneConfig {
     update_previous_location_on_leave: bool,
     #[serde(default)]
     map_id: u32,
-    chunk_size: u16,
 }
 
 #[derive(Clone)]
@@ -110,6 +110,7 @@ pub struct ZoneTemplate {
     pub template_icon: u32,
     pub max_players: u32,
     pub asset_name: String,
+    pub chunk_size: u16,
     pub default_spawn_pos: Pos,
     pub default_spawn_rot: Pos,
     default_spawn_sky: String,
@@ -122,7 +123,6 @@ pub struct ZoneTemplate {
     pub seconds_per_day: u32,
     update_previous_location_on_leave: bool,
     map_id: u32,
-    pub chunk_size: u16,
 }
 
 impl Guid<u8> for ZoneTemplate {
@@ -270,6 +270,7 @@ impl From<ZoneConfig> for ZoneTemplate {
             max_players: value.max_players,
             template_icon: value.template_icon,
             asset_name: value.asset_name.clone(),
+            chunk_size: value.chunk_size,
             default_spawn_pos: value.default_point_of_interest.pos,
             default_spawn_rot: value.default_point_of_interest.rot,
             default_spawn_sky: value.spawn_sky.clone(),
@@ -282,7 +283,6 @@ impl From<ZoneConfig> for ZoneTemplate {
             seconds_per_day: value.seconds_per_day,
             update_previous_location_on_leave: value.update_previous_location_on_leave,
             map_id: value.map_id,
-            chunk_size: value.chunk_size,
         }
     }
 }
@@ -326,6 +326,7 @@ impl ZoneTemplate {
             max_players: self.max_players,
             icon: self.template_icon,
             asset_name: self.asset_name.clone(),
+            chunk_size: self.chunk_size,
             default_spawn_pos: self.default_spawn_pos,
             default_spawn_rot: self.default_spawn_rot,
             default_spawn_sky: self.default_spawn_sky.clone(),
@@ -338,7 +339,6 @@ impl ZoneTemplate {
             seconds_per_day: self.seconds_per_day,
             update_previous_location_on_leave: self.update_previous_location_on_leave,
             map_id: self.map_id,
-            chunk_size: self.chunk_size,
         }
     }
 }
@@ -380,6 +380,7 @@ pub struct ZoneInstance {
     pub max_players: u32,
     pub icon: u32,
     pub asset_name: String,
+    chunk_size: u16,
     pub default_spawn_pos: Pos,
     pub default_spawn_rot: Pos,
     default_spawn_sky: String,
@@ -392,7 +393,6 @@ pub struct ZoneInstance {
     pub seconds_per_day: u32,
     update_previous_location_on_leave: bool,
     map_id: u32,
-    chunk_size: u16,
 }
 
 impl IndexedGuid<u64, u8> for ZoneInstance {

--- a/src/game_server/handlers/zone.rs
+++ b/src/game_server/handlers/zone.rs
@@ -1099,8 +1099,12 @@ pub fn load_zones(config_dir: &Path) -> Result<LoadedZones, ConfigError> {
                 }
             }
 
-            let template = zone_config.into();
+            let template: ZoneTemplate = zone_config.into();
             let template_guid = Guid::guid(&template);
+
+            if template.chunk_size == 0 {
+                panic!("Zone template {template_guid} cannot have a chunk size of 0");
+            }
 
             if templates.insert(template_guid, template).is_some() {
                 panic!("Two zone templates have ID {template_guid}");

--- a/src/game_server/handlers/zone.rs
+++ b/src/game_server/handlers/zone.rs
@@ -56,6 +56,10 @@ const fn default_true() -> bool {
     true
 }
 
+const fn default_chunk_size() -> u16 {
+    200
+}
+
 #[derive(Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PointOfInterestConfig {
@@ -84,6 +88,7 @@ struct ZoneConfig {
     asset_name: String,
     hide_ui: bool,
     is_combat: bool,
+    #[serde(default = "default_chunk_size")]
     chunk_size: u16,
     default_point_of_interest: PointOfInterestConfig,
     #[serde(default)]


### PR DESCRIPTION
* Make chunk size configurable per zone. A smaller chunk size mitigates the holograms disappearing when outside and then inside the player's render distance on Ryloth.
* Refactor the character movement function for clarity.
* Fix an issue where character movement between chunks would look at interactable NPCs in the previous chunk