### PR TITLE
Use `SerializePacket` and `DeserializePacket` derive macros for enums

### DIFF
--- a/src/game_server/handlers/chat.rs
+++ b/src/game_server/handlers/chat.rs
@@ -1,6 +1,5 @@
 use std::io::{Cursor, Read};
 
-use byteorder::{LittleEndian, ReadBytesExt};
 use packet_serialize::DeserializePacket;
 
 use crate::game_server::{
@@ -24,7 +23,7 @@ pub fn process_chat_packet(
     sender: u32,
     game_server: &GameServer,
 ) -> Result<Vec<Broadcast>, ProcessPacketError> {
-    let raw_op_code = cursor.read_u16::<LittleEndian>()?;
+    let raw_op_code: u16 = DeserializePacket::deserialize(cursor)?;
     match ChatOpCode::try_from(raw_op_code) {
         Ok(op_code) => match op_code {
             ChatOpCode::SendMessage => {

--- a/src/game_server/handlers/command.rs
+++ b/src/game_server/handlers/command.rs
@@ -1,6 +1,5 @@
 use std::io::{Cursor, Read};
 
-use byteorder::{LittleEndian, ReadBytesExt};
 use packet_serialize::DeserializePacket;
 
 use crate::game_server::{
@@ -15,7 +14,7 @@ pub fn process_command(
     sender: u32,
     cursor: &mut Cursor<&[u8]>,
 ) -> Result<Vec<Broadcast>, ProcessPacketError> {
-    let raw_op_code = cursor.read_u16::<LittleEndian>()?;
+    let raw_op_code: u16 = DeserializePacket::deserialize(cursor)?;
     match CommandOpCode::try_from(raw_op_code) {
         Ok(op_code) => match op_code {
             CommandOpCode::SelectPlayer => Ok(Vec::new()),

--- a/src/game_server/handlers/housing.rs
+++ b/src/game_server/handlers/housing.rs
@@ -1,6 +1,5 @@
 use std::io::{Cursor, Read};
 
-use byteorder::{LittleEndian, ReadBytesExt};
 use packet_serialize::DeserializePacket;
 
 use crate::{
@@ -354,7 +353,7 @@ pub fn process_housing_packet(
     game_server: &GameServer,
     cursor: &mut Cursor<&[u8]>,
 ) -> Result<Vec<Broadcast>, ProcessPacketError> {
-    let raw_op_code = cursor.read_u16::<LittleEndian>()?;
+    let raw_op_code: u16 = DeserializePacket::deserialize(cursor)?;
     match HousingOpCode::try_from(raw_op_code) {
         Ok(op_code) => match op_code {
             HousingOpCode::SetEditMode => {

--- a/src/game_server/handlers/inventory.rs
+++ b/src/game_server/handlers/inventory.rs
@@ -1,6 +1,5 @@
 use std::{collections::BTreeMap, fs::File, io::Cursor, iter, path::Path};
 
-use byteorder::{LittleEndian, ReadBytesExt};
 use packet_serialize::DeserializePacket;
 use parking_lot::RwLockWriteGuard;
 use serde::Deserialize;
@@ -75,7 +74,7 @@ pub fn process_inventory_packet(
     cursor: &mut Cursor<&[u8]>,
     sender: u32,
 ) -> Result<Vec<Broadcast>, ProcessPacketError> {
-    let raw_op_code = cursor.read_u16::<LittleEndian>()?;
+    let raw_op_code: u16 = DeserializePacket::deserialize(cursor)?;
     match InventoryOpCode::try_from(raw_op_code) {
         Ok(op_code) => match op_code {
             InventoryOpCode::UnequipSlot => process_unequip_slot(game_server, cursor, sender),

--- a/src/game_server/handlers/minigame.rs
+++ b/src/game_server/handlers/minigame.rs
@@ -8,7 +8,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use byteorder::ReadBytesExt;
 use chrono::{DateTime, Datelike, FixedOffset, NaiveTime, Timelike, Utc};
 use evalexpr::{context_map, eval_with_context, Value};
 use num_enum::TryFromPrimitive;
@@ -1676,7 +1675,7 @@ pub fn process_minigame_packet(
     sender: u32,
     game_server: &GameServer,
 ) -> Result<Vec<Broadcast>, ProcessPacketError> {
-    let raw_op_code: u8 = cursor.read_u8()?;
+    let raw_op_code: u8 = DeserializePacket::deserialize(cursor)?;
     match MinigameOpCode::try_from(raw_op_code) {
         Ok(op_code) => match op_code {
             MinigameOpCode::RequestMinigameStageGroupInstance => {

--- a/src/game_server/handlers/mount.rs
+++ b/src/game_server/handlers/mount.rs
@@ -1,6 +1,5 @@
 use std::{collections::BTreeMap, fs::File, io::Cursor, path::Path};
 
-use byteorder::ReadBytesExt;
 use packet_serialize::DeserializePacket;
 use parking_lot::{RwLockReadGuard, RwLockWriteGuard};
 use serde::Deserialize;
@@ -357,7 +356,7 @@ pub fn process_mount_packet(
     sender: u32,
     game_server: &GameServer,
 ) -> Result<Vec<Broadcast>, ProcessPacketError> {
-    let raw_op_code = cursor.read_u8()?;
+    let raw_op_code: u8 = DeserializePacket::deserialize(cursor)?;
     match MountOpCode::try_from(raw_op_code) {
         Ok(op_code) => match op_code {
             MountOpCode::DismountRequest => process_dismount(sender, game_server),

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -8,7 +8,6 @@ use std::str::ParseBoolError;
 use std::time::Instant;
 use std::vec;
 
-use byteorder::{LittleEndian, ReadBytesExt};
 use crossbeam_channel::Sender;
 use enum_iterator::Sequence;
 use handlers::character::{
@@ -223,7 +222,7 @@ impl GameServer {
 
     pub fn authenticate(&self, data: Vec<u8>) -> Result<(u32, String), ProcessPacketError> {
         let mut cursor = Cursor::new(&data[..]);
-        let raw_op_code = cursor.read_u16::<LittleEndian>()?;
+        let raw_op_code: u16 = DeserializePacket::deserialize(&mut cursor)?;
 
         match OpCode::try_from(raw_op_code) {
             Ok(op_code) => match op_code {
@@ -299,7 +298,7 @@ impl GameServer {
     ) -> Result<Vec<Broadcast>, ProcessPacketError> {
         let mut broadcasts = Vec::new();
         let mut cursor = Cursor::new(&data[..]);
-        let raw_op_code = cursor.read_u16::<LittleEndian>()?;
+        let raw_op_code: u16 = DeserializePacket::deserialize(&mut cursor)?;
 
         match OpCode::try_from(raw_op_code) {
             Ok(op_code) => match op_code {

--- a/src/game_server/packets/client_update.rs
+++ b/src/game_server/packets/client_update.rs
@@ -1,3 +1,4 @@
+use num_enum::{IntoPrimitive, TryFromPrimitive};
 use packet_serialize::{DeserializePacket, SerializePacket};
 
 use super::{
@@ -108,8 +109,10 @@ impl GamePacket for Power {
     const HEADER: ClientUpdateOpCode = ClientUpdateOpCode::Power;
 }
 
-#[allow(dead_code)]
-#[derive(Copy, Clone, Debug)]
+#[derive(
+    Copy, Clone, Debug, TryFromPrimitive, IntoPrimitive, SerializePacket, DeserializePacket,
+)]
+#[repr(u32)]
 pub enum StatId {
     MaxHealth = 1,
     Speed = 2,
@@ -147,12 +150,6 @@ pub enum StatId {
     MimicMovementSpeed = 57,
     GravityMultiplier = 58,
     JumpHeightMultiplier = 59,
-}
-
-impl SerializePacket for StatId {
-    fn serialize(&self, buffer: &mut Vec<u8>) {
-        (*self as u32).serialize(buffer);
-    }
 }
 
 #[derive(SerializePacket)]

--- a/src/game_server/packets/item.rs
+++ b/src/game_server/packets/item.rs
@@ -1,11 +1,23 @@
-use byteorder::{LittleEndian, ReadBytesExt};
-use num_enum::TryFromPrimitive;
-use packet_serialize::{DeserializePacket, DeserializePacketError, SerializePacket};
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+use packet_serialize::{DeserializePacket, SerializePacket};
 use serde::Deserialize;
 
 use super::{player_update::CustomizationSlot, GamePacket, OpCode};
 
-#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord, TryFromPrimitive)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    TryFromPrimitive,
+    IntoPrimitive,
+    SerializePacket,
+    DeserializePacket,
+)]
 #[serde(deny_unknown_fields)]
 #[repr(u32)]
 pub enum EquipmentSlot {
@@ -46,30 +58,20 @@ impl EquipmentSlot {
     }
 }
 
-impl SerializePacket for EquipmentSlot {
-    fn serialize(&self, buffer: &mut Vec<u8>) {
-        (*self as u32).serialize(buffer);
-    }
-}
-
-impl DeserializePacket for EquipmentSlot {
-    fn deserialize(
-        cursor: &mut std::io::Cursor<&[u8]>,
-    ) -> Result<Self, packet_serialize::DeserializePacketError>
-    where
-        Self: Sized,
-    {
-        EquipmentSlot::try_from(
-            cursor
-                .read_u32::<LittleEndian>()
-                .map_err(DeserializePacketError::IoError)?,
-        )
-        .map_err(|_| DeserializePacketError::UnknownDiscriminator)
-    }
-}
-
-#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Deserialize,
+    PartialEq,
+    Eq,
+    TryFromPrimitive,
+    IntoPrimitive,
+    SerializePacket,
+    DeserializePacket,
+)]
 #[serde(deny_unknown_fields)]
+#[repr(u32)]
 pub enum WieldType {
     None = 0,
     SingleSaber = 1,
@@ -87,12 +89,6 @@ pub enum WieldType {
     Bow = 13,
     Sparklers = 14,
     HeavyCannon = 15,
-}
-
-impl SerializePacket for WieldType {
-    fn serialize(&self, buffer: &mut Vec<u8>) {
-        (*self as u32).serialize(buffer);
-    }
 }
 
 impl WieldType {

--- a/src/game_server/packets/minigame.rs
+++ b/src/game_server/packets/minigame.rs
@@ -1,4 +1,4 @@
-use num_enum::TryFromPrimitive;
+use num_enum::{IntoPrimitive, TryFromPrimitive};
 use packet_serialize::{DeserializePacket, LengthlessSlice, SerializePacket};
 
 use super::{GamePacket, OpCode, RewardBundle};
@@ -364,19 +364,23 @@ impl GamePacket for UpdateActiveMinigameRewards {
     const HEADER: Self::Header = MinigameOpCode::UpdateActiveMinigameRewards;
 }
 
+#[derive(
+    Copy,
+    Clone,
+    Default,
+    Eq,
+    PartialEq,
+    TryFromPrimitive,
+    IntoPrimitive,
+    SerializePacket,
+    DeserializePacket,
+)]
 #[repr(i32)]
-#[derive(Copy, Clone, Default, Eq, PartialEq, TryFromPrimitive)]
 pub enum ScoreType {
     #[default]
     Counter = 0,
     Time = 2,
     Total = 4,
-}
-
-impl SerializePacket for ScoreType {
-    fn serialize(&self, buffer: &mut Vec<u8>) {
-        SerializePacket::serialize(&(*self as i32), buffer);
-    }
 }
 
 #[derive(Clone, SerializePacket)]

--- a/src/game_server/packets/mod.rs
+++ b/src/game_server/packets/mod.rs
@@ -25,11 +25,13 @@ pub mod zone;
 
 use std::fmt::Display;
 
-use num_enum::TryFromPrimitive;
+use num_enum::{IntoPrimitive, TryFromPrimitive};
 use packet_serialize::{DeserializePacket, SerializePacket};
 use serde::Deserialize;
 
-#[derive(Copy, Clone, Debug, TryFromPrimitive)]
+#[derive(
+    Copy, Clone, Debug, TryFromPrimitive, IntoPrimitive, SerializePacket, DeserializePacket,
+)]
 #[repr(u16)]
 pub enum OpCode {
     LoginRequest = 0x1,
@@ -77,12 +79,6 @@ pub enum OpCode {
     DeploymentEnv = 0xa5,
     BrandishHolster = 0xb4,
     UiInteractions = 0xbd,
-}
-
-impl SerializePacket for OpCode {
-    fn serialize(&self, buffer: &mut Vec<u8>) {
-        (*self as u16).serialize(buffer);
-    }
 }
 
 pub trait GamePacket: SerializePacket {

--- a/src/game_server/packets/player_update.rs
+++ b/src/game_server/packets/player_update.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use num_enum::{IntoPrimitive, TryFromPrimitive};
 use packet_serialize::{DeserializePacket, SerializePacket};
 use serde::Deserialize;
 
@@ -169,8 +170,10 @@ impl GamePacket for UpdateScale {
     const HEADER: Self::Header = PlayerUpdateOpCode::UpdateScale;
 }
 
-#[allow(dead_code)]
-#[derive(Copy, Clone, Debug)]
+#[derive(
+    Copy, Clone, Debug, TryFromPrimitive, IntoPrimitive, SerializePacket, DeserializePacket,
+)]
+#[repr(u32)]
 pub enum NameplateImage {
     None = 0,
     Darkside = 6162,
@@ -179,12 +182,6 @@ pub enum NameplateImage {
     Mercenary = 6165,
     Exile = 7021,
     Enforcer = 2087,
-}
-
-impl SerializePacket for NameplateImage {
-    fn serialize(&self, buffer: &mut Vec<u8>) {
-        (*self as u32).serialize(buffer);
-    }
 }
 
 impl NameplateImage {
@@ -319,8 +316,21 @@ impl GamePacket for ItemDefinitionsReply<'_> {
     const HEADER: Self::Header = PlayerUpdateOpCode::ItemDefinitionsReply;
 }
 
-#[derive(Clone, Copy, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Clone,
+    Copy,
+    Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    TryFromPrimitive,
+    IntoPrimitive,
+    SerializePacket,
+    DeserializePacket,
+)]
 #[serde(deny_unknown_fields)]
+#[repr(i32)]
 pub enum CustomizationSlot {
     None = -1,
     HeadModel = 0,
@@ -331,12 +341,6 @@ pub enum CustomizationSlot {
     FacialHair = 5,
     FacePattern = 6,
     BodyModel = 8,
-}
-
-impl SerializePacket for CustomizationSlot {
-    fn serialize(&self, buffer: &mut Vec<u8>) {
-        (*self as u32).serialize(buffer);
-    }
 }
 
 #[derive(Clone, Deserialize, SerializePacket)]
@@ -668,18 +672,14 @@ impl GamePacket for NpcRelevance {
     const HEADER: Self::Header = PlayerUpdateOpCode::NpcRelevance;
 }
 
-#[allow(dead_code)]
-#[derive(Copy, Clone, Debug)]
+#[derive(
+    Copy, Clone, Debug, TryFromPrimitive, IntoPrimitive, SerializePacket, DeserializePacket,
+)]
+#[repr(u32)]
 pub enum Hostility {
     Hostile,
     Neutral,
     Friendly,
-}
-
-impl SerializePacket for Hostility {
-    fn serialize(&self, buffer: &mut Vec<u8>) {
-        (*self as u32).serialize(buffer);
-    }
 }
 
 #[derive(SerializePacket, DeserializePacket)]
@@ -689,19 +689,15 @@ pub struct Variable {
     pub unknown3: u32,
 }
 
-#[allow(dead_code)]
-#[derive(Copy, Clone, Debug)]
+#[derive(
+    Copy, Clone, Debug, TryFromPrimitive, IntoPrimitive, SerializePacket, DeserializePacket,
+)]
+#[repr(u32)]
 pub enum Icon {
     None = 0,
     Member = 1,
     Enforcer = 2,
     FancyMember = 3,
-}
-
-impl SerializePacket for Icon {
-    fn serialize(&self, buffer: &mut Vec<u8>) {
-        (*self as u32).serialize(buffer);
-    }
 }
 
 #[derive(SerializePacket)]

--- a/src/game_server/packets/squad.rs
+++ b/src/game_server/packets/squad.rs
@@ -1,4 +1,4 @@
-use num_enum::TryFromPrimitive;
+use num_enum::{IntoPrimitive, TryFromPrimitive};
 use packet_serialize::{DeserializePacket, SerializePacket};
 
 use crate::game_server::handlers::unique_guid::player_guid;
@@ -20,7 +20,9 @@ impl SerializePacket for SquadOpCode {
     }
 }
 
-#[derive(Copy, Clone, Debug, TryFromPrimitive)]
+#[derive(
+    Copy, Clone, Debug, TryFromPrimitive, IntoPrimitive, SerializePacket, DeserializePacket,
+)]
 #[repr(u32)]
 pub enum SquadEvent {
     Joined = 1,
@@ -30,12 +32,6 @@ pub enum SquadEvent {
     Demoted = 5,
     NoMessage = 6,
     NoMessageDuplicate = 7,
-}
-
-impl SerializePacket for SquadEvent {
-    fn serialize(&self, buffer: &mut Vec<u8>) {
-        (*self as u32).serialize(buffer);
-    }
 }
 
 #[derive(SerializePacket)]
@@ -56,18 +52,14 @@ impl GamePacket for SquadMemberStatus {
     const HEADER: Self::Header = SquadOpCode::MemberStatus;
 }
 
-#[derive(Copy, Clone, Debug, TryFromPrimitive)]
+#[derive(
+    Copy, Clone, Debug, TryFromPrimitive, IntoPrimitive, SerializePacket, DeserializePacket,
+)]
 #[repr(u32)]
 pub enum SquadNameStatus {
     Accepted = 1,
     Rejected = 2,
     Pending = 4,
-}
-
-impl SerializePacket for SquadNameStatus {
-    fn serialize(&self, buffer: &mut Vec<u8>) {
-        (*self as u32).serialize(buffer);
-    }
 }
 
 pub struct SquadMember {
@@ -91,19 +83,15 @@ impl SerializePacket for SquadMember {
     }
 }
 
-#[derive(Copy, Clone, Debug, TryFromPrimitive)]
+#[derive(
+    Copy, Clone, Debug, TryFromPrimitive, IntoPrimitive, SerializePacket, DeserializePacket,
+)]
 #[repr(u32)]
 pub enum SquadRank {
     Leader = 1,
     General = 2,
     Commander = 3,
     Trooper = 4,
-}
-
-impl SerializePacket for SquadRank {
-    fn serialize(&self, buffer: &mut Vec<u8>) {
-        (*self as u32).serialize(buffer);
-    }
 }
 
 pub struct SquadRankDefinition {

--- a/src/game_server/packets/tunnel.rs
+++ b/src/game_server/packets/tunnel.rs
@@ -1,4 +1,3 @@
-use byteorder::{LittleEndian, ReadBytesExt};
 use packet_serialize::{DeserializePacket, DeserializePacketError, SerializePacket};
 use std::io::{Cursor, Read};
 
@@ -23,9 +22,9 @@ fn serialize_tunneled_packet_from_bytes(buffer: &mut Vec<u8>, unknown1: bool, in
 fn deserialize_tunneled_packet(
     cursor: &mut Cursor<&[u8]>,
 ) -> Result<(bool, Vec<u8>), DeserializePacketError> {
-    let unknown1 = cursor.read_u8()? != 0;
+    let unknown1: bool = DeserializePacket::deserialize(cursor)?;
 
-    let inner_size = cursor.read_u32::<LittleEndian>()?;
+    let inner_size: u32 = DeserializePacket::deserialize(cursor)?;
     let mut inner = vec![0; inner_size as usize];
     cursor.read_exact(&mut inner)?;
 


### PR DESCRIPTION
Reduce redundant code with the support for enums in `SerializePacket` and `DeserializePacket` derive macros. Remove any manual byteorder code from the game server so that it is only pushed to the packet_serialize sub-crate and protocol implementation.