### PR TITLE
Fix typoed ID values.

### DIFF
--- a/config/items/gear/costume.yaml
+++ b/config/items/gear/costume.yaml
@@ -369,7 +369,7 @@
   item_type: 1
   category: 60
 # Padme Amidala Mask
-- guid: 170035
+- guid: 1188
   name_id: 1856
   description_id: 14
   icon_set_id: 1390
@@ -380,7 +380,7 @@
   category: 60
   members: true
 # Chancellor Palpatine Mask
-- guid: 170036
+- guid: 1189
   name_id: 1858
   description_id: 14
   icon_set_id: 1391

--- a/config/items/gear/planetary_forces.yaml
+++ b/config/items/gear/planetary_forces.yaml
@@ -133,7 +133,7 @@
   item_type: 1
   category: 60
 # Pre Vizsla's Gloves
-- guid: 380
+- guid: 390
   name_id: 1198
   description_id: 14
   icon_set_id: 388
@@ -533,7 +533,7 @@
   item_type: 1
   category: 62
 # Mandalorian Deathwatch Boots
-- guid: 4168
+- guid: 3168
   name_id: 4304
   description_id: 14
   icon_set_id: 2424

--- a/config/items/gear/weapons/weapons.yaml
+++ b/config/items/gear/weapons/weapons.yaml
@@ -1,6 +1,6 @@
 ---
 # Pink Gaffi Stick
-- guid: 38
+- guid: 48
   name_id: 97
   description_id: 14
   icon_set_id: 518


### PR DESCRIPTION
Fixed ID values for the following:
- Padme Amidala Mask
- Chancellor Palpatine Mask
- Pre Vizsla's Gloves
- Mandalorian Deathwatch Boots
- Pink Gaffi Stick

These were overlooked in the ID migration.