### PR TITLE
Fix lint errors on latest clippy version

### DIFF
--- a/src/channel_manager.rs
+++ b/src/channel_manager.rs
@@ -251,8 +251,8 @@ impl AuthenticatedChannelManager {
     ) -> Vec<(u32, Mutex<Channel>)> {
         let addrs_to_remove: Vec<SocketAddr> = self
             .channels
-            .iter()
-            .filter_map(|(_, channel)| {
+            .values()
+            .filter_map(|channel| {
                 let mut channel_handle = channel.lock();
                 if predicate(&mut channel_handle) {
                     Some(channel_handle.addr)

--- a/src/game_server/handlers/zone.rs
+++ b/src/game_server/handlers/zone.rs
@@ -167,9 +167,8 @@ impl From<ZoneConfig> for ZoneTemplate {
     fn from(value: ZoneConfig) -> Self {
         let mut button_keys_to_id = HashMap::new();
         let mut seen_keys = HashSet::new();
-        let mut next_id = 1;
 
-        for choice in &value.dialog_choices {
+        for (next_id, choice) in (1..).zip(value.dialog_choices.iter()) {
             if !seen_keys.insert(choice.button_key.clone()) {
                 panic!(
                     "Duplicate (Button Key: '{}') found in (Zone Template GUID: {})",
@@ -178,7 +177,6 @@ impl From<ZoneConfig> for ZoneTemplate {
             }
 
             button_keys_to_id.insert(choice.button_key.clone(), next_id);
-            next_id += 1;
         }
 
         let mut characters = Vec::new();


### PR DESCRIPTION
Clippy updated on CI and found these new issues:
```
$ cargo clippy -- -Dwarnings -A unused -A clippy::too_many_arguments
error: iterating on a map's values
   --> src\channel_manager.rs:252:48
    |
252 |           let addrs_to_remove: Vec<SocketAddr> = self
    |  ________________________________________________^
253 | |             .channels
254 | |             .iter()
255 | |             .filter_map(|(_, channel)| {
...   |
262 | |             })
    | |______________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#iter_kv_map
    = note: `-D clippy::iter-kv-map` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::iter_kv_map)]`
help: try
    |
252 ~         let addrs_to_remove: Vec<SocketAddr> = self
253 +             .channels.values().filter_map(|channel| {
254 +                 let mut channel_handle = channel.lock();
255 +                 if predicate(&mut channel_handle) {
256 +                     Some(channel_handle.addr)
257 +                 } else {
258 +                     None
259 +                 }
260 +             })
    |

error: the variable `next_id` is used as a loop counter
   --> src\game_server\handlers\zone.rs:172:9
    |
172 |         for choice in &value.dialog_choices {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `for (next_id, choice) in (1..).zip(value.dialog_choices.iter())`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#explicit_counter_loop
    = note: `-D clippy::explicit-counter-loop` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::explicit_counter_loop)]`
```

Refactor to fix these errors.