### PR TITLE
Reset dailies at UTC-8

### DIFF
--- a/config/minigames.yaml
+++ b/config/minigames.yaml
@@ -1,5 +1,5 @@
 ---
-daily_reset_utc_offset_seconds: 0
+daily_reset_utc_offset_seconds: -28800
 categories:
   # Popular
   - guid: 1

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -1209,7 +1209,7 @@ impl<'de> Deserialize<'de> for DailyResetOffset {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let daily_reset_offset_seconds: i32 = Deserialize::deserialize(deserializer)?;
 
-        FixedOffset::west_opt(daily_reset_offset_seconds)
+        FixedOffset::east_opt(daily_reset_offset_seconds)
             .map(DailyResetOffset)
             .ok_or_else(|| {
                 serde::de::Error::custom(format!(

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -60,6 +60,7 @@ use packets::zone::PointOfInterestTeleportRequest;
 use packets::{GamePacket, OpCode};
 use rand::Rng;
 
+use crate::game_server::handlers::tick::reset_daily_minigames;
 use crate::ConfigError;
 use packet_serialize::{DeserializePacket, DeserializePacketError};
 
@@ -285,6 +286,10 @@ impl GameServer {
         minigame_group: MinigameMatchmakingGroup,
     ) -> Vec<Broadcast> {
         tick_minigame(self, now, minigame_group)
+    }
+
+    pub fn reset_daily_minigames(&self) -> Vec<Broadcast> {
+        reset_daily_minigames(self)
     }
 
     pub fn process_packet(

--- a/src/game_server/packets/minigame.rs
+++ b/src/game_server/packets/minigame.rs
@@ -40,6 +40,16 @@ pub struct MinigameHeader {
     pub stage_group_guid: i32,
 }
 
+impl Default for MinigameHeader {
+    fn default() -> Self {
+        Self {
+            stage_guid: -1,
+            sub_op_code: -1,
+            stage_group_guid: -1,
+        }
+    }
+}
+
 #[derive(SerializePacket, DeserializePacket)]
 pub struct MinigameStageDefinition {
     pub guid: i32,

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,6 +182,13 @@ async fn main() {
         &game_server_arc,
     );
 
+    spawn_minigame_daily_reset_thread(
+        &channel_manager_arc,
+        client_enqueue.clone(),
+        &server_options,
+        &game_server_arc,
+    );
+
     let cleanup_tick_dequeue = tick(Duration::from_millis(
         server_options.channel_cleanup_period_millis,
     ));
@@ -686,6 +693,28 @@ fn spawn_minigame_tick_threads(
                 .expect("Minigame tick done channel disconnected");
             done_signals += 1;
         }
+    });
+}
+
+fn spawn_minigame_daily_reset_thread(
+    channel_manager: &Arc<RwLock<ChannelManager>>,
+    client_enqueue: Sender<SocketAddr>,
+    server_options: &Arc<ServerOptions>,
+    game_server: &Arc<GameServer>,
+) {
+    let channel_manager = channel_manager.clone();
+    let client_enqueue = client_enqueue.clone();
+    let server_options = server_options.clone();
+    let game_server = game_server.clone();
+
+    thread::spawn(move || loop {
+        let broadcasts = game_server.reset_daily_minigames();
+        channel_manager
+            .read()
+            .broadcast(client_enqueue.clone(), broadcasts, &server_options);
+        thread::sleep(Duration::from_secs(
+            game_server.minigames().seconds_until_minigame_daily_reset() as u64,
+        ));
     });
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -708,13 +708,14 @@ fn spawn_minigame_daily_reset_thread(
     let game_server = game_server.clone();
 
     thread::spawn(move || loop {
+        thread::sleep(Duration::from_secs(
+            game_server.minigames().seconds_until_minigame_daily_reset() as u64,
+        ));
+
         let broadcasts = game_server.reset_daily_minigames();
         channel_manager
             .read()
             .broadcast(client_enqueue.clone(), broadcasts, &server_options);
-        thread::sleep(Duration::from_secs(
-            game_server.minigames().seconds_until_minigame_daily_reset() as u64,
-        ));
     });
 }
 


### PR DESCRIPTION
* Send daily reset packets to all players at the minigame daily reset time (UTC-8, which is 12am PST/1am PDT)
* Fix the calculation of the UTC offset so that negative == western hemisphere timezones
* We don't re-send *all* definitions to avoid allocating space for all minigame stages/stage groups/portal entries for every player at the same time, when only a handful of portal entries will be daily.