### PR TITLE
Add Daily Holocron

### DIFF
--- a/config/items.yaml
+++ b/config/items.yaml
@@ -295,6 +295,49 @@
   unknown40: 0
   stats: []
   abilities: []
+# Holocron Boost
+- guid: 2384
+  name_id: 33818
+  description_id: 33819
+  icon_set_id: 1687
+  tint: 0
+  unknown6: 0
+  unknown7: 0
+  cost: 15
+  item_class: -1
+  required_battle_class: 0
+  slot: None
+  disable_trade: false
+  disable_sale: false
+  model_name: ''
+  texture_alias: ''
+  required_gender: 0
+  item_type: 1
+  category: 0
+  members: false
+  non_minigame: false
+  weapon_trail_effect: 0
+  composite_effect: 0
+  power_rating: 0
+  min_battle_class_level: 0
+  rarity: 0
+  activatable_ability_id: 0
+  passive_ability_id: 0
+  single_use: false
+  max_stack_size: 1
+  is_tintable: false
+  tint_alias: ''
+  disable_preview: false
+  unknown33: false
+  race_set_id: 0
+  unknown35: false
+  unknown36: 0
+  unknown37: 0
+  customization_slot: None
+  customization_id: 0
+  unknown40: 0
+  stats: []
+  abilities: []
 # Adi Gallia's Tunic
 - guid: 10000
   name_id: 914

--- a/config/minigames.yaml
+++ b/config/minigames.yaml
@@ -4686,3 +4686,46 @@ categories:
                       end: 10000
                       weight: 1
               score_to_credits_expression: x
+      - guid: 29000
+        name_id: 14054
+        description_id: 14161
+        members_only: true
+        is_flash: true
+        is_active: true
+        param1: 0
+        icon_id: 1236
+        background_icon_id: 0
+        is_popular: false
+        is_game_of_day: false
+        sort_order: 29000
+        tutorial_swf: 'HowtoHolocron.swf'
+        daily_type: Holocron
+        stage_group:
+          guid: 18
+          name_id: 14054
+          description_id: 14161
+          icon_id: 875
+          stage_icon_id: 875
+          members_only: true
+          stage_select_map_name: ''
+          stages:
+            - !Stage
+              guid: 29001
+              name_id: 14054
+              description_id: 14161
+              stage_icon_id: 1236
+              start_screen_icon_id: 1901
+              min_players: 1
+              max_players: 1
+              difficulty: 1
+              start_sound_id: 3355
+              show_end_score_screen: false
+              members_only: true
+              require_previous_completed: false
+              link_name: stage
+              short_name: ''
+              minigame_type:
+                !Flash
+                game_swf_name: DailyHolocron.swf
+                game_type: DailyHolocron
+              score_to_credits_expression: x

--- a/config/minigames.yaml
+++ b/config/minigames.yaml
@@ -4638,7 +4638,7 @@ categories:
         param1: 0
         icon_id: 1237
         background_icon_id: 0
-        is_popular: true
+        is_popular: false
         is_game_of_day: false
         sort_order: 28000
         tutorial_swf: HowtoSpin.swf

--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -3,7 +3,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, FixedOffset, Utc};
 use enum_iterator::Sequence;
 use rand::thread_rng;
 use rand_distr::{Distribution, WeightedAliasIndex};
@@ -1180,13 +1180,17 @@ pub struct BattleClass {
 }
 
 #[derive(Clone, Default)]
