### PR TITLE
Allow defining a BVH for line of sight calculations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 asset_serialize = { path = "crates/asset_serialize" }
 axum = "0.7.5"
+bvh = { version = "0.12.0", features = ["serde"] }
 byteorder = "1.5.0"
 chrono = "0.4.38"
 clap = { version = "4.5.51", features = ["derive"] }
@@ -14,14 +15,17 @@ crossbeam-channel = "0.5.13"
 defer-lite = "1.0.0"
 enum-iterator = "2.1.0"
 evalexpr = "11.3.0"
+flate2 = "1.1.9"
 glam = "0.30.10"
 kiddo = "5.3.0"
 packet_serialize = { path = "crates/packet_serialize" }
 priority-queue = "2.7.0"
 miniz_oxide = "0.7.2"
 num_enum = "0.7.2"
+oxide_bvh = { path = "crates/bvh" }
 parking_lot = "0.12.1"
 polyanya = "0.16.1"
+pot = "3.0.1"
 rand = "0.8.5"
 rand_distr = "0.4.3"
 shlex = "1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 asset_serialize = { path = "crates/asset_serialize" }
 axum = "0.7.5"
-bvh = { version = "0.12.0", features = ["serde"] }
 byteorder = "1.5.0"
 chrono = "0.4.38"
 clap = { version = "4.5.51", features = ["derive"] }
@@ -15,7 +14,6 @@ crossbeam-channel = "0.5.13"
 defer-lite = "1.0.0"
 enum-iterator = "2.1.0"
 evalexpr = "11.3.0"
-flate2 = "1.1.9"
 glam = "0.30.10"
 kiddo = "5.3.0"
 packet_serialize = { path = "crates/packet_serialize" }

--- a/crates/bvh/Cargo.toml
+++ b/crates/bvh/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "oxide_bvh"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+bvh = { version = "0.12.0", features = ["serde"] }
+flate2 = "1.1.9"
+glam = "0.30.10"
+pot = "3.0.1"
+serde = { version = "1.0.196", features = ["derive"] }

