### PR TITLE
Fix ZoneCombatSettings struct

### DIFF
--- a/src/game_server/packets/zone.rs
+++ b/src/game_server/packets/zone.rs
@@ -15,6 +15,7 @@ impl GamePacket for PointOfInterestTeleportRequest {
 #[derive(SerializePacket, DeserializePacket)]
 pub struct ZoneCombatSettings {
     pub zone_guid: u32,
+    pub force_combat_pose: bool,
     pub combat_camera: bool,
     pub unknown3: bool,
     pub unknown4: bool,


### PR DESCRIPTION
Restores `ZoneCombatSettings` `force_combat_pose` field that was accidentally removed in #72.