### PR TITLE
Preload all BVHs to allow shared ownership

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -34,25 +34,31 @@ impl From<pot::Error> for ConfigError {
     }
 }
 
-fn list_config_yamls(root: &Path) -> Result<Vec<PathBuf>, ConfigError> {
-    let mut files_with_yaml = Vec::new();
+pub fn list_files_with_extension(
+    root: &Path,
+    required_extension: &str,
+) -> Result<Vec<PathBuf>, ConfigError> {
+    let mut files_with_extension = Vec::new();
 
     for entry in fs::read_dir(root)? {
         let entry_path = entry?.path();
         match entry_path.is_dir() {
-            true => files_with_yaml.append(&mut list_config_yamls(&entry_path)?),
+            true => files_with_extension.append(&mut list_files_with_extension(
+                &entry_path,
+                required_extension,
+            )?),
             false => {
                 if entry_path
                     .extension()
-                    .is_some_and(|extension| extension == "yaml")
+                    .is_some_and(|extension| extension == required_extension)
                 {
-                    files_with_yaml.push(entry_path);
+                    files_with_extension.push(entry_path);
                 }
             }
         }
     }
 
-    Ok(files_with_yaml)
+    Ok(files_with_extension)
 }
 
 fn merge_yaml_values(
@@ -85,7 +91,7 @@ fn merge_yaml_values(
 
 pub fn merge_config_dir<T: DeserializeOwned>(root: &Path) -> Result<T, ConfigError> {
     let mut accumulated_map = Mapping::new();
-    for path in list_config_yamls(root)? {
+    for path in list_files_with_extension(root, "yaml")? {
         let file = File::open(&path)?;
         accumulated_map = merge_yaml_values("", accumulated_map, serde_yaml::from_reader(file)?)?;
     }

--- a/src/game_server/mod.rs
+++ b/src/game_server/mod.rs
@@ -5,6 +5,7 @@ use std::io::{Cursor, Error};
 use std::num::ParseIntError;
 use std::path::Path;
 use std::str::ParseBoolError;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::vec;
 
@@ -49,6 +50,7 @@ use handlers::zone::{
     load_zones, teleport_anywhere, teleport_within_zone, DestinationZoneInstance,
     PointOfInterestConfig, ZoneInstance, ZoneTemplate,
 };
+use oxide_bvh::Bvh;
 use packets::client_update::{Health, Power, PreloadCharactersDone, Stat, StatId, Stats};
 use packets::login::{LoginRequest, WelcomeScreen, ZoneDetailsDone};
 use packets::player_update::{Customization, InitCustomizations, QueueAnimation, UpdateWieldType};
@@ -64,7 +66,7 @@ use crate::config::ConfigError;
 use crate::game_server::handlers::combat::{load_enemy_types, EnemyTypeConfig};
 use crate::game_server::handlers::store::{redirect_packets, ItemCostMap};
 use crate::game_server::handlers::tick::reset_daily_minigames;
-use crate::game_server::navmesh::config::load_navmeshes;
+use crate::game_server::navmesh::config::{load_bvhs, load_navmeshes};
 use crate::game_server::navmesh::{Collision, Navmesh};
 use packet_serialize::{DeserializePacket, DeserializePacketError};
 
@@ -185,6 +187,7 @@ pub enum TickableNpcSynchronization {
 
 pub struct GameServer {
     abilities: HashMap<String, AbilityConfig>,
+    bvhs: HashMap<String, Arc<Bvh>>,
     categories: CategoryDefinitions,
     costs: ItemCostMap,
     customizations: BTreeMap<i32, Customization>,
@@ -207,6 +210,7 @@ pub struct GameServer {
 impl GameServer {
     pub fn new(config_dir: &Path) -> Result<Self, ConfigError> {
         let abilities = load_abilities(config_dir)?;
+        let bvhs = load_bvhs(config_dir)?;
         let characters = GuidTable::new();
         let (templates, zones, points_of_interest) = load_zones(config_dir)?;
         let (items, mut costs) = load_items(config_dir, &abilities)?;
@@ -227,10 +231,11 @@ impl GameServer {
             },
             minigames: load_all_minigames(config_dir)?,
             mounts: load_mounts(config_dir)?,
-            navmeshes: load_navmeshes(config_dir)?,
+            navmeshes: load_navmeshes(config_dir, &bvhs)?,
             points_of_interest,
             start_time: Instant::now(),
             zone_templates: templates,
+            bvhs,
             commands: load_commands(config_dir)?,
         })
     }
@@ -826,6 +831,10 @@ impl GameServer {
 
     pub fn abilities(&self) -> &HashMap<String, AbilityConfig> {
         &self.abilities
+    }
+
+    pub fn bvhs(&self) -> &HashMap<String, Arc<Bvh>> {
+        &self.bvhs
     }
 
     pub fn costs(&self) -> &ItemCostMap {

--- a/src/game_server/navmesh/config.rs
+++ b/src/game_server/navmesh/config.rs
@@ -1,4 +1,9 @@
-use std::{collections::HashMap, fs::File, path::Path};
+use std::{
+    collections::HashMap,
+    fs::File,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use glam::Vec2;
 use kiddo::{immutable::float::kdtree::ImmutableKdTree, SquaredEuclidean};
@@ -7,7 +12,7 @@ use polyanya::{Layer, Mesh, Triangulation};
 use serde::Deserialize;
 
 use crate::{
-    config::merge_config_dir,
+    config::{list_files_with_extension, merge_config_dir},
     game_server::navmesh::{Collision, Navmesh},
     info, ConfigError,
 };
@@ -86,15 +91,29 @@ struct NavmeshConfig {
 
 type NavmeshConfigs = HashMap<String, NavmeshConfig>;
 
-fn load_bvh(config_dir: &Path, name: &str) -> Result<Bvh, ConfigError> {
-    let path = config_dir.join("bvhs").join(format!("{name}.gz"));
-
+fn load_bvh(path: PathBuf) -> Result<Bvh, ConfigError> {
     let file = File::open(path)?;
     Ok(read_bvh(&file)?)
 }
 
+pub fn load_bvhs(config_dir: &Path) -> Result<HashMap<String, Arc<Bvh>>, ConfigError> {
+    let paths = list_files_with_extension(&config_dir.join("bvhs"), "gz")?;
+    let mut bvhs = HashMap::new();
+
+    for path in paths.into_iter() {
+        let stem = path.file_stem().unwrap_or_default();
+        let name = stem.to_str().ok_or_else(|| {
+            ConfigError::ConstraintViolated(format!("{stem:?} must be valid UTF-8"))
+        })?;
+        bvhs.insert(name.to_owned(), Arc::new(load_bvh(path)?));
+    }
+
+    Ok(bvhs)
+}
+
 pub fn load_navmeshes(
     config_dir: &Path,
+    bvhs: &HashMap<String, Arc<Bvh>>,
 ) -> Result<HashMap<String, (Navmesh, Collision)>, ConfigError> {
     let navmeshes_dir = config_dir.join("navmeshes");
     let configs: NavmeshConfigs = merge_config_dir(&navmeshes_dir)?;
@@ -155,10 +174,10 @@ pub fn load_navmeshes(
             mesh.set_search_delta(config.search_delta);
             mesh.set_search_steps(config.search_steps);
 
-            let collision = match load_bvh(config_dir, &asset_name) {
-                Ok(bvh) => Collision::Bvh(bvh),
-                Err(err) => {
-                    info!("Failed to read BVH for {asset_name}: {err:?}. Defaulting to empty BVH.");
+            let collision = match bvhs.get(&asset_name).cloned() {
+                Some(bvh) => Collision::Bvh(bvh),
+                None => {
+                    info!("Missing BVH for {asset_name}. Defaulting to empty BVH.");
                     Collision::Empty
                 }
             };

--- a/src/game_server/navmesh/mod.rs
+++ b/src/game_server/navmesh/mod.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::VecDeque,
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -388,7 +389,7 @@ impl Navmesh {
 pub enum Collision {
     #[default]
     Empty,
-    Bvh(oxide_bvh::Bvh),
+    Bvh(Arc<oxide_bvh::Bvh>),
 }
 
 pub const DEFAULT_COLLISION: Collision = Collision::Empty;


### PR DESCRIPTION
We need to use BVHs for Attack Cruiser. Instead of loading multiple copies of the BVH for each game, simply load one immutable copy of the BVH and share ownership with `Arc`.