### PR TITLE
Optimize BVH `has_line_of_sight` calculations

### DIFF
--- a/crates/bvh/src/lib.rs
+++ b/crates/bvh/src/lib.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashMap,
     fs::File,
     io::{BufReader, Read, Write},
     sync::atomic::AtomicUsize,
@@ -110,7 +109,7 @@ impl From<BvhTemplateData> for BvhTemplate {
 
 #[derive(Serialize, Deserialize)]
 struct BvhInstanceData {
-    id: u32,
+    bvh_index: usize,
     pos: [f32; 3],
     rot: [f32; 3],
     scale: f32,
@@ -121,7 +120,7 @@ struct BvhInstanceData {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(from = "BvhInstanceData")]
 pub struct BvhInstance {
-    id: u32,
+    bvh_index: usize,
     pos: [f32; 3],
     rot: [f32; 3],
     scale: f32,
@@ -136,14 +135,14 @@ pub struct BvhInstance {
 
 impl BvhInstance {
     pub fn new(
-        id: u32,
+        bvh_index: usize,
         pos: [f32; 3],
         rot: [f32; 3],
         scale: f32,
         global_triangles: impl Iterator<Item = [[f32; 3]; 3]>,
     ) -> Self {
         BvhInstance {
-            id,
+            bvh_index,
             pos,
             rot,
             scale,
@@ -165,7 +164,7 @@ impl From<BvhInstanceData> for BvhInstance {
         let inv_scale = 1.0 / value.scale.max(f32::EPSILON);
 
         BvhInstance {
-            id: value.id,
+            bvh_index: value.bvh_index,
             pos: value.pos,
             rot: value.rot,
             scale: value.scale,
@@ -196,12 +195,12 @@ impl BHShape<f32, 3> for BvhInstance {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Bvh {
     root: SubBvh<f32, 3>,
-    templates: HashMap<u32, BvhTemplate>,
+    templates: Vec<BvhTemplate>,
     instances: Vec<BvhInstance>,
 }
 
 impl Bvh {
-    pub fn new(templates: HashMap<u32, BvhTemplate>, mut instances: Vec<BvhInstance>) -> Self {
+    pub fn new(templates: Vec<BvhTemplate>, mut instances: Vec<BvhInstance>) -> Self {
         Bvh {
             root: SubBvh::build(&mut instances),
             templates,
@@ -223,7 +222,7 @@ impl Bvh {
         let ray = Ray::new(start.into(), direction.to_array().into());
 
         for bvh_instance in self.root.traverse(&ray, &self.instances) {
-            let Some(bvh_template) = self.templates.get(&bvh_instance.id) else {
+            let Some(bvh_template) = self.templates.get(bvh_instance.bvh_index) else {
                 continue;
             };
 

--- a/crates/bvh/src/lib.rs
+++ b/crates/bvh/src/lib.rs
@@ -1,7 +1,6 @@
 use std::{
     fs::File,
     io::{BufReader, Read, Write},
-    sync::atomic::AtomicUsize,
 };
 
 use bvh::{
@@ -39,25 +38,66 @@ fn triangle_to_aabb(v1: [f32; 3], v2: [f32; 3], v3: [f32; 3]) -> Aabb<f32, 3> {
 #[derive(Debug, Deserialize, Serialize)]
 struct Triangle {
     indices: [u16; 3],
-    node_index: AtomicUsize,
+    node_index: usize,
 }
 
 impl From<[u16; 3]> for Triangle {
     fn from(indices: [u16; 3]) -> Self {
         Triangle {
             indices,
-            node_index: AtomicUsize::new(0),
+            node_index: 0,
         }
     }
 }
 
+struct TriangleAabb {
+    aabb: Aabb<f32, 3>,
+    node_index: usize,
+}
+
+impl Bounded<f32, 3> for TriangleAabb {
+    fn aabb(&self) -> Aabb<f32, 3> {
+        self.aabb
+    }
+}
+
+impl BHShape<f32, 3> for TriangleAabb {
+    fn set_bh_node_index(&mut self, node_index: usize) {
+        self.node_index = node_index;
+    }
+
+    fn bh_node_index(&self) -> usize {
+        self.node_index
+    }
+}
+
+fn generate_bvh(vertices: &[[f32; 3]], triangles: &mut [Triangle]) -> SubBvh<f32, 3> {
+    let mut aabbs: Vec<TriangleAabb> = triangles
+        .iter()
+        .map(|triangle| TriangleAabb {
+            aabb: triangle_to_aabb(
+                vertices[triangle.indices[0] as usize],
+                vertices[triangle.indices[1] as usize],
+                vertices[triangle.indices[2] as usize],
+            ),
+            node_index: triangle.node_index,
+        })
+        .collect();
+    let bvh = SubBvh::build(&mut aabbs);
+    aabbs
+        .iter()
+        .enumerate()
+        .for_each(|(index, aabb)| triangles[index].node_index = aabb.node_index);
+    bvh
+}
+
 #[derive(Debug, Clone)]
-struct TriangleWithVertices {
-    pos: [[f32; 3]; 3],
+struct BakedTriangle {
+    indices: [u16; 3],
     aabb: Aabb<f32, 3>,
 }
 
-impl Bounded<f32, 3> for TriangleWithVertices {
+impl Bounded<f32, 3> for BakedTriangle {
     fn aabb(&self) -> Aabb<f32, 3> {
         self.aabb
     }
@@ -78,12 +118,28 @@ pub struct BvhTemplate {
     triangles: Vec<Triangle>,
 
     #[serde(skip)]
-    cached_triangles: Vec<TriangleWithVertices>,
+    baked_triangles: Vec<BakedTriangle>,
+}
+
+impl BvhTemplate {
+    pub fn new(vertices: Vec<[f32; 3]>, triangles: Vec<[u16; 3]>) -> Self {
+        let mut triangles: Vec<Triangle> = triangles
+            .iter()
+            .map(|triangle| Triangle::from(*triangle))
+            .collect();
+
+        BvhTemplateData {
+            bvh: generate_bvh(&vertices, &mut triangles),
+            vertices,
+            triangles,
+        }
+        .into()
+    }
 }
 
 impl From<BvhTemplateData> for BvhTemplate {
     fn from(data: BvhTemplateData) -> Self {
-        let cached_triangles = data
+        let baked_triangles = data
             .triangles
             .iter()
             .map(|triangle| {
@@ -91,8 +147,8 @@ impl From<BvhTemplateData> for BvhTemplate {
                 let v2 = vertex_from_index(&data.vertices, triangle.indices[1]).into();
                 let v3 = vertex_from_index(&data.vertices, triangle.indices[2]).into();
 
-                TriangleWithVertices {
-                    pos: [v1, v2, v3],
+                BakedTriangle {
+                    indices: triangle.indices,
                     aabb: triangle_to_aabb(v1, v2, v3),
                 }
             })
@@ -102,7 +158,7 @@ impl From<BvhTemplateData> for BvhTemplate {
             vertices: data.vertices,
             triangles: data.triangles,
             bvh: data.bvh,
-            cached_triangles,
+            baked_triangles,
         }
     }
 }
@@ -141,7 +197,7 @@ impl BvhInstance {
         scale: f32,
         global_triangles: impl Iterator<Item = [[f32; 3]; 3]>,
     ) -> Self {
-        BvhInstance {
+        BvhInstanceData {
             bvh_index,
             pos,
             rot,
@@ -150,9 +206,8 @@ impl BvhInstance {
                 .map(|triangle| triangle_to_aabb(triangle[0], triangle[1], triangle[2]))
                 .fold(Aabb::empty(), |acc, next| acc.join(&next)),
             node_index: 0,
-            inv_rotation: Quat::default(),
-            inv_scale: f32::default(),
         }
+        .into()
     }
 }
 
@@ -246,15 +301,13 @@ impl Bvh {
                 <[f32; 3]>::from(relative_direction).into(),
             );
 
-            let triangles_with_vertices = &bvh_template.cached_triangles;
-
-            for cached_triangle in bvh_template
+            for triangle in bvh_template
                 .bvh
-                .traverse(&relative_ray, triangles_with_vertices)
+                .traverse(&relative_ray, &bvh_template.baked_triangles)
             {
-                let v1 = cached_triangle.pos[0].into();
-                let v2 = cached_triangle.pos[1].into();
-                let v3 = cached_triangle.pos[2].into();
+                let v1 = vertex_from_index(&bvh_template.vertices, triangle.indices[0]).into();
+                let v2 = vertex_from_index(&bvh_template.vertices, triangle.indices[1]).into();
+                let v3 = vertex_from_index(&bvh_template.vertices, triangle.indices[2]).into();
 
                 let intersection = relative_ray.intersects_triangle(&v1, &v2, &v3);
                 if intersection.distance >= 0.0 && intersection.distance <= relative_max_distance {

--- a/crates/bvh/src/lib.rs
+++ b/crates/bvh/src/lib.rs
@@ -13,11 +13,6 @@ use flate2::{bufread::GzDecoder, write::GzEncoder, Compression};
 use glam::{EulerRot, Quat, Vec3};
 use serde::{de::Error, Deserialize, Serialize};
 
-fn vertex_from_index(vertices: &[[f32; 3]], index: u16) -> [f32; 3] {
-    let index = usize::from(index);
-    vertices[index]
-}
-
 fn triangle_to_aabb(v1: [f32; 3], v2: [f32; 3], v3: [f32; 3]) -> Aabb<f32, 3> {
     Aabb::with_bounds(
         [
@@ -93,7 +88,7 @@ fn generate_bvh(vertices: &[[f32; 3]], triangles: &mut [Triangle]) -> SubBvh<f32
 
 #[derive(Debug, Clone)]
 struct BakedTriangle {
-    indices: [u16; 3],
+    vertex1_index: usize,
     aabb: Aabb<f32, 3>,
 }
 
@@ -139,23 +134,30 @@ impl BvhTemplate {
 
 impl From<BvhTemplateData> for BvhTemplate {
     fn from(data: BvhTemplateData) -> Self {
+        let mut sequential_vertices = Vec::with_capacity(data.triangles.len() * 3);
+
         let baked_triangles = data
             .triangles
             .iter()
             .map(|triangle| {
-                let v1 = vertex_from_index(&data.vertices, triangle.indices[0]).into();
-                let v2 = vertex_from_index(&data.vertices, triangle.indices[1]).into();
-                let v3 = vertex_from_index(&data.vertices, triangle.indices[2]).into();
+                let v1 = data.vertices[triangle.indices[0] as usize];
+                let v2 = data.vertices[triangle.indices[1] as usize];
+                let v3 = data.vertices[triangle.indices[2] as usize];
+
+                let vertex1_index = sequential_vertices.len();
+                sequential_vertices.push(v1);
+                sequential_vertices.push(v2);
+                sequential_vertices.push(v3);
 
                 BakedTriangle {
-                    indices: triangle.indices,
+                    vertex1_index,
                     aabb: triangle_to_aabb(v1, v2, v3),
                 }
             })
             .collect();
 
         BvhTemplate {
-            vertices: data.vertices,
+            vertices: sequential_vertices,
             triangles: data.triangles,
             bvh: data.bvh,
             baked_triangles,
@@ -305,9 +307,9 @@ impl Bvh {
                 .bvh
                 .traverse(&relative_ray, &bvh_template.baked_triangles)
             {
-                let v1 = vertex_from_index(&bvh_template.vertices, triangle.indices[0]).into();
-                let v2 = vertex_from_index(&bvh_template.vertices, triangle.indices[1]).into();
-                let v3 = vertex_from_index(&bvh_template.vertices, triangle.indices[2]).into();
+                let v1 = bvh_template.vertices[triangle.vertex1_index].into();
+                let v2 = bvh_template.vertices[triangle.vertex1_index + 1].into();
+                let v3 = bvh_template.vertices[triangle.vertex1_index + 2].into();
 
                 let intersection = relative_ray.intersects_triangle(&v1, &v2, &v3);
                 if intersection.distance >= 0.0 && intersection.distance <= relative_max_distance {

--- a/crates/bvh/src/lib.rs
+++ b/crates/bvh/src/lib.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashMap,
     fs::File,
     io::{BufReader, Read, Write},
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::atomic::AtomicUsize,
 };
 
 use bvh::{
@@ -37,24 +37,6 @@ fn triangle_to_aabb(v1: [f32; 3], v2: [f32; 3], v3: [f32; 3]) -> Aabb<f32, 3> {
     )
 }
 
-fn with_vertices<'a>(
-    vertices: &'a [[f32; 3]],
-    triangles: &'a [Triangle],
-) -> Vec<TriangleWithVertices<'a>> {
-    triangles
-        .iter()
-        .map(|triangle| TriangleWithVertices {
-            triangle,
-            vertices: &vertices,
-        })
-        .collect()
-}
-
-fn generate_bvh(vertices: &[[f32; 3]], triangles: &mut [Triangle]) -> SubBvh<f32, 3> {
-    let mut triangles_with_vertices = with_vertices(vertices, triangles);
-    SubBvh::build(&mut triangles_with_vertices)
-}
-
 #[derive(Debug, Deserialize, Serialize)]
 struct Triangle {
     indices: [u16; 3],
@@ -70,55 +52,74 @@ impl From<[u16; 3]> for Triangle {
     }
 }
 
-struct TriangleWithVertices<'a> {
-    triangle: &'a Triangle,
-    vertices: &'a [[f32; 3]],
+#[derive(Debug, Clone)]
+struct TriangleWithVertices {
+    pos: [[f32; 3]; 3],
+    aabb: Aabb<f32, 3>,
 }
 
-impl<'a> Bounded<f32, 3> for TriangleWithVertices<'a> {
+impl Bounded<f32, 3> for TriangleWithVertices {
     fn aabb(&self) -> Aabb<f32, 3> {
-        let v1 = vertex_from_index(self.vertices, self.triangle.indices[0]);
-        let v2 = vertex_from_index(self.vertices, self.triangle.indices[1]);
-        let v3 = vertex_from_index(self.vertices, self.triangle.indices[2]);
-        triangle_to_aabb(v1, v2, v3)
+        self.aabb
     }
 }
 
-impl<'a> BHShape<f32, 3> for TriangleWithVertices<'a> {
-    fn set_bh_node_index(&mut self, node_index: usize) {
-        self.triangle
-            .node_index
-            .store(node_index, Ordering::Relaxed);
-    }
-
-    fn bh_node_index(&self) -> usize {
-        self.triangle.node_index.load(Ordering::Relaxed)
-    }
+#[derive(Deserialize)]
+struct BvhTemplateData {
+    vertices: Vec<[f32; 3]>,
+    triangles: Vec<Triangle>,
+    bvh: SubBvh<f32, 3>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(from = "BvhTemplateData")]
 pub struct BvhTemplate {
     bvh: SubBvh<f32, 3>,
     vertices: Vec<[f32; 3]>,
     triangles: Vec<Triangle>,
+
+    #[serde(skip)]
+    cached_triangles: Vec<TriangleWithVertices>,
 }
 
-impl BvhTemplate {
-    pub fn new(vertices: Vec<[f32; 3]>, triangles: Vec<[u16; 3]>) -> Self {
-        let mut triangles: Vec<Triangle> = triangles
+impl From<BvhTemplateData> for BvhTemplate {
+    fn from(data: BvhTemplateData) -> Self {
+        let cached_triangles = data
+            .triangles
             .iter()
-            .map(|triangle| Triangle::from(*triangle))
+            .map(|triangle| {
+                let v1 = vertex_from_index(&data.vertices, triangle.indices[0]).into();
+                let v2 = vertex_from_index(&data.vertices, triangle.indices[1]).into();
+                let v3 = vertex_from_index(&data.vertices, triangle.indices[2]).into();
+
+                TriangleWithVertices {
+                    pos: [v1, v2, v3],
+                    aabb: triangle_to_aabb(v1, v2, v3),
+                }
+            })
             .collect();
 
         BvhTemplate {
-            bvh: generate_bvh(&vertices, &mut triangles),
-            vertices,
-            triangles,
+            vertices: data.vertices,
+            triangles: data.triangles,
+            bvh: data.bvh,
+            cached_triangles,
         }
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Serialize, Deserialize)]
+struct BvhInstanceData {
+    id: u32,
+    pos: [f32; 3],
+    rot: [f32; 3],
+    scale: f32,
+    aabb: Aabb<f32, 3>,
+    node_index: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(from = "BvhInstanceData")]
 pub struct BvhInstance {
     id: u32,
     pos: [f32; 3],
@@ -126,6 +127,11 @@ pub struct BvhInstance {
     scale: f32,
     aabb: Aabb<f32, 3>,
     node_index: usize,
+
+    #[serde(skip)]
+    inv_rotation: Quat,
+    #[serde(skip)]
+    inv_scale: f32,
 }
 
 impl BvhInstance {
@@ -145,6 +151,28 @@ impl BvhInstance {
                 .map(|triangle| triangle_to_aabb(triangle[0], triangle[1], triangle[2]))
                 .fold(Aabb::empty(), |acc, next| acc.join(&next)),
             node_index: 0,
+            inv_rotation: Quat::default(),
+            inv_scale: f32::default(),
+        }
+    }
+}
+
+impl From<BvhInstanceData> for BvhInstance {
+    fn from(value: BvhInstanceData) -> BvhInstance {
+        let inv_rotation =
+            Quat::from_euler(EulerRot::YXZ, value.rot[0], value.rot[1], value.rot[2]).inverse();
+
+        let inv_scale = 1.0 / value.scale.max(f32::EPSILON);
+
+        BvhInstance {
+            id: value.id,
+            pos: value.pos,
+            rot: value.rot,
+            scale: value.scale,
+            aabb: value.aabb,
+            node_index: value.node_index,
+            inv_rotation,
+            inv_scale,
         }
     }
 }
@@ -199,17 +227,12 @@ impl Bvh {
                 continue;
             };
 
-            let inverse_rotation = Quat::from_euler(
-                EulerRot::YXZ,
-                bvh_instance.rot[0],
-                bvh_instance.rot[1],
-                bvh_instance.rot[2],
-            )
-            .inverse();
-            let relative_start = (inverse_rotation * (start_vec - Vec3::from(bvh_instance.pos)))
-                / bvh_instance.scale;
-            let relative_end =
-                (inverse_rotation * (end_vec - Vec3::from(bvh_instance.pos))) / bvh_instance.scale;
+            let inv_rot = bvh_instance.inv_rotation;
+            let inv_scale = bvh_instance.inv_scale;
+
+            let instance_pos = Vec3::from(bvh_instance.pos);
+            let relative_start = (inv_rot * (start_vec - instance_pos)) * inv_scale;
+            let relative_end = (inv_rot * (end_vec - instance_pos)) * inv_scale;
 
             let local_delta = relative_end - relative_start;
             let relative_max_distance = local_delta.length();
@@ -219,21 +242,21 @@ impl Bvh {
             }
 
             let relative_direction = local_delta / relative_max_distance;
-
             let relative_ray = Ray::new(
                 <[f32; 3]>::from(relative_start).into(),
                 <[f32; 3]>::from(relative_direction).into(),
             );
 
-            let triangles_with_vertices =
-                with_vertices(&bvh_template.vertices, &bvh_template.triangles);
-            for triangle in bvh_template
+            let triangles_with_vertices = &bvh_template.cached_triangles;
+
+            for cached_triangle in bvh_template
                 .bvh
-                .traverse(&relative_ray, &triangles_with_vertices)
+                .traverse(&relative_ray, triangles_with_vertices)
             {
-                let v1 = vertex_from_index(triangle.vertices, triangle.triangle.indices[0]).into();
-                let v2 = vertex_from_index(triangle.vertices, triangle.triangle.indices[1]).into();
-                let v3 = vertex_from_index(triangle.vertices, triangle.triangle.indices[2]).into();
+                let v1 = cached_triangle.pos[0].into();
+                let v2 = cached_triangle.pos[1].into();
+                let v3 = cached_triangle.pos[2].into();
+
                 let intersection = relative_ray.intersects_triangle(&v1, &v2, &v3);
                 if intersection.distance >= 0.0 && intersection.distance <= relative_max_distance {
                     return false;

--- a/crates/bvh/src/lib.rs
+++ b/crates/bvh/src/lib.rs
@@ -10,7 +10,7 @@ use bvh::{
     ray::Ray,
 };
 use flate2::{bufread::GzDecoder, write::GzEncoder, Compression};
-use glam::{EulerRot, Quat, Vec3};
+use glam::{Affine3A, EulerRot, Quat, Vec3};
 use serde::{de::Error, Deserialize, Serialize};
 
 fn triangle_to_aabb(v1: [f32; 3], v2: [f32; 3], v3: [f32; 3]) -> Aabb<f32, 3> {
@@ -186,9 +186,7 @@ pub struct BvhInstance {
     node_index: usize,
 
     #[serde(skip)]
-    inv_rotation: Quat,
-    #[serde(skip)]
-    inv_scale: f32,
+    global_to_local: Affine3A,
 }
 
 impl BvhInstance {
@@ -215,10 +213,13 @@ impl BvhInstance {
 
 impl From<BvhInstanceData> for BvhInstance {
     fn from(value: BvhInstanceData) -> BvhInstance {
-        let inv_rotation =
-            Quat::from_euler(EulerRot::YXZ, value.rot[0], value.rot[1], value.rot[2]).inverse();
+        let rotation = Quat::from_euler(EulerRot::YXZ, value.rot[0], value.rot[1], value.rot[2]);
+        let translation = Vec3::from(value.pos);
+        let scale = Vec3::splat(value.scale);
 
-        let inv_scale = 1.0 / value.scale.max(f32::EPSILON);
+        let local_to_global =
+            Affine3A::from_scale_rotation_translation(scale, rotation, translation);
+        let global_to_local = local_to_global.inverse();
 
         BvhInstance {
             bvh_index: value.bvh_index,
@@ -227,8 +228,7 @@ impl From<BvhInstanceData> for BvhInstance {
             scale: value.scale,
             aabb: value.aabb,
             node_index: value.node_index,
-            inv_rotation,
-            inv_scale,
+            global_to_local,
         }
     }
 }
@@ -283,12 +283,8 @@ impl Bvh {
                 continue;
             };
 
-            let inv_rot = bvh_instance.inv_rotation;
-            let inv_scale = bvh_instance.inv_scale;
-
-            let instance_pos = Vec3::from(bvh_instance.pos);
-            let relative_start = (inv_rot * (start_vec - instance_pos)) * inv_scale;
-            let relative_end = (inv_rot * (end_vec - instance_pos)) * inv_scale;
+            let relative_start = bvh_instance.global_to_local.transform_point3(start_vec);
+            let relative_end = bvh_instance.global_to_local.transform_point3(end_vec);
 
             let local_delta = relative_end - relative_start;
             let relative_max_distance = local_delta.length();
@@ -299,17 +295,18 @@ impl Bvh {
 
             let relative_direction = local_delta / relative_max_distance;
             let relative_ray = Ray::new(
-                <[f32; 3]>::from(relative_start).into(),
-                <[f32; 3]>::from(relative_direction).into(),
+                relative_start.to_array().into(),
+                relative_direction.to_array().into(),
             );
 
             for triangle in bvh_template
                 .bvh
                 .traverse(&relative_ray, &bvh_template.baked_triangles)
             {
-                let v1 = bvh_template.vertices[triangle.vertex1_index].into();
-                let v2 = bvh_template.vertices[triangle.vertex1_index + 1].into();
-                let v3 = bvh_template.vertices[triangle.vertex1_index + 2].into();
+                let v = &bvh_template.vertices[triangle.vertex1_index..triangle.vertex1_index + 3];
+                let v1 = v[0].into();
+                let v2 = v[1].into();
+                let v3 = v[2].into();
 
                 let intersection = relative_ray.intersects_triangle(&v1, &v2, &v3);
                 if intersection.distance >= 0.0 && intersection.distance <= relative_max_distance {


### PR DESCRIPTION
* Reorder the vertices array sequentially during the baking process. This allows the CPU to fetch a continuous slice of data, improving CPU cache locality instead of random RAM lookups.
* Combine an instance's pos, rot, and scale into a `Affine3A` matrix and pre-compute its inverse. This replaces the previous manual, multi-step rotation and scaling calculations.
* Since BVH IDs are sequential, replace the hash map lookups with a simple `Vec`.