--- a/crates/bvh/src/lib.rs
+++ b/crates/bvh/src/lib.rs
@@ -1,0 +1,233 @@
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::{BufReader, Read},
+    path::Path,
+};
+
+use bvh::{
+    aabb::{Aabb, Bounded},
+    bounding_hierarchy::BHShape,
+    bvh::Bvh,
+    ray::Ray,
+};
+use flate2::bufread::GzDecoder;
+use glam::{EulerRot, Quat, Vec3};
+use serde::{Deserialize, Serialize};
+
+fn vertex_from_index(vertices: &[[f32; 3]], index: u16) -> [f32; 3] {
+    let index = usize::from(index);
+    vertices[index]
+}
+
+fn triangle_to_aabb(v1: [f32; 3], v2: [f32; 3], v3: [f32; 3]) -> Aabb<f32, 3> {
+    Aabb::with_bounds(
+        [
+            v1[0].min(v2[0]).min(v3[0]),
+            v1[1].min(v2[1]).min(v3[1]),
+            v1[2].min(v2[2]).min(v3[2]),
+        ]
+        .into(),
+        [
+            v1[0].max(v2[0]).max(v3[0]),
+            v1[1].max(v2[1]).max(v3[1]),
+            v1[2].max(v2[2]).max(v3[2]),
+        ]
+        .into(),
+    )
+}
+
+fn map_triangles_with_vertices<'a>(vertices: &'a [[f32; 3]], triangles: &'a mut [Triangle]) -> Vec<TriangleWithVertices<'a>> {
+    triangles
+        .iter_mut()
+        .map(|triangle| TriangleWithVertices {
+            triangle,
+            vertices: &vertices,
+        })
+        .collect()
+}
+
+fn generate_bvh(vertices: &[[f32; 3]], triangles: &mut [Triangle]) -> Bvh<f32, 3> {
+    let mut triangles_with_vertices = map_triangles_with_vertices(vertices, triangles);
+    Bvh::build(&mut triangles_with_vertices)
+}
+
+#[derive(Deserialize, Serialize)]
+struct Triangle {
+    indices: [u16; 3],
+    node_index: usize,
+}
+
+impl From<[u16; 3]> for Triangle {
+    fn from(indices: [u16; 3]) -> Self {
+        Triangle {
+            indices,
+            node_index: 0,
+        }
+    }
+}
+
+struct TriangleWithVertices<'a> {
+    triangle: &'a mut Triangle,
+    vertices: &'a [[f32; 3]],
+}
+
+impl<'a> Bounded<f32, 3> for TriangleWithVertices<'a> {
+    fn aabb(&self) -> Aabb<f32, 3> {
+        let v1 = vertex_from_index(self.vertices, self.triangle.indices[0]);
+        let v2 = vertex_from_index(self.vertices, self.triangle.indices[1]);
+        let v3 = vertex_from_index(self.vertices, self.triangle.indices[2]);
+        triangle_to_aabb(v1, v2, v3)
+    }
+}
+
+impl<'a> BHShape<f32, 3> for TriangleWithVertices<'a> {
+    fn set_bh_node_index(&mut self, node_index: usize) {
+        self.triangle.node_index = node_index;
+    }
+
+    fn bh_node_index(&self) -> usize {
+        self.triangle.node_index
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct BvhTemplate {
+    bvh: Bvh<f32, 3>,
+    vertices: Vec<[f32; 3]>,
+    triangles: Vec<Triangle>,
+}
+
+impl BvhTemplate {
+    pub fn new(vertices: Vec<[f32; 3]>, triangles: Vec<[u16; 3]>) -> Self {
+        let mut triangles: Vec<Triangle> = triangles
+            .iter()
+            .map(|triangle| Triangle::from(*triangle))
+            .collect();
+
+        BvhTemplate {
+            bvh: generate_bvh(&vertices, &mut triangles),
+            vertices,
+            triangles,
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct BvhInstance {
+    id: u32,
+    pos: [f32; 3],
+    rot: [f32; 3],
+    scale: f32,
+    aabb: Aabb<f32, 3>,
+    node_index: usize,
+}
+
+impl BvhInstance {
+    pub fn new(
+        id: u32,
+        pos: [f32; 3],
+        rot: [f32; 3],
+        scale: f32,
+        vertices: &[[f32; 3]],
+        triangles: &[[u16; 3]],
+    ) -> Self {
+        BvhInstance {
+            id,
+            pos,
+            rot,
+            scale,
+            aabb: triangles
+                .iter()
+                .map(|triangle| {
+                    triangle_to_aabb(
+                        vertices[usize::from(triangle[0])],
+                        vertices[usize::from(triangle[1])],
+                        vertices[usize::from(triangle[2])],
+                    )
+                })
+                .fold(Aabb::empty(), |acc, next| acc.join(&next)),
+            node_index: 0,
+        }
+    }
+}
+
+impl Bounded<f32, 3> for BvhInstance {
+    fn aabb(&self) -> Aabb<f32, 3> {
+        self.aabb
+    }
+}
+
+impl BHShape<f32, 3> for BvhInstance {
+    fn set_bh_node_index(&mut self, node_index: usize) {
+        self.node_index = node_index;
+    }
+
+    fn bh_node_index(&self) -> usize {
+        self.node_index
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct ZoneBvh {
+    root: Bvh<f32, 3>,
+    templates: HashMap<u32, BvhTemplate>,
+    instances: Vec<BvhInstance>,
+}
+
+impl ZoneBvh {
+    pub fn new(templates: HashMap<u32, BvhTemplate>, mut instances: Vec<BvhInstance>) -> Self {
+        ZoneBvh {
+            root: Bvh::build(&mut instances),
+            templates,
+            instances,
+        }
+    }
+
+    pub fn has_line_of_sight(&self, start: [f32; 3], end: [f32; 3]) -> bool {
+        let start = Vec3::from(start);
+        let end = Vec3::from(end);
+        let direction: [f32; 3] = (end - start).normalize().into();
+        let ray = Ray::new(<[f32; 3]>::from(start).into(), direction.into());
+        for bvh_instance in self.root.traverse(&ray, &self.instances) {
+            let Some(bvh_template) = self.templates.get(&bvh_instance.id) else {
+                continue;
+            };
+
+            let inverse_rotation = Quat::from_euler(
+                EulerRot::YXZ,
+                bvh_instance.rot[0],
+                bvh_instance.rot[1],
+                bvh_instance.rot[2],
+            )
+            .inverse();
+            let relative_start =
+                (inverse_rotation * (start - Vec3::from(bvh_instance.pos))) / bvh_instance.scale;
+            let relative_end =
+                (inverse_rotation * (end - Vec3::from(bvh_instance.pos))) / bvh_instance.scale;
+            let relative_direction: [f32; 3] = (relative_end - relative_start).normalize().into();
+            let relative_ray = Ray::new(
+                <[f32; 3]>::from(relative_start).into(),
+                relative_direction.into(),
+            );
+
+            let triangles_with_vertices = map_triangles_with_vertices(&bvh_template.vertices, &mut bvh_template.triangles);
+            for triangle in bvh_template.bvh.traverse(&relative_ray, &triangles_with_vertices) {
+                //
+            }
+        }
+
+        true
+    }
+}
+
+pub fn load_bvh(config_dir: &Path, name: &str) -> Result<ZoneBvh, pot::Error> {
+    let path = config_dir.join(format!("{name}.gz"));
+
+    let file = File::open(path)?;
+    let mut decoder = GzDecoder::new(BufReader::new(file));
+    let mut buffer = Vec::new();
+    decoder.read_to_end(&mut buffer)?;
+
+    pot::from_slice(&buffer)
+}

--- a/crates/bvh/src/lib.rs
+++ b/crates/bvh/src/lib.rs
@@ -1,8 +1,8 @@
 use std::{
-    cell::Cell,
     collections::HashMap,
     fs::File,
     io::{BufReader, Read},
+    sync::atomic::{AtomicUsize, Ordering},
 };
 
 use bvh::{
@@ -55,17 +55,17 @@ fn generate_bvh(vertices: &[[f32; 3]], triangles: &mut [Triangle]) -> SubBvh<f32
     SubBvh::build(&mut triangles_with_vertices)
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 struct Triangle {
     indices: [u16; 3],
-    node_index: Cell<usize>,
+    node_index: AtomicUsize,
 }
 
 impl From<[u16; 3]> for Triangle {
     fn from(indices: [u16; 3]) -> Self {
         Triangle {
             indices,
-            node_index: Cell::new(0),
+            node_index: AtomicUsize::new(0),
         }
     }
 }
@@ -86,15 +86,17 @@ impl<'a> Bounded<f32, 3> for TriangleWithVertices<'a> {
 
 impl<'a> BHShape<f32, 3> for TriangleWithVertices<'a> {
     fn set_bh_node_index(&mut self, node_index: usize) {
-        self.triangle.node_index.set(node_index);
+        self.triangle
+            .node_index
+            .store(node_index, Ordering::Relaxed);
     }
 
     fn bh_node_index(&self) -> usize {
-        self.triangle.node_index.get()
+        self.triangle.node_index.load(Ordering::Relaxed)
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct BvhTemplate {
     bvh: SubBvh<f32, 3>,
     vertices: Vec<[f32; 3]>,
@@ -116,7 +118,7 @@ impl BvhTemplate {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct BvhInstance {
     id: u32,
     pos: [f32; 3],
@@ -163,7 +165,7 @@ impl BHShape<f32, 3> for BvhInstance {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Bvh {
     root: SubBvh<f32, 3>,
     templates: HashMap<u32, BvhTemplate>,

--- a/crates/bvh/src/lib.rs
+++ b/crates/bvh/src/lib.rs
@@ -215,11 +215,10 @@ impl Bvh {
                 .bvh
                 .traverse(&relative_ray, &triangles_with_vertices)
             {
-                let intersection = relative_ray.intersects_triangle(
-                    &triangle.vertices[0].into(),
-                    &triangle.vertices[1].into(),
-                    &triangle.vertices[2].into(),
-                );
+                let v1 = vertex_from_index(triangle.vertices, triangle.triangle.indices[0]).into();
+                let v2 = vertex_from_index(triangle.vertices, triangle.triangle.indices[1]).into();
+                let v3 = vertex_from_index(triangle.vertices, triangle.triangle.indices[2]).into();
+                let intersection = relative_ray.intersects_triangle(&v1, &v2, &v3);
                 if intersection.distance >= 0.0 && intersection.distance <= relative_max_distance {
                     return false;
                 }

--- a/crates/bvh/src/lib.rs
+++ b/crates/bvh/src/lib.rs
@@ -1,4 +1,5 @@
 use std::{
+    cell::Cell,
     collections::HashMap,
     fs::File,
     io::{BufReader, Read},
@@ -37,9 +38,12 @@ fn triangle_to_aabb(v1: [f32; 3], v2: [f32; 3], v3: [f32; 3]) -> Aabb<f32, 3> {
     )
 }
 
-fn map_triangles_with_vertices<'a>(vertices: &'a [[f32; 3]], triangles: &'a mut [Triangle]) -> Vec<TriangleWithVertices<'a>> {
+fn with_vertices<'a>(
+    vertices: &'a [[f32; 3]],
+    triangles: &'a [Triangle],
+) -> Vec<TriangleWithVertices<'a>> {
     triangles
-        .iter_mut()
+        .iter()
         .map(|triangle| TriangleWithVertices {
             triangle,
             vertices: &vertices,
@@ -48,27 +52,27 @@ fn map_triangles_with_vertices<'a>(vertices: &'a [[f32; 3]], triangles: &'a mut 
 }
 
 fn generate_bvh(vertices: &[[f32; 3]], triangles: &mut [Triangle]) -> Bvh<f32, 3> {
-    let mut triangles_with_vertices = map_triangles_with_vertices(vertices, triangles);
+    let mut triangles_with_vertices = with_vertices(vertices, triangles);
     Bvh::build(&mut triangles_with_vertices)
 }
 
 #[derive(Deserialize, Serialize)]
 struct Triangle {
     indices: [u16; 3],
-    node_index: usize,
+    node_index: Cell<usize>,
 }
 
 impl From<[u16; 3]> for Triangle {
     fn from(indices: [u16; 3]) -> Self {
         Triangle {
             indices,
-            node_index: 0,
+            node_index: Cell::new(0),
         }
     }
 }
 
 struct TriangleWithVertices<'a> {
-    triangle: &'a mut Triangle,
+    triangle: &'a Triangle,
     vertices: &'a [[f32; 3]],
 }
 
@@ -83,11 +87,11 @@ impl<'a> Bounded<f32, 3> for TriangleWithVertices<'a> {
 
 impl<'a> BHShape<f32, 3> for TriangleWithVertices<'a> {
     fn set_bh_node_index(&mut self, node_index: usize) {
-        self.triangle.node_index = node_index;
+        self.triangle.node_index.set(node_index);
     }
 
     fn bh_node_index(&self) -> usize {
-        self.triangle.node_index
+        self.triangle.node_index.get()
     }
 }
 
@@ -211,9 +215,20 @@ impl ZoneBvh {
                 relative_direction.into(),
             );
 
-            let triangles_with_vertices = map_triangles_with_vertices(&bvh_template.vertices, &mut bvh_template.triangles);
-            for triangle in bvh_template.bvh.traverse(&relative_ray, &triangles_with_vertices) {
-                //
+            let triangles_with_vertices =
+                with_vertices(&bvh_template.vertices, &bvh_template.triangles);
+            for triangle in bvh_template
+                .bvh
+                .traverse(&relative_ray, &triangles_with_vertices)
+            {
+                let intersection = relative_ray.intersects_triangle(
+                    &triangle.vertices[0].into(),
+                    &triangle.vertices[1].into(),
+                    &triangle.vertices[2].into(),
+                );
+                if intersection.distance < f32::INFINITY {
+                    return false;
+                }
             }
         }
 

--- a/crates/bvh/src/lib.rs
+++ b/crates/bvh/src/lib.rs
@@ -127,13 +127,12 @@ pub struct BvhInstance {
 }
 
 impl BvhInstance {
-    pub fn new(
+    pub fn new<'a>(
         id: u32,
         pos: [f32; 3],
         rot: [f32; 3],
         scale: f32,
-        vertices: &[[f32; 3]],
-        triangles: &[[u16; 3]],
+        triangles: impl Iterator<Item = &'a [[f32; 3]; 3]>,
     ) -> Self {
         BvhInstance {
             id,
@@ -141,14 +140,7 @@ impl BvhInstance {
             rot,
             scale,
             aabb: triangles
-                .iter()
-                .map(|triangle| {
-                    triangle_to_aabb(
-                        vertices[usize::from(triangle[0])],
-                        vertices[usize::from(triangle[1])],
-                        vertices[usize::from(triangle[2])],
-                    )
-                })
+                .map(|triangle| triangle_to_aabb(triangle[0], triangle[1], triangle[2]))
                 .fold(Aabb::empty(), |acc, next| acc.join(&next)),
             node_index: 0,
         }

--- a/crates/bvh/src/lib.rs
+++ b/crates/bvh/src/lib.rs
@@ -3,16 +3,15 @@ use std::{
     collections::HashMap,
     fs::File,
     io::{BufReader, Read},
-    path::Path,
 };
 
 use bvh::{
     aabb::{Aabb, Bounded},
     bounding_hierarchy::BHShape,
-    bvh::Bvh,
+    bvh::Bvh as SubBvh,
     ray::Ray,
 };
-use flate2::bufread::GzDecoder;
+use flate2::{bufread::GzDecoder, write::GzEncoder, Compression};
 use glam::{EulerRot, Quat, Vec3};
 use serde::{Deserialize, Serialize};
 
@@ -51,9 +50,9 @@ fn with_vertices<'a>(
         .collect()
 }
 
-fn generate_bvh(vertices: &[[f32; 3]], triangles: &mut [Triangle]) -> Bvh<f32, 3> {
+fn generate_bvh(vertices: &[[f32; 3]], triangles: &mut [Triangle]) -> SubBvh<f32, 3> {
     let mut triangles_with_vertices = with_vertices(vertices, triangles);
-    Bvh::build(&mut triangles_with_vertices)
+    SubBvh::build(&mut triangles_with_vertices)
 }
 
 #[derive(Deserialize, Serialize)]
@@ -97,7 +96,7 @@ impl<'a> BHShape<f32, 3> for TriangleWithVertices<'a> {
 
 #[derive(Deserialize, Serialize)]
 pub struct BvhTemplate {
-    bvh: Bvh<f32, 3>,
+    bvh: SubBvh<f32, 3>,
     vertices: Vec<[f32; 3]>,
     triangles: Vec<Triangle>,
 }
@@ -173,16 +172,16 @@ impl BHShape<f32, 3> for BvhInstance {
 }
 
 #[derive(Deserialize, Serialize)]
-pub struct ZoneBvh {
-    root: Bvh<f32, 3>,
+pub struct Bvh {
+    root: SubBvh<f32, 3>,
     templates: HashMap<u32, BvhTemplate>,
     instances: Vec<BvhInstance>,
 }
 
-impl ZoneBvh {
+impl Bvh {
     pub fn new(templates: HashMap<u32, BvhTemplate>, mut instances: Vec<BvhInstance>) -> Self {
-        ZoneBvh {
-            root: Bvh::build(&mut instances),
+        Bvh {
+            root: SubBvh::build(&mut instances),
             templates,
             instances,
         }
@@ -236,13 +235,17 @@ impl ZoneBvh {
     }
 }
 
-pub fn load_bvh(config_dir: &Path, name: &str) -> Result<ZoneBvh, pot::Error> {
-    let path = config_dir.join(format!("{name}.gz"));
+pub fn write_bvh(file: &File, bvh: &Bvh) -> Result<(), pot::Error> {
+    let serialized_bvh: Vec<u8> = pot::to_vec(bvh)?;
+    let mut encoder = GzEncoder::new(file, Compression::best());
+    std::io::Write::write_all(&mut encoder, &serialized_bvh)?;
+    encoder.finish()?;
+    Ok(())
+}
 
-    let file = File::open(path)?;
+pub fn read_bvh(file: &File) -> Result<Bvh, pot::Error> {
     let mut decoder = GzDecoder::new(BufReader::new(file));
     let mut buffer = Vec::new();
     decoder.read_to_end(&mut buffer)?;
-
     pot::from_slice(&buffer)
 }

--- a/crates/bvh/src/lib.rs
+++ b/crates/bvh/src/lib.rs
@@ -127,12 +127,12 @@ pub struct BvhInstance {
 }
 
 impl BvhInstance {
-    pub fn new<'a>(
+    pub fn new(
         id: u32,
         pos: [f32; 3],
         rot: [f32; 3],
         scale: f32,
-        triangles: impl Iterator<Item = &'a [[f32; 3]; 3]>,
+        triangles: impl Iterator<Item = [[f32; 3]; 3]>,
     ) -> Self {
         BvhInstance {
             id,

--- a/crates/bvh/src/lib.rs
+++ b/crates/bvh/src/lib.rs
@@ -203,6 +203,7 @@ impl Bvh {
             let relative_end =
                 (inverse_rotation * (end - Vec3::from(bvh_instance.pos))) / bvh_instance.scale;
             let relative_direction: [f32; 3] = (relative_end - relative_start).normalize().into();
+            let relative_max_distance = (relative_end - relative_start).length();
             let relative_ray = Ray::new(
                 <[f32; 3]>::from(relative_start).into(),
                 relative_direction.into(),
@@ -219,7 +220,7 @@ impl Bvh {
                     &triangle.vertices[1].into(),
                     &triangle.vertices[2].into(),
                 );
-                if intersection.distance < f32::INFINITY {
+                if intersection.distance >= 0.0 && intersection.distance <= relative_max_distance {
                     return false;
                 }
             }

--- a/crates/bvh/src/lib.rs
+++ b/crates/bvh/src/lib.rs
@@ -55,7 +55,7 @@ fn generate_bvh(vertices: &[[f32; 3]], triangles: &mut [Triangle]) -> SubBvh<f32
     SubBvh::build(&mut triangles_with_vertices)
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 struct Triangle {
     indices: [u16; 3],
     node_index: Cell<usize>,
@@ -94,7 +94,7 @@ impl<'a> BHShape<f32, 3> for TriangleWithVertices<'a> {
     }
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BvhTemplate {
     bvh: SubBvh<f32, 3>,
     vertices: Vec<[f32; 3]>,
@@ -116,7 +116,7 @@ impl BvhTemplate {
     }
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BvhInstance {
     id: u32,
     pos: [f32; 3],
@@ -163,7 +163,7 @@ impl BHShape<f32, 3> for BvhInstance {
     }
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Bvh {
     root: SubBvh<f32, 3>,
     templates: HashMap<u32, BvhTemplate>,

--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -3130,20 +3130,7 @@ impl Character {
                     target_read_handle.stats.pos,
                     target_read_handle.stats.ability_height,
                 ) {
-                    return vec![Broadcast::Multi(
-                        nearby_player_guids.to_vec(),
-                        vec![GamePacket::serialize(&TunneledPacket {
-                            unknown1: true,
-                            inner: PlayCompositeEffect {
-                                guid: *guid,
-                                triggered_by_guid: self.stats.guid,
-                                composite_effect: 1166,
-                                delay_millis: 0,
-                                duration_millis: tick_duration.as_millis() as u32,
-                                pos: Pos::default(),
-                            },
-                        })],
-                    )];
+                    return vec![Broadcast::Multi(nearby_player_guids.to_vec(), vec![])];
                 }
 
                 Vec::new()

--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -18,7 +18,7 @@ use crate::{
             lock_enforcer::CharacterWriteGuard,
             unique_guid::AMBIENT_NPC_DISCRIMINANT,
         },
-        navmesh::{Navmesh, NavmeshWaypoint, NonLinearPathState},
+        navmesh::{Collision, Navmesh, NavmeshWaypoint, NonLinearPathState},
         packets::{
             chat::{ActionBarTextColor, SendStringId},
             client_update::UpdateCredits,
@@ -2768,6 +2768,7 @@ impl Character {
         customizations: &BTreeMap<u32, Customization>,
         tick_duration: Duration,
         navmesh: &Navmesh,
+        collision: &Collision,
     ) -> (Vec<Broadcast>, Option<UpdatePlayerPos>) {
         self.update_target(nearby_characters, navmesh);
 

--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -2795,7 +2795,12 @@ impl Character {
             navmesh,
         );
 
-        broadcasts.append(&mut self.use_ability(nearby_characters, collision));
+        broadcasts.append(&mut self.use_ability(
+            nearby_player_guids,
+            nearby_characters,
+            tick_duration,
+            collision,
+        ));
 
         (broadcasts, pos_update)
     }
@@ -3107,7 +3112,9 @@ impl Character {
 
     fn use_ability(
         &mut self,
+        nearby_player_guids: &[u32],
         nearby_characters: &mut BTreeMap<u64, CharacterWriteGuard>,
+        tick_duration: Duration,
         collision: &Collision,
     ) -> Vec<Broadcast> {
         match &self.stats.target_state {
@@ -3123,7 +3130,20 @@ impl Character {
                     target_read_handle.stats.pos,
                     target_read_handle.stats.ability_height,
                 ) {
-                    return Vec::new();
+                    return vec![Broadcast::Multi(
+                        nearby_player_guids.to_vec(),
+                        vec![GamePacket::serialize(&TunneledPacket {
+                            unknown1: true,
+                            inner: PlayCompositeEffect {
+                                guid: *guid,
+                                triggered_by_guid: self.stats.guid,
+                                composite_effect: 1166,
+                                delay_millis: 0,
+                                duration_millis: tick_duration.as_millis() as u32,
+                                pos: Pos::default(),
+                            },
+                        })],
+                    )];
                 }
 
                 Vec::new()

--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -102,6 +102,10 @@ pub const fn default_spawn_animation_id() -> i32 {
     1
 }
 
+const fn default_ability_height() -> f32 {
+    1.0
+}
+
 const fn default_hud_message_millis() -> u32 {
     2000
 }
@@ -297,6 +301,8 @@ pub struct BaseNpcConfig {
     pub max_distance_from_origin: f32,
     #[serde(default)]
     pub auto_target_radius: f32,
+    #[serde(default = "default_ability_height")]
+    pub ability_height: f32,
     #[serde(default)]
     pub enemy_types: HashSet<String>,
     #[serde(default)]
@@ -2099,6 +2105,7 @@ pub struct BaseNpcTemplate {
     pub max_distance_from_target: f32,
     pub max_distance_from_origin: f32,
     pub auto_target_radius: f32,
+    pub ability_height: f32,
     pub enemy_types: HashSet<String>,
     pub enemy_prioritization: HashMap<String, i8>,
     pub texture_alias: String,
@@ -2214,6 +2221,7 @@ impl BaseNpcTemplate {
             triggered_npc_keys_on_interact: config.triggered_npc_keys_on_interact.clone(),
             notification_icon: config.notification_icon,
             navmesh: config.navmesh,
+            ability_height: config.ability_height,
         }
     }
 
@@ -2272,6 +2280,7 @@ impl BaseNpcTemplate {
                 health: 1,
                 composite_effect_tags: BTreeMap::new(),
                 navmesh: self.navmesh.clone(),
+                ability_height: self.ability_height,
             },
             tickable_procedure_tracker: TickableProcedureTracker::new(
                 self.tickable_procedures.clone(),
@@ -2402,6 +2411,7 @@ pub struct CharacterStats {
     pub max_distance_from_target: f32,
     pub max_distance_from_origin: f32,
     pub auto_target_radius: f32,
+    pub ability_height: f32,
     pub enemy_types: HashSet<String>,
     pub threat_table: ThreatTable,
     pub health: u32,
@@ -2666,6 +2676,7 @@ impl Character {
                 health: 1,
                 composite_effect_tags: BTreeMap::new(),
                 navmesh: None,
+                ability_height: default_ability_height(),
             },
             tickable_procedure_tracker: TickableProcedureTracker::new(
                 tickable_procedures,
@@ -2735,6 +2746,7 @@ impl Character {
                 health: 1,
                 composite_effect_tags: BTreeMap::new(),
                 navmesh: None,
+                ability_height: default_ability_height(),
             },
             tickable_procedure_tracker: TickableProcedureTracker::new(HashMap::new(), Vec::new()),
             synchronize_with: None,
@@ -2762,7 +2774,7 @@ impl Character {
         &mut self,
         now: Instant,
         nearby_player_guids: &[u32],
-        nearby_characters: &BTreeMap<u64, CharacterWriteGuard>,
+        nearby_characters: &mut BTreeMap<u64, CharacterWriteGuard>,
         mount_configs: &BTreeMap<u32, MountConfig>,
         item_definitions: &BTreeMap<u32, ItemDefinition>,
         customizations: &BTreeMap<u32, Customization>,
@@ -2772,139 +2784,20 @@ impl Character {
     ) -> (Vec<Broadcast>, Option<UpdatePlayerPos>) {
         self.update_target(nearby_characters, navmesh);
 
-        let speed = self.stats.speed.total();
+        let (mut broadcasts, pos_update) = self.seek_next_pos(
+            now,
+            nearby_player_guids,
+            nearby_characters,
+            mount_configs,
+            item_definitions,
+            customizations,
+            tick_duration,
+            navmesh,
+        );
 
-        match &mut self.stats.target_state {
-            TargetState::None => self.tickable_procedure_tracker.tick(
-                &mut self.stats,
-                now,
-                nearby_player_guids,
-                nearby_characters,
-                mount_configs,
-                item_definitions,
-                customizations,
-                tick_duration,
-                navmesh,
-            ),
-            TargetState::Targeting {
-                guid,
-                origin_pos,
-                origin_rot,
-                pos_update_progress,
-            } => {
-                let broadcasts = Vec::new();
-                let pos_update;
+        broadcasts.append(&mut self.use_ability(nearby_characters, collision));
 
-                if let Some(target_read_handle) = nearby_characters.get(guid) {
-                    let distance_from_origin =
-                        distance3_pos(target_read_handle.stats.pos, *origin_pos);
-                    let too_far_from_origin =
-                        distance_from_origin > self.stats.max_distance_from_origin;
-
-                    if !too_far_from_origin {
-                        let destination = target_read_handle.stats.pos;
-                        if pos_update_progress.destination_differs_from(
-                            destination,
-                            STANDING,
-                            self.stats.max_distance_from_target,
-                        ) {
-                            **pos_update_progress = NonLinearPathState::new(
-                                self.stats.pos,
-                                NavmeshWaypoint::without_rot(destination, STANDING),
-                                navmesh,
-                                self.stats.max_distance_from_target,
-                            );
-                        }
-
-                        pos_update = Some(pos_update_progress.tick(
-                            self.stats.guid,
-                            speed,
-                            tick_duration,
-                            self.stats.rot,
-                        ));
-
-                        return (broadcasts, pos_update);
-                    }
-                }
-
-                **pos_update_progress = NonLinearPathState::new(
-                    self.stats.pos,
-                    NavmeshWaypoint {
-                        pos: *origin_pos,
-                        rot_x: Some(origin_rot.x),
-                        rot_y: Some(origin_rot.y),
-                        rot_z: Some(origin_rot.z),
-                        rot_x_offset: 0.0,
-                        rot_y_offset: 0.0,
-                        rot_z_offset: 0.0,
-                        character_state: STANDING,
-                    },
-                    navmesh,
-                    0.0,
-                );
-                pos_update = Some(pos_update_progress.tick(
-                    self.stats.guid,
-                    speed,
-                    tick_duration,
-                    self.stats.rot,
-                ));
-                self.stats.target_state = TargetState::ReturningToOrigin {
-                    pos_update_progress: pos_update_progress.clone(),
-                };
-                self.stats
-                    .composite_effect_tags
-                    .insert(ORIGIN_RESET_TAG_ID, ORIGIN_RESET_COMPOSITE_EFFECT_ID);
-
-                (
-                    vec![Broadcast::Multi(
-                        nearby_player_guids.to_vec(),
-                        vec![GamePacket::serialize(&TunneledPacket {
-                            unknown1: true,
-                            inner: AddCompositeEffectTag {
-                                guid: self.stats.guid,
-                                tag_id: ORIGIN_RESET_TAG_ID,
-                                composite_effect_id: ORIGIN_RESET_COMPOSITE_EFFECT_ID,
-                                triggered_by_guid: 0,
-                                unknown2: 0,
-                            },
-                        })],
-                    )],
-                    pos_update,
-                )
-            }
-            TargetState::ReturningToOrigin {
-                pos_update_progress,
-            } => {
-                let pos_update = Some(pos_update_progress.tick(
-                    self.stats.guid,
-                    speed,
-                    tick_duration,
-                    self.stats.rot,
-                ));
-                if !pos_update_progress.reached_destination() {
-                    return (Vec::new(), pos_update);
-                }
-
-                self.stats.target_state = TargetState::None;
-                self.stats.threat_table.clear();
-                self.stats
-                    .composite_effect_tags
-                    .remove(&ORIGIN_RESET_TAG_ID);
-                (
-                    vec![Broadcast::Multi(
-                        nearby_player_guids.to_vec(),
-                        vec![GamePacket::serialize(&TunneledPacket {
-                            unknown1: true,
-                            inner: RemoveCompositeEffectTag {
-                                guid: self.stats.guid,
-                                tag_id: ORIGIN_RESET_TAG_ID,
-                            },
-                        })],
-                    )],
-                    pos_update,
-                )
-            }
-        }
+        (broadcasts, pos_update)
     }
 
     pub fn current_tickable_procedure(&self) -> Option<&String> {
@@ -3064,6 +2957,178 @@ impl Character {
                     )),
                 };
             }
+        }
+    }
+
+    fn seek_next_pos(
+        &mut self,
+        now: Instant,
+        nearby_player_guids: &[u32],
+        nearby_characters: &mut BTreeMap<u64, CharacterWriteGuard>,
+        mount_configs: &BTreeMap<u32, MountConfig>,
+        item_definitions: &BTreeMap<u32, ItemDefinition>,
+        customizations: &BTreeMap<u32, Customization>,
+        tick_duration: Duration,
+        navmesh: &Navmesh,
+    ) -> (Vec<Broadcast>, Option<UpdatePlayerPos>) {
+        let speed = self.stats.speed.total();
+
+        match &mut self.stats.target_state {
+            TargetState::None => self.tickable_procedure_tracker.tick(
+                &mut self.stats,
+                now,
+                nearby_player_guids,
+                nearby_characters,
+                mount_configs,
+                item_definitions,
+                customizations,
+                tick_duration,
+                navmesh,
+            ),
+            TargetState::Targeting {
+                guid,
+                origin_pos,
+                origin_rot,
+                pos_update_progress,
+            } => {
+                let pos_update;
+
+                if let Some(target_read_handle) = nearby_characters.get(guid) {
+                    let distance_from_origin =
+                        distance3_pos(target_read_handle.stats.pos, *origin_pos);
+                    let too_far_from_origin =
+                        distance_from_origin > self.stats.max_distance_from_origin;
+
+                    if !too_far_from_origin {
+                        let destination = target_read_handle.stats.pos;
+                        if pos_update_progress.destination_differs_from(
+                            destination,
+                            STANDING,
+                            self.stats.max_distance_from_target,
+                        ) {
+                            **pos_update_progress = NonLinearPathState::new(
+                                self.stats.pos,
+                                NavmeshWaypoint::without_rot(destination, STANDING),
+                                navmesh,
+                                self.stats.max_distance_from_target,
+                            );
+                        }
+
+                        pos_update = Some(pos_update_progress.tick(
+                            self.stats.guid,
+                            speed,
+                            tick_duration,
+                            self.stats.rot,
+                        ));
+
+                        return (Vec::new(), pos_update);
+                    }
+                }
+
+                **pos_update_progress = NonLinearPathState::new(
+                    self.stats.pos,
+                    NavmeshWaypoint {
+                        pos: *origin_pos,
+                        rot_x: Some(origin_rot.x),
+                        rot_y: Some(origin_rot.y),
+                        rot_z: Some(origin_rot.z),
+                        rot_x_offset: 0.0,
+                        rot_y_offset: 0.0,
+                        rot_z_offset: 0.0,
+                        character_state: STANDING,
+                    },
+                    navmesh,
+                    0.0,
+                );
+                pos_update = Some(pos_update_progress.tick(
+                    self.stats.guid,
+                    speed,
+                    tick_duration,
+                    self.stats.rot,
+                ));
+                self.stats.target_state = TargetState::ReturningToOrigin {
+                    pos_update_progress: pos_update_progress.clone(),
+                };
+                self.stats
+                    .composite_effect_tags
+                    .insert(ORIGIN_RESET_TAG_ID, ORIGIN_RESET_COMPOSITE_EFFECT_ID);
+
+                (
+                    vec![Broadcast::Multi(
+                        nearby_player_guids.to_vec(),
+                        vec![GamePacket::serialize(&TunneledPacket {
+                            unknown1: true,
+                            inner: AddCompositeEffectTag {
+                                guid: self.stats.guid,
+                                tag_id: ORIGIN_RESET_TAG_ID,
+                                composite_effect_id: ORIGIN_RESET_COMPOSITE_EFFECT_ID,
+                                triggered_by_guid: 0,
+                                unknown2: 0,
+                            },
+                        })],
+                    )],
+                    pos_update,
+                )
+            }
+            TargetState::ReturningToOrigin {
+                pos_update_progress,
+            } => {
+                let pos_update = Some(pos_update_progress.tick(
+                    self.stats.guid,
+                    speed,
+                    tick_duration,
+                    self.stats.rot,
+                ));
+                if !pos_update_progress.reached_destination() {
+                    return (Vec::new(), pos_update);
+                }
+
+                self.stats.target_state = TargetState::None;
+                self.stats.threat_table.clear();
+                self.stats
+                    .composite_effect_tags
+                    .remove(&ORIGIN_RESET_TAG_ID);
+                (
+                    vec![Broadcast::Multi(
+                        nearby_player_guids.to_vec(),
+                        vec![GamePacket::serialize(&TunneledPacket {
+                            unknown1: true,
+                            inner: RemoveCompositeEffectTag {
+                                guid: self.stats.guid,
+                                tag_id: ORIGIN_RESET_TAG_ID,
+                            },
+                        })],
+                    )],
+                    pos_update,
+                )
+            }
+        }
+    }
+
+    fn use_ability(
+        &mut self,
+        nearby_characters: &mut BTreeMap<u64, CharacterWriteGuard>,
+        collision: &Collision,
+    ) -> Vec<Broadcast> {
+        match &self.stats.target_state {
+            TargetState::None => Vec::new(),
+            TargetState::Targeting { guid, .. } => {
+                let Some(target_read_handle) = nearby_characters.get(guid) else {
+                    return Vec::new();
+                };
+
+                if collision.has_line_of_sight(
+                    self.stats.pos,
+                    self.stats.ability_height,
+                    target_read_handle.stats.pos,
+                    target_read_handle.stats.ability_height,
+                ) {
+                    return Vec::new();
+                }
+
+                Vec::new()
+            }
+            TargetState::ReturningToOrigin { .. } => Vec::new(),
         }
     }
 }

--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -3114,7 +3114,7 @@ impl Character {
         &mut self,
         nearby_player_guids: &[u32],
         nearby_characters: &mut BTreeMap<u64, CharacterWriteGuard>,
-        tick_duration: Duration,
+        _: Duration,
         collision: &Collision,
     ) -> Vec<Broadcast> {
         match &self.stats.target_state {

--- a/src/game_server/handlers/character.rs
+++ b/src/game_server/handlers/character.rs
@@ -103,7 +103,7 @@ pub const fn default_spawn_animation_id() -> i32 {
 }
 
 const fn default_ability_height() -> f32 {
-    1.0
+    1.5
 }
 
 const fn default_hud_message_millis() -> u32 {

--- a/src/game_server/handlers/tick.rs
+++ b/src/game_server/handlers/tick.rs
@@ -131,7 +131,7 @@ pub fn tick_single_chunk(
                     let (mut character_broadcasts, character_pos_update) = tickable_character.tick(
                         now,
                         &nearby_player_guids,
-                        &characters_write,
+                        &mut characters_write,
                         game_server.mounts(),
                         game_server.items(),
                         game_server.customizations(),

--- a/src/game_server/handlers/tick.rs
+++ b/src/game_server/handlers/tick.rs
@@ -5,7 +5,7 @@ use crossbeam_channel::Sender;
 use crate::{
     game_server::{
         handlers::{character::CharacterType, guid::IndexedGuid},
-        navmesh::{Navmesh, DEFAULT_NAVMESH},
+        navmesh::{Collision, Navmesh, DEFAULT_COLLISION, DEFAULT_NAVMESH},
         packets::{
             minigame::{MinigameDefinitions, MinigameDefinitionsUpdate, MinigameHeader},
             player_update::PhysicsState,
@@ -120,12 +120,12 @@ pub fn tick_single_chunk(
                         }
                     }
 
-                    let navmesh: &Navmesh = match tickable_character.stats.physics {
-                        PhysicsState::Disabled => &DEFAULT_NAVMESH,
+                    let (navmesh, collision): &(Navmesh, Collision) = match tickable_character.stats.physics {
+                        PhysicsState::Disabled => &(DEFAULT_NAVMESH, DEFAULT_COLLISION),
                         PhysicsState::Enabled => tickable_character.stats.navmesh
                             .as_ref()
                             .and_then(|navmesh| game_server.navmeshes().get(navmesh))
-                            .unwrap_or(&DEFAULT_NAVMESH),
+                            .unwrap_or(&(DEFAULT_NAVMESH, DEFAULT_COLLISION)),
                     };
 
                     let (mut character_broadcasts, character_pos_update) = tickable_character.tick(
@@ -137,6 +137,7 @@ pub fn tick_single_chunk(
                         game_server.customizations(),
                         tick_duration,
                         navmesh,
+                        collision,
                     );
                     broadcasts.append(&mut character_broadcasts);
                     if let Some(pos_update) = character_pos_update {

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -64,7 +64,7 @@ use rand::Rng;
 use crate::game_server::handlers::combat::{load_enemy_types, EnemyTypeConfig};
 use crate::game_server::handlers::tick::reset_daily_minigames;
 use crate::game_server::navmesh::config::load_navmeshes;
-use crate::game_server::navmesh::Navmesh;
+use crate::game_server::navmesh::{Collision, Navmesh};
 use crate::ConfigError;
 use packet_serialize::{DeserializePacket, DeserializePacketError};
 
@@ -196,7 +196,7 @@ pub struct GameServer {
     item_groups: ItemGroupDefinitions,
     minigames: AllMinigameConfigs,
     mounts: BTreeMap<u32, MountConfig>,
-    navmeshes: HashMap<String, Navmesh>,
+    navmeshes: HashMap<String, (Navmesh, Collision)>,
     points_of_interest: BTreeMap<u32, (u8, PointOfInterestConfig)>,
     start_time: Instant,
     zone_templates: BTreeMap<u8, ZoneTemplate>,
@@ -857,7 +857,7 @@ impl GameServer {
         &self.mounts
     }
 
-    pub fn navmeshes(&self) -> &HashMap<String, Navmesh> {
+    pub fn navmeshes(&self) -> &HashMap<String, (Navmesh, Collision)> {
         &self.navmeshes
     }
 

--- a/src/game_server/navmesh/config.rs
+++ b/src/game_server/navmesh/config.rs
@@ -6,7 +6,10 @@ use oxide_bvh::{read_bvh, Bvh};
 use polyanya::{Layer, Mesh, Triangulation};
 use serde::Deserialize;
 
-use crate::{game_server::navmesh::Navmesh, ConfigError};
+use crate::{
+    game_server::navmesh::{Collision, Navmesh},
+    info, ConfigError,
+};
 
 type Polygon = Vec<[f32; 3]>;
 
@@ -89,7 +92,9 @@ fn load_bvh(config_dir: &Path, name: &str) -> Result<Bvh, ConfigError> {
     Ok(read_bvh(&file)?)
 }
 
-pub fn load_navmeshes(config_dir: &Path) -> Result<HashMap<String, Navmesh>, ConfigError> {
+pub fn load_navmeshes(
+    config_dir: &Path,
+) -> Result<HashMap<String, (Navmesh, Collision)>, ConfigError> {
     let mut file = File::open(config_dir.join("navmeshes.yaml"))?;
     let configs: NavmeshConfigs = serde_yaml::from_reader(&mut file)?;
 
@@ -149,7 +154,15 @@ pub fn load_navmeshes(config_dir: &Path) -> Result<HashMap<String, Navmesh>, Con
             mesh.set_search_delta(config.search_delta);
             mesh.set_search_steps(config.search_steps);
 
-            (asset_name, Navmesh::Complex(mesh))
+            let collision = match load_bvh(config_dir, &asset_name) {
+                Ok(bvh) => Collision::Bvh(bvh),
+                Err(err) => {
+                    info!("Failed to read BVH for {asset_name}: {err:?}. Defaulting to empty BVH.");
+                    Collision::Empty
+                }
+            };
+
+            (asset_name, (Navmesh::Complex(mesh), collision))
         })
         .collect())
 }

--- a/src/game_server/navmesh/config.rs
+++ b/src/game_server/navmesh/config.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, fs::File, path::Path};
 
 use glam::Vec2;
 use kiddo::{immutable::float::kdtree::ImmutableKdTree, SquaredEuclidean};
+use oxide_bvh::{read_bvh, Bvh};
 use polyanya::{Layer, Mesh, Triangulation};
 use serde::Deserialize;
 
@@ -80,6 +81,13 @@ struct NavmeshConfig {
 }
 
 type NavmeshConfigs = HashMap<String, NavmeshConfig>;
+
+fn load_bvh(config_dir: &Path, name: &str) -> Result<Bvh, ConfigError> {
+    let path = config_dir.join(format!("{name}.gz"));
+
+    let file = File::open(path)?;
+    Ok(read_bvh(&file)?)
+}
 
 pub fn load_navmeshes(config_dir: &Path) -> Result<HashMap<String, Navmesh>, ConfigError> {
     let mut file = File::open(config_dir.join("navmeshes.yaml"))?;

--- a/src/game_server/navmesh/config.rs
+++ b/src/game_server/navmesh/config.rs
@@ -86,7 +86,7 @@ struct NavmeshConfig {
 type NavmeshConfigs = HashMap<String, NavmeshConfig>;
 
 fn load_bvh(config_dir: &Path, name: &str) -> Result<Bvh, ConfigError> {
-    let path = config_dir.join(format!("{name}.gz"));
+    let path = config_dir.join("bvhs").join(format!("{name}.gz"));
 
     let file = File::open(path)?;
     Ok(read_bvh(&file)?)

--- a/src/game_server/navmesh/mod.rs
+++ b/src/game_server/navmesh/mod.rs
@@ -383,3 +383,34 @@ impl Navmesh {
         }
     }
 }
+
+#[derive(Clone, Debug, Default)]
+pub enum Collision {
+    #[default]
+    Empty,
+    Bvh(oxide_bvh::Bvh),
+}
+
+impl Collision {
+    pub fn has_line_of_sight(
+        &self,
+        start_feet_pos: Pos,
+        start_height: f32,
+        end_feet_pos: Pos,
+        end_height: f32,
+    ) -> bool {
+        match self {
+            Collision::Empty => true,
+            Collision::Bvh(bvh) => {
+                let start = [
+                    start_feet_pos.x,
+                    start_feet_pos.y + start_height,
+                    start_feet_pos.z,
+                ];
+                let end = [end_feet_pos.x, end_feet_pos.y + end_height, end_feet_pos.z];
+
+                bvh.has_line_of_sight(start, end)
+            }
+        }
+    }
+}

--- a/src/game_server/navmesh/mod.rs
+++ b/src/game_server/navmesh/mod.rs
@@ -384,12 +384,14 @@ impl Navmesh {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, Default)]
 pub enum Collision {
     #[default]
     Empty,
     Bvh(oxide_bvh::Bvh),
 }
+
+pub const DEFAULT_COLLISION: Collision = Collision::Empty;
 
 impl Collision {
     pub fn has_line_of_sight(

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,7 @@ pub enum ConfigError {
     Io(Error),
     Deserialize(serde_yaml::Error),
     ConstraintViolated(String),
+    BvhDeserialize(pot::Error),
 }
 
 impl From<Error> for ConfigError {
@@ -93,6 +94,12 @@ impl From<Error> for ConfigError {
 impl From<serde_yaml::Error> for ConfigError {
     fn from(value: serde_yaml::Error) -> Self {
         ConfigError::Deserialize(value)
+    }
+}
+
+impl From<pot::Error> for ConfigError {
+    fn from(value: pot::Error) -> Self {
+        ConfigError::BvhDeserialize(value)
     }
 }
 


### PR DESCRIPTION
Add a stub for NPC ability usage gated by a line of sight calculation. For each navmesh, a bounding volume hierarchy (BVH) is read from the `bvhs` folder of the same name. We use this BVH to determine if there is a line of sight from the NPC's torso (based on `ability_height`) to the target.

BVHs are generated by https://github.com/soir20/oxide/pull/264