-pub struct MinigameWinStatus(Option<DateTime<Utc>>);
+pub struct MinigameWinStatus(pub Option<DateTime<FixedOffset>>);
 
 impl MinigameWinStatus {
     pub fn set_won(&mut self, won: bool) {
         if won {
-            self.0 = Some(Utc::now());
+            self.0 = Some(Utc::now().fixed_offset());
         }
+    }
+
+    pub fn set_win_time(&mut self, won_time: DateTime<FixedOffset>) {
+        self.0 = Some(won_time);
     }
 
     pub fn won(&self) -> bool {

--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -3,6 +3,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use chrono::{DateTime, Utc};
 use enum_iterator::Sequence;
 use rand::thread_rng;
 use rand_distr::{Distribution, WeightedAliasIndex};
@@ -1178,12 +1179,27 @@ pub struct BattleClass {
     pub items: BTreeMap<EquipmentSlot, EquippedItem>,
 }
 
+#[derive(Clone, Default)]
+pub struct MinigameWinStatus(Option<DateTime<Utc>>);
+
+impl MinigameWinStatus {
+    pub fn set_won(&mut self, won: bool) {
+        if won {
+            self.0 = Some(Utc::now());
+        }
+    }
+
+    pub fn won(&self) -> bool {
+        self.0.is_some()
+    }
+}
+
 #[derive(Clone)]
 pub struct MinigameStatus {
     pub group: MinigameMatchmakingGroup,
     pub teleported_to_game: bool,
     pub game_created: bool,
-    pub game_won: bool,
+    pub win_status: MinigameWinStatus,
     pub score_entries: Vec<ScoreEntry>,
     pub total_score: i32,
     pub awarded_credits: u32,

--- a/src/game_server/handlers/daily.rs
+++ b/src/game_server/handlers/daily.rs
@@ -450,23 +450,23 @@ impl DailyHolocronGame {
         )])
     }
 
-    /*pub fn stop_holocron(
+    pub fn display_reward(
         &mut self,
         sender: u32,
         player_credits: &mut u32,
         game_awarded_credits: &mut u32,
         stage_config: &MinigameStageConfig,
     ) -> Result<Vec<Broadcast>, ProcessPacketError> {
-        let DailyHolocronGameState::Holocronning { reward } = self.state else {
+        let DailyHolocronGameState::OpeningHolocron { reward } = self.state else {
             return Err(ProcessPacketError::new(
                 ProcessPacketErrorType::ConstraintViolated,
                 format!(
-                    "Player {sender} sent a stop holocron request for Daily Holocron, but the game isn't holocronning ({self:?})"
+                    "Player {sender} sent a display reward for Daily Holocron, but they haven't picked a holocron ({self:?})"
                 ),
             ));
         };
 
-        let mut broadcasts = award_credits(
+        let broadcasts = award_credits(
             sender,
             player_credits,
             game_awarded_credits,
@@ -475,23 +475,8 @@ impl DailyHolocronGame {
         )?
         .0;
 
-        broadcasts.push(Broadcast::Single(
-            sender,
-            vec![GamePacket::serialize(&TunneledPacket {
-                unknown1: true,
-                inner: FlashPayload {
-                    header: MinigameHeader {
-                        stage_guid: self.stage_guid,
-                        sub_op_code: -1,
-                        stage_group_guid: self.stage_group_guid,
-                    },
-                    payload: format!("OnRewardInfoMsg\t0\t0\t{reward}\t0\t0\t0"),
-                },
-            })],
-        ));
-
-        self.state = DailyHolocronGameState::WaitingForHolocron;
+        self.state = DailyHolocronGameState::GameOver;
 
         Ok(broadcasts)
-    }*/
+    }
 }

--- a/src/game_server/handlers/daily.rs
+++ b/src/game_server/handlers/daily.rs
@@ -265,7 +265,10 @@ enum DailyHolocronGameState {
         completions_this_week: [u8; 7],
         start_time: DateTime<FixedOffset>,
     },
-    WaitingForSelection,
+    WaitingForSelection {
+        completions_this_week: [u8; 7],
+        start_time: DateTime<FixedOffset>,
+    },
     OpeningHolocron {
         reward: u16,
     },
@@ -375,19 +378,23 @@ impl DailyHolocronGame {
     }
 
     pub fn mark_player_ready(&mut self, sender: u32) -> Result<Vec<Broadcast>, ProcessPacketError> {
-        if !matches!(
-            self.state,
-            DailyHolocronGameState::WaitingForPlayersReady { .. }
-        ) {
+        let DailyHolocronGameState::WaitingForPlayersReady {
+            completions_this_week,
+            start_time,
+        } = self.state
+        else {
             return Err(ProcessPacketError::new(
                 ProcessPacketErrorType::ConstraintViolated,
                 format!(
                     "Player {sender} sent a ready payload for Daily Holocron, but the game has already started ({self:?})"
                 ),
             ));
-        }
+        };
 
-        self.state = DailyHolocronGameState::WaitingForSelection;
+        self.state = DailyHolocronGameState::WaitingForSelection {
+            completions_this_week,
+            start_time,
+        };
 
         Ok(Vec::new())
     }

