### PR TITLE
Add decision tree for player attacks

### DIFF
--- a/config/enemy_types.yaml
+++ b/config/enemy_types.yaml
@@ -7,3 +7,23 @@ enemy_types:
   - player
 enemy_types_applied_to_players:
   - player
+allowed_player_enemies:
+  else: Unattackable
+  if:
+    aerial:
+      else: Unattackable
+      if: {}
+
+    player:
+      else: Unattackable
+      if: {}
+
+    republic:
+      else: Unattackable
+      if: {}
+
+    separatist:
+      else: Attackable
+
+    ground:
+      else: Attackable

--- a/config/enemy_types.yaml
+++ b/config/enemy_types.yaml
@@ -1,5 +1,7 @@
 ---
 enemy_types:
+  - republic
+  - separatist
   - aerial
   - ground
   - player

--- a/config/enemy_types.yaml
+++ b/config/enemy_types.yaml
@@ -7,7 +7,7 @@ enemy_types:
   - player
 enemy_types_applied_to_players:
   - player
-allowed_player_enemies:
+allowed_player_attacks:
   else: Unattackable
   if:
     aerial:

--- a/config/enemy_types.yaml
+++ b/config/enemy_types.yaml
@@ -12,23 +12,18 @@ enemy_types_applied_to_players:
 allowed_player_attacks:
   if:
     aerial:
-      if: {}
       else: Unattackable
 
     player:
-      if: {}
       else: Unattackable
 
     republic:
-      if: {}
       else: Unattackable
 
     separatist:
-      if: {}
       else: Attackable
 
     ground:
-      if: {}
       else: Attackable
 
   else: Unattackable

--- a/config/enemy_types.yaml
+++ b/config/enemy_types.yaml
@@ -5,25 +5,30 @@ enemy_types:
   - aerial
   - ground
   - player
+
 enemy_types_applied_to_players:
   - player
+
 allowed_player_attacks:
-  else: Unattackable
   if:
     aerial:
-      else: Unattackable
       if: {}
+      else: Unattackable
 
     player:
-      else: Unattackable
       if: {}
+      else: Unattackable
 
     republic:
-      else: Unattackable
       if: {}
+      else: Unattackable
 
     separatist:
+      if: {}
       else: Attackable
 
     ground:
+      if: {}
       else: Attackable
+
+  else: Unattackable

--- a/src/game_server/handlers/combat.rs
+++ b/src/game_server/handlers/combat.rs
@@ -11,10 +11,42 @@ use serde::Deserialize;
 use crate::ConfigError;
 
 #[derive(Deserialize)]
+pub enum Attackability {
+    Attackable,
+    Unattackable,
+}
+
+#[allow(dead_code)]
+#[derive(Deserialize)]
+pub struct AttackDecisionNode {
+    #[serde(rename = "if")]
+    pub if_branches: HashMap<String, AttackDecisionNode>,
+    #[serde(rename = "else")]
+    pub else_result: Attackability,
+}
+
+#[allow(dead_code)]
+pub fn player_can_attack(node: &AttackDecisionNode, enemy_types: &[String]) -> bool {
+    let mut result = matches!(node.else_result, Attackability::Attackable);
+
+    for enemy_type in enemy_types {
+        if let Some(next_node) = node.if_branches.get(enemy_type) {
+            if !player_can_attack(next_node, enemy_types) {
+                return false;
+            }
+            result = true;
+        }
+    }
+
+    result
+}
+
+#[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EnemyTypeConfig {
     pub enemy_types: HashSet<String>,
     pub enemy_types_applied_to_players: HashSet<String>,
+    pub allowed_player_attacks: AttackDecisionNode,
 }
 
 pub fn load_enemy_types(config_dir: &Path) -> Result<EnemyTypeConfig, ConfigError> {
@@ -27,6 +59,15 @@ pub fn load_enemy_types(config_dir: &Path) -> Result<EnemyTypeConfig, ConfigErro
         return Err(ConfigError::ConstraintViolated(
             "Enemy types applied to players must be a subset of valid enemy types".to_string(),
         ));
+    }
+
+    for enemy_type in config.allowed_player_attacks.if_branches.keys() {
+        if !config.enemy_types.contains(enemy_type) {
+            return Err(ConfigError::ConstraintViolated(format!(
+                "Invalid enemy type found in allowed player attacks {}",
+                enemy_type
+            )));
+        }
     }
     Ok(config)
 }

--- a/src/game_server/handlers/combat.rs
+++ b/src/game_server/handlers/combat.rs
@@ -20,7 +20,7 @@ pub enum Attackability {
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AttackDecisionNode {
-    #[serde(rename = "if")]
+    #[serde(rename = "if", default)]
     pub if_branches: HashMap<String, AttackDecisionNode>,
     #[serde(rename = "else")]
     pub else_result: Attackability,

--- a/src/game_server/handlers/combat.rs
+++ b/src/game_server/handlers/combat.rs
@@ -18,6 +18,7 @@ pub enum Attackability {
 
 #[allow(dead_code)]
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AttackDecisionNode {
     #[serde(rename = "if")]
     pub if_branches: HashMap<String, AttackDecisionNode>,

--- a/src/game_server/handlers/combat.rs
+++ b/src/game_server/handlers/combat.rs
@@ -11,6 +11,7 @@ use serde::Deserialize;
 use crate::ConfigError;
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 pub enum Attackability {
     Attackable,
     Unattackable,


### PR DESCRIPTION
* Added two new enemy types:
  * `republic`
  * `separatist`
* Added decision tree for player attacks based on enemy type.
  * Players can only attack separatist non-aerial units and ground units.