### PR TITLE
Fix BVH `has_line_of_sight` ordering bug

### DIFF
--- a/crates/bvh/src/lib.rs
+++ b/crates/bvh/src/lib.rs
@@ -13,6 +13,11 @@ use flate2::{bufread::GzDecoder, write::GzEncoder, Compression};
 use glam::{Affine3A, EulerRot, Quat, Vec3};
 use serde::{de::Error, Deserialize, Serialize};
 
+fn vertex_from_index(vertices: &[[f32; 3]], index: u16) -> [f32; 3] {
+    let index = usize::from(index);
+    vertices[index]
+}
+
 fn triangle_to_aabb(v1: [f32; 3], v2: [f32; 3], v3: [f32; 3]) -> Aabb<f32, 3> {
     Aabb::with_bounds(
         [
@@ -30,7 +35,7 @@ fn triangle_to_aabb(v1: [f32; 3], v2: [f32; 3], v3: [f32; 3]) -> Aabb<f32, 3> {
     )
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 struct Triangle {
     indices: [u16; 3],
     node_index: usize,
@@ -48,6 +53,7 @@ impl From<[u16; 3]> for Triangle {
 struct TriangleAabb {
     aabb: Aabb<f32, 3>,
     node_index: usize,
+    triangle_index: usize,
 }
 
 impl Bounded<f32, 3> for TriangleAabb {
@@ -66,24 +72,30 @@ impl BHShape<f32, 3> for TriangleAabb {
     }
 }
 
-fn generate_bvh(vertices: &[[f32; 3]], triangles: &mut [Triangle]) -> SubBvh<f32, 3> {
+fn generate_bvh(
+    vertices: &[[f32; 3]],
+    triangles: &mut [Triangle],
+) -> (SubBvh<f32, 3>, Vec<TriangleAabb>) {
     let mut aabbs: Vec<TriangleAabb> = triangles
         .iter()
-        .map(|triangle| TriangleAabb {
+        .enumerate()
+        .map(|(index, triangle)| TriangleAabb {
             aabb: triangle_to_aabb(
                 vertices[triangle.indices[0] as usize],
                 vertices[triangle.indices[1] as usize],
                 vertices[triangle.indices[2] as usize],
             ),
             node_index: triangle.node_index,
+            triangle_index: index,
         })
         .collect();
     let bvh = SubBvh::build(&mut aabbs);
-    aabbs
-        .iter()
-        .enumerate()
-        .for_each(|(index, aabb)| triangles[index].node_index = aabb.node_index);
-    bvh
+
+    aabbs.iter().for_each(|aabb| {
+        triangles[aabb.triangle_index].node_index = aabb.node_index;
+    });
+
+    (bvh, aabbs)
 }
 
 #[derive(Debug, Clone)]
@@ -123,26 +135,16 @@ impl BvhTemplate {
             .map(|triangle| Triangle::from(*triangle))
             .collect();
 
-        BvhTemplateData {
-            bvh: generate_bvh(&vertices, &mut triangles),
-            vertices,
-            triangles,
-        }
-        .into()
-    }
-}
+        let (bvh, sorted_aabbs) = generate_bvh(&vertices, &mut triangles);
 
-impl From<BvhTemplateData> for BvhTemplate {
-    fn from(data: BvhTemplateData) -> Self {
-        let mut sequential_vertices = Vec::with_capacity(data.triangles.len() * 3);
-
-        let baked_triangles = data
-            .triangles
+        let mut sequential_vertices = Vec::with_capacity(sorted_aabbs.len() * 3);
+        let baked_triangles: Vec<BakedTriangle> = sorted_aabbs
             .iter()
-            .map(|triangle| {
-                let v1 = data.vertices[triangle.indices[0] as usize];
-                let v2 = data.vertices[triangle.indices[1] as usize];
-                let v3 = data.vertices[triangle.indices[2] as usize];
+            .map(|aabb| {
+                let triangle = &triangles[aabb.triangle_index];
+                let v1 = vertex_from_index(&vertices, triangle.indices[0]);
+                let v2 = vertex_from_index(&vertices, triangle.indices[1]);
+                let v3 = vertex_from_index(&vertices, triangle.indices[2]);
 
                 let vertex1_index = sequential_vertices.len();
                 sequential_vertices.push(v1);
@@ -151,15 +153,44 @@ impl From<BvhTemplateData> for BvhTemplate {
 
                 BakedTriangle {
                     vertex1_index,
-                    aabb: triangle_to_aabb(v1, v2, v3),
+                    aabb: aabb.aabb,
                 }
             })
             .collect();
 
         BvhTemplate {
+            bvh,
             vertices: sequential_vertices,
-            triangles: data.triangles,
+            triangles,
+            baked_triangles,
+        }
+    }
+}
+
+impl From<BvhTemplateData> for BvhTemplate {
+    fn from(data: BvhTemplateData) -> Self {
+        let baked_triangles = data
+            .triangles
+            .iter()
+            .enumerate()
+            .map(|(index, _)| {
+                let vertex1_index = index * 3;
+
+                BakedTriangle {
+                    vertex1_index,
+                    aabb: triangle_to_aabb(
+                        data.vertices[vertex1_index],
+                        data.vertices[vertex1_index + 1],
+                        data.vertices[vertex1_index + 2],
+                    ),
+                }
+            })
+            .collect();
+
+        BvhTemplate {
             bvh: data.bvh,
+            vertices: data.vertices,
+            triangles: data.triangles,
             baked_triangles,
         }
     }

--- a/crates/bvh/src/lib.rs
+++ b/crates/bvh/src/lib.rs
@@ -100,7 +100,7 @@ fn generate_bvh(
 
 #[derive(Clone, Debug)]
 struct BakedTriangle {
-    vertex1_index: usize,
+    indices: [u16; 3],
     aabb: Aabb<f32, 3>,
 }
 
@@ -137,22 +137,12 @@ impl BvhTemplate {
 
         let (bvh, sorted_aabbs) = generate_bvh(&vertices, &mut triangles);
 
-        let mut sequential_vertices = Vec::with_capacity(sorted_aabbs.len() * 3);
         let baked_triangles: Vec<BakedTriangle> = sorted_aabbs
             .iter()
             .map(|aabb| {
                 let triangle = &triangles[aabb.triangle_index];
-                let v1 = vertex_from_index(&vertices, triangle.indices[0]);
-                let v2 = vertex_from_index(&vertices, triangle.indices[1]);
-                let v3 = vertex_from_index(&vertices, triangle.indices[2]);
-
-                let vertex1_index = sequential_vertices.len();
-                sequential_vertices.push(v1);
-                sequential_vertices.push(v2);
-                sequential_vertices.push(v3);
-
                 BakedTriangle {
-                    vertex1_index,
+                    indices: triangle.indices,
                     aabb: aabb.aabb,
                 }
             })
@@ -160,7 +150,7 @@ impl BvhTemplate {
 
         BvhTemplate {
             bvh,
-            vertices: sequential_vertices,
+            vertices,
             triangles,
             baked_triangles,
         }
@@ -172,18 +162,13 @@ impl From<BvhTemplateData> for BvhTemplate {
         let baked_triangles = data
             .triangles
             .iter()
-            .enumerate()
-            .map(|(index, _)| {
-                let vertex1_index = index * 3;
-
-                BakedTriangle {
-                    vertex1_index,
-                    aabb: triangle_to_aabb(
-                        data.vertices[vertex1_index],
-                        data.vertices[vertex1_index + 1],
-                        data.vertices[vertex1_index + 2],
-                    ),
-                }
+            .map(|triangle| BakedTriangle {
+                indices: triangle.indices,
+                aabb: triangle_to_aabb(
+                    vertex_from_index(&data.vertices, triangle.indices[0]),
+                    vertex_from_index(&data.vertices, triangle.indices[1]),
+                    vertex_from_index(&data.vertices, triangle.indices[2]),
+                ),
             })
             .collect();
 
@@ -334,10 +319,9 @@ impl Bvh {
                 .bvh
                 .traverse(&relative_ray, &bvh_template.baked_triangles)
             {
-                let v = &bvh_template.vertices[triangle.vertex1_index..triangle.vertex1_index + 3];
-                let v1 = v[0].into();
-                let v2 = v[1].into();
-                let v3 = v[2].into();
+                let v1 = vertex_from_index(&bvh_template.vertices, triangle.indices[0]).into();
+                let v2 = vertex_from_index(&bvh_template.vertices, triangle.indices[1]).into();
+                let v3 = vertex_from_index(&bvh_template.vertices, triangle.indices[2]).into();
 
                 let intersection = relative_ray.intersects_triangle(&v1, &v2, &v3);
                 if intersection.distance >= 0.0 && intersection.distance <= relative_max_distance {

--- a/crates/bvh/src/lib.rs
+++ b/crates/bvh/src/lib.rs
@@ -72,10 +72,7 @@ impl BHShape<f32, 3> for TriangleAabb {
     }
 }
 
-fn generate_bvh(
-    vertices: &[[f32; 3]],
-    triangles: &mut [Triangle],
-) -> (SubBvh<f32, 3>, Vec<TriangleAabb>) {
+fn generate_bvh(vertices: &[[f32; 3]], triangles: &mut [Triangle]) -> SubBvh<f32, 3> {
     let mut aabbs: Vec<TriangleAabb> = triangles
         .iter()
         .enumerate()
@@ -95,7 +92,7 @@ fn generate_bvh(
         triangles[aabb.triangle_index].node_index = aabb.node_index;
     });
 
-    (bvh, aabbs)
+    bvh
 }
 
 #[derive(Clone, Debug)]
@@ -135,16 +132,16 @@ impl BvhTemplate {
             .map(|triangle| Triangle::from(*triangle))
             .collect();
 
-        let (bvh, sorted_aabbs) = generate_bvh(&vertices, &mut triangles);
-
-        let baked_triangles: Vec<BakedTriangle> = sorted_aabbs
+        let bvh = generate_bvh(&vertices, &mut triangles);
+        let baked_triangles: Vec<BakedTriangle> = triangles
             .iter()
-            .map(|aabb| {
-                let triangle = &triangles[aabb.triangle_index];
-                BakedTriangle {
-                    indices: triangle.indices,
-                    aabb: aabb.aabb,
-                }
+            .map(|triangle| BakedTriangle {
+                indices: triangle.indices,
+                aabb: triangle_to_aabb(
+                    vertex_from_index(&vertices, triangle.indices[0]),
+                    vertex_from_index(&vertices, triangle.indices[1]),
+                    vertex_from_index(&vertices, triangle.indices[2]),
+                ),
             })
             .collect();
 

--- a/crates/bvh/src/lib.rs
+++ b/crates/bvh/src/lib.rs
@@ -98,7 +98,7 @@ fn generate_bvh(
     (bvh, aabbs)
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 struct BakedTriangle {
     vertex1_index: usize,
     aabb: Aabb<f32, 3>,

--- a/crates/bvh/src/lib.rs
+++ b/crates/bvh/src/lib.rs
@@ -285,14 +285,14 @@ impl Bvh {
         let start_vec = Vec3::from(start);
         let end_vec = Vec3::from(end);
         let delta = end_vec - start_vec;
-        let global_max_distance = delta.length();
 
-        if global_max_distance < f32::EPSILON {
+        // Only perform expensive sqrt() when necessary
+        let global_max_distance_sq = delta.length_squared();
+        if global_max_distance_sq < f32::EPSILON * f32::EPSILON {
             return true;
         }
 
-        let direction = delta / global_max_distance;
-        let ray = Ray::new(start.into(), direction.to_array().into());
+        let ray = Ray::new(start.into(), delta.normalize().to_array().into());
 
         for bvh_instance in self.root.traverse(&ray, &self.instances) {
             let Some(bvh_template) = self.templates.get(bvh_instance.bvh_index) else {
@@ -303,17 +303,17 @@ impl Bvh {
             let relative_end = bvh_instance.global_to_local.transform_point3(end_vec);
 
             let local_delta = relative_end - relative_start;
-            let relative_max_distance = local_delta.length();
+            let relative_max_distance_sq = local_delta.length_squared();
 
-            if relative_max_distance < f32::EPSILON {
+            if relative_max_distance_sq < f32::EPSILON * f32::EPSILON {
                 continue;
             }
 
-            let relative_direction = local_delta / relative_max_distance;
             let relative_ray = Ray::new(
                 relative_start.to_array().into(),
-                relative_direction.to_array().into(),
+                local_delta.normalize().to_array().into(),
             );
+            let relative_max_distance = relative_max_distance_sq.sqrt();
 
             for triangle in bvh_template
                 .bvh


### PR DESCRIPTION
#281 caused an issue where the triangles were not in the correct order when serializing and then deserializing.

`BvhTemplate::new(`) used the unordered array of vertices and indices. Because `SubBvh::build(&mut aabbs)` builds the tree structure based on the original order, reordering the vertices inside `From<BvhTemplateData>` creates an inconsistency between the serialized `SubBvh` and the new `baked_triangles`.

I decided to remove the sequential array of vertices because we only traverse triangles that are actually hit. This change caused a slight increase in size of the serialized BVH and memory usage, but when we don't traverse all the triangles (often only one or two triangles), this doesn't improve performance much.

I also added some early termination checks that avoid expensive `sqrt()` operations.