--- a/src/game_server/handlers/daily.rs
+++ b/src/game_server/handlers/daily.rs
@@ -157,18 +157,18 @@ impl DailySpinGame {
         }
 
         match self.daily_game_playability {
-            DailyGamePlayability::NotYetPlayed { boost, timestamp: time } => {
+            DailyGamePlayability::NotYetPlayed { boost, timestamp } => {
                 if minigame_stats.boosts_remaining(boost) == 0 {
-                    self.daily_game_playability = DailyGamePlayability::Unplayable { timestamp: time };
+                    self.daily_game_playability = DailyGamePlayability::Unplayable { timestamp };
                 } else {
-                    self.daily_game_playability = DailyGamePlayability::OnlyWithBoosts { boost, timestamp: time };
+                    self.daily_game_playability = DailyGamePlayability::OnlyWithBoosts { boost, timestamp };
                 }
             },
-            DailyGamePlayability::OnlyWithBoosts { boost, timestamp: time } => {
+            DailyGamePlayability::OnlyWithBoosts { boost, timestamp } => {
                 if minigame_stats.use_boost(boost)? == 0 {
-                    self.daily_game_playability = DailyGamePlayability::Unplayable { timestamp: time };
+                    self.daily_game_playability = DailyGamePlayability::Unplayable { timestamp };
                 } else {
-                    self.daily_game_playability = DailyGamePlayability::OnlyWithBoosts { boost, timestamp: time };
+                    self.daily_game_playability = DailyGamePlayability::OnlyWithBoosts { boost, timestamp };
                 }
             },
             DailyGamePlayability::Unplayable { .. } => return Err(ProcessPacketError::new(

--- a/src/game_server/handlers/daily.rs
+++ b/src/game_server/handlers/daily.rs
@@ -157,18 +157,18 @@ impl DailySpinGame {
         }
 
         match self.daily_game_playability {
-            DailyGamePlayability::NotYetPlayed { boost, time } => {
+            DailyGamePlayability::NotYetPlayed { boost, timestamp: time } => {
                 if minigame_stats.boosts_remaining(boost) == 0 {
-                    self.daily_game_playability = DailyGamePlayability::Unplayable { time };
+                    self.daily_game_playability = DailyGamePlayability::Unplayable { timestamp: time };
                 } else {
-                    self.daily_game_playability = DailyGamePlayability::OnlyWithBoosts { boost, time };
+                    self.daily_game_playability = DailyGamePlayability::OnlyWithBoosts { boost, timestamp: time };
                 }
             },
-            DailyGamePlayability::OnlyWithBoosts { boost, time } => {
+            DailyGamePlayability::OnlyWithBoosts { boost, timestamp: time } => {
                 if minigame_stats.use_boost(boost)? == 0 {
-                    self.daily_game_playability = DailyGamePlayability::Unplayable { time };
+                    self.daily_game_playability = DailyGamePlayability::Unplayable { timestamp: time };
                 } else {
-                    self.daily_game_playability = DailyGamePlayability::OnlyWithBoosts { boost, time };
+                    self.daily_game_playability = DailyGamePlayability::OnlyWithBoosts { boost, timestamp: time };
                 }
             },
             DailyGamePlayability::Unplayable { .. } => return Err(ProcessPacketError::new(
@@ -272,7 +272,7 @@ enum DailyHolocronGameState {
 #[derive(Clone, Debug)]
 pub struct DailyHolocronGame {
     state: DailyHolocronGameState,
-    time: DateTime<FixedOffset>,
+    timestamp: DateTime<FixedOffset>,
     stage_guid: i32,
     stage_group_guid: i32,
 }
@@ -285,7 +285,7 @@ impl DailyHolocronGame {
     ) -> Self {
         DailyHolocronGame {
             state: DailyHolocronGameState::WaitingForConnection,
-            time: daily_game_playability.time(),
+            timestamp: daily_game_playability.time(),
             stage_guid,
             stage_group_guid,
         }
@@ -310,7 +310,7 @@ impl DailyHolocronGame {
             completions_this_week,
         };
 
-        let current_day = self.time.weekday().num_days_from_sunday();
+        let current_day = self.timestamp.weekday().num_days_from_sunday();
 
         let mut packets = vec![
             GamePacket::serialize(&TunneledPacket {
@@ -411,13 +411,13 @@ impl DailyHolocronGame {
                 .into_iter()
                 .enumerate()
                 .take_while(|(index, _)| {
-                    *index < self.time.weekday().num_days_from_sunday() as usize
+                    *index < self.timestamp.weekday().num_days_from_sunday() as usize
                 })
                 .map(|(_, completions)| completions.min(4) as u16 * HOLOCRON_DAILY_BONUS)
                 .sum::<u16>();
 
         *game_score = reward as i32;
-        win_status.set_win_time(self.time);
+        win_status.set_win_time(self.timestamp);
         score_entries.push(ScoreEntry {
             entry_text: "".to_string(),
             icon_set_id: 0,

--- a/src/game_server/handlers/daily.rs
+++ b/src/game_server/handlers/daily.rs
@@ -4,9 +4,12 @@ use rand_distr::{Distribution, WeightedAliasIndex};
 use serde::Deserialize;
 
 use crate::game_server::{
-    handlers::minigame::{
-        award_credits, DailyGamePlayability, DailyResetOffset, MinigameStageConfig,
-        PlayerMinigameStats,
+    handlers::{
+        character::MinigameWinStatus,
+        minigame::{
+            award_credits, DailyGamePlayability, DailyResetOffset, MinigameStageConfig,
+            PlayerMinigameStats,
+        },
     },
     packets::{
         minigame::{FlashPayload, MinigameHeader, ScoreEntry, ScoreType},
@@ -143,7 +146,7 @@ impl DailySpinGame {
         &mut self,
         sender: u32,
         game_score: &mut i32,
-        game_won: &mut bool,
+        game_won: &mut MinigameWinStatus,
         score_entries: &mut Vec<ScoreEntry>,
         minigame_stats: &mut PlayerMinigameStats,
     ) -> Result<Vec<Broadcast>, ProcessPacketError> {
@@ -185,7 +188,7 @@ impl DailySpinGame {
         let reward = rng.gen_range(bucket.start..bucket.end);
 
         *game_score = reward as i32;
-        *game_won = true;
+        game_won.set_won(true);
         score_entries.push(ScoreEntry {
             entry_text: "".to_string(),
             icon_set_id: 0,

--- a/src/game_server/handlers/fleet_commander.rs
+++ b/src/game_server/handlers/fleet_commander.rs
@@ -1052,8 +1052,10 @@ impl FleetCommanderGame {
             return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to remove player {player}, who is not playing this instance of Fleet Commander ({self:?})")));
         };
 
-        minigame_status.game_won = !self.player_states[player_index].lost()
-            && self.player_states[(player_index + 1) % 2].lost();
+        minigame_status.win_status.set_won(
+            !self.player_states[player_index].lost()
+                && self.player_states[(player_index + 1) % 2].lost(),
+        );
         minigame_status.total_score = self.player_states[player_index].score();
         minigame_status.score_entries.push(ScoreEntry {
             entry_text: "".to_string(),

--- a/src/game_server/handlers/force_connection.rs
+++ b/src/game_server/handlers/force_connection.rs
@@ -955,7 +955,9 @@ impl ForceConnectionGame {
             return Err(ProcessPacketError::new(ProcessPacketErrorType::ConstraintViolated, format!("Tried to remove player {player}, who is not playing this instance of Force Connection ({self:?})")));
         };
 
-        minigame_status.game_won = self.matches[player_index] >= MATCHES_TO_WIN;
+        minigame_status
+            .win_status
+            .set_won(self.matches[player_index] >= MATCHES_TO_WIN);
         minigame_status.total_score = self.score[player_index];
         minigame_status.score_entries.push(ScoreEntry {
             entry_text: "".to_string(),

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -495,23 +495,23 @@ impl DailyGameType {
 pub enum DailyGamePlayability {
     NotYetPlayed {
         boost: MinigameBoost,
-        time: DateTime<FixedOffset>,
+        timestamp: DateTime<FixedOffset>,
     },
     OnlyWithBoosts {
         boost: MinigameBoost,
-        time: DateTime<FixedOffset>,
+        timestamp: DateTime<FixedOffset>,
     },
     Unplayable {
-        time: DateTime<FixedOffset>,
+        timestamp: DateTime<FixedOffset>,
     },
 }
 
 impl DailyGamePlayability {
     pub fn time(&self) -> DateTime<FixedOffset> {
         match *self {
-            DailyGamePlayability::NotYetPlayed { time, .. } => time,
-            DailyGamePlayability::OnlyWithBoosts { time, .. } => time,
-            DailyGamePlayability::Unplayable { time, .. } => time,
+            DailyGamePlayability::NotYetPlayed { timestamp, .. } => timestamp,
+            DailyGamePlayability::OnlyWithBoosts { timestamp, .. } => timestamp,
+            DailyGamePlayability::Unplayable { timestamp, .. } => timestamp,
         }
     }
 }
@@ -993,15 +993,15 @@ impl MinigamePortalEntryConfig {
             let daily_game_playability = if !played_today {
                 DailyGamePlayability::NotYetPlayed {
                     boost: daily_type.boost(),
-                    time: now,
+                    timestamp: now,
                 }
             } else if minigame_stats.boosts_remaining(daily_type.boost()) > 0 {
                 DailyGamePlayability::OnlyWithBoosts {
                     boost: daily_type.boost(),
-                    time: now,
+                    timestamp: now,
                 }
             } else {
-                DailyGamePlayability::Unplayable { time: now }
+                DailyGamePlayability::Unplayable { timestamp: now }
             };
 
             let add_packet = AddDailyMinigame {
@@ -1968,7 +1968,7 @@ fn prepare_active_minigame_instance_for_player(
 
         let daily_game_playability = daily_settings.map(|(daily_game_playability, _)| daily_game_playability)
             .unwrap_or(DailyGamePlayability::Unplayable {
-                time: Utc::now().with_timezone(&game_server.minigames().daily_reset_offset.0),
+                timestamp: Utc::now().with_timezone(&game_server.minigames().daily_reset_offset.0),
             });
 
         minigame_status.type_data = stage_config.stage_config.minigame_type().to_type_data(

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use byteorder::ReadBytesExt;
-use chrono::{DateTime, Datelike, FixedOffset, IsoWeek, NaiveTime, Timelike, Utc};
+use chrono::{DateTime, Datelike, FixedOffset, NaiveTime, Timelike, Utc};
 use evalexpr::{context_map, eval_with_context, Value};
 use num_enum::TryFromPrimitive;
 use packet_serialize::DeserializePacket;

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -3049,7 +3049,7 @@ fn handle_flash_payload(
                         Err(ProcessPacketError::new(
                             ProcessPacketErrorType::ConstraintViolated,
                             format!(
-                                "Expected 1 parameters in complete powerup animation payload, but only found {}",
+                                "Expected 1 parameter in complete powerup animation payload, but only found {}",
                                 parts.len().saturating_sub(1)
                             ),
                         ))
@@ -3128,17 +3128,28 @@ fn handle_flash_payload(
             game_server,
             &payload.header,
             |minigame_status, _, _, _, _, _| {
-                 match &mut minigame_status.type_data {
-                    MinigameTypeData::DailyHolocron { game } => game.select_holocron(
-                        sender,
-                        &mut minigame_status.total_score,
-                        &mut minigame_status.win_status,
-                        &mut minigame_status.score_entries,
-                    ),
-                    _ => Err(ProcessPacketError::new(
+                if parts.len() == 2 {
+                    let _: u8 = parts[1].parse()?;
+                    match &mut minigame_status.type_data {
+                        MinigameTypeData::DailyHolocron { game } => game.select_holocron(
+                            sender,
+                            &mut minigame_status.total_score,
+                            &mut minigame_status.win_status,
+                            &mut minigame_status.score_entries,
+                        ),
+                        _ => Err(ProcessPacketError::new(
+                            ProcessPacketErrorType::ConstraintViolated,
+                            format!(
+                                "Received pick holocron request for unexpected game from player {sender}"
+                            ),
+                        ))
+                    }
+                } else {
+                    Err(ProcessPacketError::new(
                         ProcessPacketErrorType::ConstraintViolated,
                         format!(
-                            "Received pick holocron request for unexpected game from player {sender}"
+                            "Expected 1 parameter in pick holocron request payload, but only found {}",
+                            parts.len().saturating_sub(1)
                         ),
                     ))
                 }

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -3123,6 +3123,27 @@ fn handle_flash_payload(
             }
         ),
         "OnChangeWheelRequestMsg" => Ok(Vec::new()),
+        "OnPickHolocronRequest" => handle_minigame_packet_write(
+            sender,
+            game_server,
+            &payload.header,
+            |minigame_status, _, _, _, _, _| {
+                 match &mut minigame_status.type_data {
+                    MinigameTypeData::DailyHolocron { game } => game.select_holocron(
+                        sender,
+                        &mut minigame_status.total_score,
+                        &mut minigame_status.win_status,
+                        &mut minigame_status.score_entries,
+                    ),
+                    _ => Err(ProcessPacketError::new(
+                        ProcessPacketErrorType::ConstraintViolated,
+                        format!(
+                            "Received pick holocron request for unexpected game from player {sender}"
+                        ),
+                    ))
+                }
+            }
+        ),
         _ => Err(ProcessPacketError::new(
             ProcessPacketErrorType::ConstraintViolated,
             format!(

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -3155,6 +3155,27 @@ fn handle_flash_payload(
                 }
             }
         ),
+        "OnRewardRequest" => handle_minigame_packet_write(
+            sender,
+            game_server,
+            &payload.header,
+            |minigame_status, _, player_credits, stage_config, _, _| {
+                 match &mut minigame_status.type_data {
+                    MinigameTypeData::DailyHolocron { game } => game.display_reward(
+                        sender,
+                        player_credits,
+                        &mut minigame_status.awarded_credits,
+                        &stage_config.stage_config
+                    ),
+                    _ => Err(ProcessPacketError::new(
+                        ProcessPacketErrorType::ConstraintViolated,
+                        format!(
+                            "Received reward request for unexpected game from player {sender}"
+                        ),
+                    ))
+                }
+            }
+        ),
         _ => Err(ProcessPacketError::new(
             ProcessPacketErrorType::ConstraintViolated,
             format!(

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -67,6 +67,7 @@ use super::{
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum MinigameBoost {
     Spin,
+    Holocron,
 }
 
 #[derive(Clone)]
@@ -463,18 +464,21 @@ const GROUP_LINK_NAME: &str = "group";
 #[derive(Clone, Copy, Deserialize)]
 enum DailyGameType {
     Spin,
+    Holocron,
 }
 
 impl DailyGameType {
     pub fn key(&self) -> &str {
         match *self {
             DailyGameType::Spin => "Daily Wheel",
+            DailyGameType::Holocron => "Daily Holocron",
         }
     }
 
     pub fn boost(&self) -> MinigameBoost {
         match *self {
             DailyGameType::Spin => MinigameBoost::Spin,
+            DailyGameType::Holocron => MinigameBoost::Holocron,
         }
     }
 }
@@ -2763,7 +2767,7 @@ fn handle_flash_payload(
                     SharedMinigameTypeData::ForceConnection { game } => {
                         game.connect(sender, characters_table_read_handle)
                     }
-                    _ => match &minigame_status.type_data {
+                    _ => match &mut minigame_status.type_data {
                         MinigameTypeData::DailySpin { game } => game.connect(sender, minigame_stats),
                         MinigameTypeData::DailyHolocron { game } => game.connect(
                             sender,

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -3066,7 +3066,6 @@ fn handle_flash_payload(
             |minigame_status, _, _, _, _, _| {
                  match &mut minigame_status.type_data {
                     MinigameTypeData::DailySpin { game } => game.mark_player_ready(sender),
-                    MinigameTypeData::DailyHolocron { game } => game.mark_player_ready(sender),
                     _ => Err(ProcessPacketError::new(
                         ProcessPacketErrorType::ConstraintViolated,
                         format!(

--- a/src/game_server/handlers/saber_strike.rs
+++ b/src/game_server/handlers/saber_strike.rs
@@ -154,7 +154,7 @@ fn handle_saber_strike_game_over(
                 score_points: 0,
             });
             minigame_status.total_score = game_over.total_score;
-            minigame_status.game_won = game_over.won;
+            minigame_status.win_status.set_won(game_over.won);
             Ok(())
         },
     )?;


### PR DESCRIPTION
* Add Daily Holocron and the Daily Holocron boost item.
* Refactor daily game playability and game won status to include a timestamp.
  * Daily Spin now uses this timestamp to fix a bug where, if you played with a boost around reset time, the boost could be consumed while the game was considered played in the following day.
  * This avoids a similar edge case in Daily Holocron where bonuses could be computed for the previous day around the reset time, but the completion would count for the following day.
* Formatting improvements to reduce very long lines in minigames.rs.
* Unmarked Daily Spin as popular.